### PR TITLE
onnx should be 1.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI
 # conda install -yc conda-forge scikit-image pycocotools tensorboard
 # conda install -yc spyder-ide spyder-line-profiler
 # conda install -yc pytorch pytorch torchvision
-# conda install -yc conda-forge protobuf numpy && pip install onnx  # https://github.com/onnx/onnx#linux-and-macos
+# conda install -yc conda-forge protobuf numpy && pip install onnx==1.6.0  # https://github.com/onnx/onnx#linux-and-macos


### PR DESCRIPTION
for smoothly export model to onnx, onnx should be 1.6.0

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fixed ONNX version to 1.6.0 in the requirements to maintain compatibility.

### 📊 Key Changes
- Updated the `requirements.txt` file.
- Specified the ONNX version to 1.6.0 instead of using the latest version.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To avoid potential issues with newer, untested versions of ONNX which may introduce compatibility problems or bugs.
- ✔️ **Impact**: Users can expect more stable model exporting using ONNX, leading to fewer disruptions in ML workflows and more consistent performance across different environments.