### PR TITLE
Ensures weights/ dir exists

### DIFF
--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ except:
     mixed_precision = False  # not installed
 
 wdir = 'weights' + os.sep  # weights dir
+os.makedirs(wdir, exist_ok=True)
 last = wdir + 'last.pt'
 best = wdir + 'best.pt'
 results_file = 'results.txt'


### PR DESCRIPTION
Allows train.py to be run outside of yolov5/ directory.

Otherwise this requires the user to make a directory called `weights/` in the working directory. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced training script to ensure weights directory exists.

### 📊 Key Changes
- Added a line of code to create the 'weights' directory if it does not exist.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: Prevents potential errors or crashes that could occur if the 'weights' directory, where model weights are saved during training, is missing.
- 🔁 **Impact**: Users experience a more robust and error-proof training process, as the script now automatically handles directory creation.