### PR TITLE
fix refrence bug

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -1,5 +1,7 @@
 import argparse
 
+import torch.backends.cudnn as cudnn
+
 from utils.datasets import *
 from utils.utils import *
 
@@ -36,7 +38,7 @@ def detect(save_img=False):
     vid_path, vid_writer = None, None
     if webcam:
         view_img = True
-        torch.backends.cudnn.benchmark = True  # set True to speed up constant image size inference
+        cudnn.benchmark = True  # set True to speed up constant image size inference
         dataset = LoadStreams(source, img_size=imgsz)
     else:
         save_img = True

--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@ import torch.distributed as dist
 import torch.nn.functional as F
 import torch.optim as optim
 import torch.optim.lr_scheduler as lr_scheduler
+import torch.utils.data
 from torch.utils.tensorboard import SummaryWriter
 
 import test  # import test.py to get mAP after each epoch


### PR DESCRIPTION
In torch==1.5, the import of the API has changed. Although it does not interrupt the operation of the program, it seems to me to be an implicit error and may throw an exception in later versions.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved code cleanliness and consistency in YOLOv5's detect and train scripts.

### 📊 Key Changes
- Imported `torch.backends.cudnn` as `cudnn` directly at the beginning of `detect.py`.
- Used the shortened `cudnn.benchmark` directly in place of `torch.backends.cudnn.benchmark`.
- Added `import torch.utils.data` in `train.py` without further changes in the diff provided.

### 🎯 Purpose & Impact
- 🧹 **Code Cleanliness**: Refactoring import statements for a cleaner and more consistent codebase.
- ⚙️ **Performance**: Utilizing `cudnn.benchmark` for potentially faster inference when image size doesn't change.
- 🚀 **Impact to Users**: No immediate changes in functionality, but sets the stage for more maintainable and potentially better-performing code.
- 📚 **Ease of Readability**: For new developers or users looking into the code, these changes make it clearer where certain functionality is sourced from.