### PR TITLE
Video inference txt file

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -97,7 +97,9 @@ def detect(save_img=False):
                         xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
                         with open(save_path[:save_path.rfind('.')] + '.txt', 'a') as file:
                             file.write(('%g ' * 5 + '\n') % (cls, *xywh))  # label format
-
+                with open(save_path[:save_path.rfind('.')] + '.txt', 'a') as file:
+                    file.write('\n')
+                    
                     if save_img or view_img:  # Add bbox to image
                         label = '%s %.2f' % (names[int(cls)], conf)
                         plot_one_box(xyxy, im0, label=label, color=colors[int(cls)], line_thickness=3)


### PR DESCRIPTION
Hi

While running detect.py on a video mp4 file and using the --save-txt flag, a single text file is created with 1 line per object. However, there is no way to distinguish which line/object belongs to which frame. 

This PR adds a simple fix to add a line break after inference on every frame. 

Thanks

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced output formatting in detection files for YOLOv5.

### 📊 Key Changes
- Included a new line insertion in the saved detection `.txt` files after writing the detection results.

### 🎯 Purpose & Impact
- 📝 **Consistency:** Each detection result is now consistently separated by new lines, which improves readability and parsing of detection outputs.
- 🤖 **Automation Friendly:** This change is particularly important for automated systems that process detection results, ensuring better compatibility and fewer parsing errors.
- ⚙️ **No Impact on Performance:** The update is related to output formatting and does not affect the model's performance or accuracy.