### PR TITLE
Fix Google Drive URI for YOLOv5 weights

### DIFF
--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -10,7 +10,7 @@ from pathlib import Path
 def attempt_download(weights):
     # Attempt to download pretrained weights if not found locally
     weights = weights.strip()
-    msg = weights + ' missing, try downloading from https://drive.google.com/open?id=1LezFG5g3BCW6iYaV89B2i64cqEUZD7e0'
+    msg = weights + ' missing, try downloading from https://drive.google.com/drive/folders/1Drs_Aiu7xx6S-ix95f9kNsA6ueKRpN2J'
 
     r = 1
     if len(weights) > 0 and not os.path.isfile(weights):


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update Google Drive links for downloading missing pretrained weights.

### 📊 Key Changes
- Altered the URL provided to users for downloading YOLOv5 pretrained weights when they are not found locally.

### 🎯 Purpose & Impact
- Ensures users are redirected to the correct Google Drive folder to download pretrained models.
- Prevents confusion and download errors, improving user experience when setting up YOLOv5. 🛠️
- Maintains the ease of use of YOLOv5, potentially increasing its adoption and user satisfaction. 👍