### PR TITLE
Fix the problem that Torch does not correspond to Torchvision version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,12 @@
 Cython
 numpy==1.17
 opencv-python
-torch>=1.4
+torch==1.4
 matplotlib
 pillow
 tensorboard
 PyYAML>=5.3
-torchvision
+torchvision==0.5.0
 scipy
 tqdm
 git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI


### PR DESCRIPTION
fix #148 errors

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjusting PyTorch and torchvision to specific versions for consistency.

### 📊 Key Changes
- Changed PyTorch requirement from any version newer than 1.4 (`>=1.4`) to the specific version 1.4 (`==1.4`).
- Pinned torchvision to an exact version 0.5.0 (`==0.5.0`) instead of the latest available version.

### 🎯 Purpose & Impact
- Ensures compatibility and predictability by using specific versions of PyTorch and torchvision, reducing the likelihood of bugs or incompatibilities with new releases.
- Users can expect a more stable environment with less risk of encountering issues due to changing dependencies.
- May impact users who work with newer features of PyTorch and torchvision that are not available in the specified versions. 🔄