### PR TITLE
Fix config path for PyTorch Hub

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -6,6 +6,9 @@ Usage:
 """
 
 dependencies = ['torch', 'yaml']
+
+import os
+
 import torch
 
 from models.yolo import Model
@@ -24,7 +27,8 @@ def create(name, pretrained, channels, classes):
     Returns:
         pytorch model
     """
-    model = Model('models/%s.yaml' % name, channels, classes)
+    config = os.path.join(os.path.dirname(__file__), 'models', '%s.yaml' % name)
+    model = Model(config, channels, classes)
     if pretrained:
         ckpt = '%s.pt' % name  # checkpoint filename
         google_utils.attempt_download(ckpt)  # download if not found locally

--- a/hubconf.py
+++ b/hubconf.py
@@ -27,12 +27,12 @@ def create(name, pretrained, channels, classes):
     Returns:
         pytorch model
     """
-    config = os.path.join(os.path.dirname(__file__), 'models', '%s.yaml' % name)
+    config = os.path.join(os.path.dirname(__file__), 'models', '%s.yaml' % name)  # model.yaml path
     model = Model(config, channels, classes)
     if pretrained:
         ckpt = '%s.pt' % name  # checkpoint filename
         google_utils.attempt_download(ckpt)  # download if not found locally
-        state_dict = torch.load(ckpt)['model'].state_dict()
+        state_dict = torch.load(ckpt, map_location=torch.device('cpu'))['model'].state_dict()
         state_dict = {k: v for k, v in state_dict.items() if model.state_dict()[k].numel() == v.numel()}  # filter
         model.load_state_dict(state_dict, strict=False)  # load
     return model


### PR DESCRIPTION
#36 
The relative path in `hubconf.py` cannot be handled properly. 
```python
import torch
model = torch.hub.load('ultralytics/yolov5', 'yolov5s', pretrained=True, force_reload=True)
```
```raw
Downloading: "https://github.com/ultralytics/yolov5/archive/master.zip" to /home/lijun/.cache/torch/hub/master.zip
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-2-a446dedfedeb> in <module>
      1 import torch
----> 2 model = torch.hub.load('ultralytics/yolov5', 'yolov5s', pretrained=True, force_reload=True)

~/environments/miniconda3/envs/actev/lib/python3.7/site-packages/torch/hub.py in load(github, model, *args, **kwargs)
    367     entry = _load_entry_from_hubconf(hub_module, model)
    368 
--> 369     model = entry(*args, **kwargs)
    370 
    371     sys.path.remove(repo_dir)

~/.cache/torch/hub/ultralytics_yolov5_master/hubconf.py in yolov5s(pretrained, channels, classes)
     46         pytorch model
     47     """
---> 48     return create('yolov5s', pretrained, channels, classes)
     49 
     50 

~/.cache/torch/hub/ultralytics_yolov5_master/hubconf.py in create(name, pretrained, channels, classes)
     25         pytorch model
     26     """
---> 27     model = Model('models/%s.yaml' % name, channels, classes)
     28     if pretrained:
     29         ckpt = '%s.pt' % name  # checkpoint filename

~/.cache/torch/hub/ultralytics_yolov5_master/models/yolo.py in __init__(self, model_cfg, ch, nc)
     51             self.md = model_cfg  # model dict
     52         else:  # is *.yaml
---> 53             with open(model_cfg) as f:
     54                 self.md = yaml.load(f, Loader=yaml.FullLoader)  # model dict
     55 

FileNotFoundError: [Errno 2] No such file or directory: 'models/yolov5s.yaml'
```

Changing to the absolute path should fix it.
```python
import torch
model = torch.hub.load('Lijun-Yu/yolov5', 'yolov5s', pretrained=True, force_reload=True)
```
```raw

Downloading: "https://github.com/Lijun-Yu/yolov5/archive/master.zip" to /home/lijun/.cache/torch/hub/master.zip

              from  n    params  module                                  arguments                     
  0             -1  1      3520  models.common.Focus                     [3, 32, 3]                    
  1             -1  1     18560  models.common.Conv                      [32, 64, 3, 2]                
  2             -1  1     20672  models.common.Bottleneck                [64, 64]                      
  3             -1  1     73984  models.common.Conv                      [64, 128, 3, 2]               
  4             -1  1    161152  models.common.BottleneckCSP             [128, 128, 3]                 
  5             -1  1    295424  models.common.Conv                      [128, 256, 3, 2]              
  6             -1  1    641792  models.common.BottleneckCSP             [256, 256, 3]                 
  7             -1  1   1180672  models.common.Conv                      [256, 512, 3, 2]              
  8             -1  1    656896  models.common.SPP                       [512, 512, [5, 9, 13]]        
  9             -1  1   1905152  models.common.BottleneckCSP             [512, 512, 2]                 
 10             -1  1   1248768  models.common.BottleneckCSP             [512, 512, 1, False]          
 11             -1  1    130815  torch.nn.modules.conv.Conv2d            [512, 255, 1, 1]              
 12             -2  1         0  torch.nn.modules.upsampling.Upsample    [None, 2, 'nearest']          
 13        [-1, 6]  1         0  models.common.Concat                    [1]                           
 14             -1  1    197120  models.common.Conv                      [768, 256, 1, 1]              
 15             -1  1    313088  models.common.BottleneckCSP             [256, 256, 1, False]          
 16             -1  1     65535  torch.nn.modules.conv.Conv2d            [256, 255, 1, 1]              
 17             -2  1         0  torch.nn.modules.upsampling.Upsample    [None, 2, 'nearest']          
 18        [-1, 4]  1         0  models.common.Concat                    [1]                           
 19             -1  1     49408  models.common.Conv                      [384, 128, 1, 1]              
 20             -1  1     78720  models.common.BottleneckCSP             [128, 128, 1, False]          
 21             -1  1     32895  torch.nn.modules.conv.Conv2d            [128, 255, 1, 1]              
 22   [-1, 16, 11]  1         0  models.yolo.Detect                      [80, [[10, 13, 16, 30, 33, 23], [30, 61, 62, 45, 59, 119], [116, 90, 156, 198, 373, 326]]]
Model Summary: 165 layers, 7.07417e+06 parameters, 7.07417e+06 gradients

Downloading https://drive.google.com/uc?export=download&id=1R5T6rIyy3lLwgFXNms8whc-387H0tMQO as yolov5s.pt... Done (3.3s)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement to model loading in `hubconf.py`.

### 📊 Key Changes
- Added Python's `os` module to enable path manipulations.
- Improved the way the model configuration file path is constructed, using `os.path.join` and `os.path.dirname`.
- Adjusted the model checkpoint loading to explicitly map to CPU memory, ensuring compatibility across environments that may not have a GPU.

### 🎯 Purpose & Impact
- These changes provide clearer, environment-independent paths that reduce the risk of file-path errors across different operating systems.
- The mapping of state dictionaries to CPU memory when loading pretrained models ensures users without access to a GPU can still load models seamlessly.
- Users can benefit from a more robust and error-proof model instantiation, making the YOLOv5 model easier to work with for both development and deployment, potentially broadening the user base to those with less technical expertise.