### PR TITLE
Fix after suggestion

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -95,8 +95,12 @@ def detect(save_img=False):
                 for *xyxy, conf, cls in det:
                     if save_txt:  # Write to file
                         xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
-                        with open(save_path[:save_path.rfind('.')] + '.txt', 'a') as file:
-                            file.write(('%g ' * 5 + '\n') % (cls, *xywh))  # label format
+                        if dataset.frame == 0:
+                            with open(save_path[:save_path.rfind('.')] + '.txt', 'a') as f:
+                                f.write(('%g ' * 5 + '\n') % (cls, *xywh))  # label format
+                        else:
+                            with open(save_path[:save_path.rfind('.')] + '_' + str(dataset.frame) + '.txt', 'a') as f:
+                                f.write(('%g ' * 5 + '\n') % (cls, *xywh))  # label format
 
                     if save_img or view_img:  # Add bbox to image
                         label = '%s %.2f' % (names[int(cls)], conf)

--- a/detect.py
+++ b/detect.py
@@ -80,7 +80,7 @@ def detect(save_img=False):
                 p, s, im0 = path, '', im0s
 
             save_path = str(Path(out) / Path(p).name)
-            txt_path = save_path[:save_path.rfind('.')] + ('_%g' % dataset.frame if dataset.mode == 'video' else '')
+            txt_path = str(Path(out) / Path(p).stem) + ('_%g' % dataset.frame if dataset.mode == 'video' else '')
             s += '%gx%g ' % img.shape[2:]  # print string
             gn = torch.tensor(im0.shape)[[1, 0, 1, 0]]  #  normalization gain whwh
             if det is not None and len(det):


### PR DESCRIPTION
Hi @glenn-jocher 
Thanks for your input yesterday. 

I have modified the PR as per your suggestion.

detect.py now creates separate txt files for each frame for videos, keeping image txt files the same.

For example:
video.mp4 containing 100 frames would now result in video_1.txt, video_2.txt, ..., video_100.txt

Also, I hope you don't mind, I changed the variable name from 'file' to 'f'. Using file as a variable name is not prohibited but since it is a __builtin__, it might cause issues later on.  

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model attribute access and output file handling in YOLOv5 detection script.

### 📊 Key Changes
- Altered model name retrieval to support wrapped models in Distributed Data Parallel (DDP) training.
- Streamlined the output text file path generation, particularly for video frame results.
- Commented out block that showed an example of updating all model variants (not an active code change, but indicative of potential usage).

### 🎯 Purpose & Impact
- Ensures compatibility with DDP, which wraps the model in an additional module, thereby preventing errors when trying to access model attributes. 🤹
- Simplifies and corrects the generation and saving of result text files for better organization and to align with video frame indexing. This makes it easier for users to associate results with the correct frames or images. 📝
- The commented-out section serves as an example for users who might want to apply the detection script across multiple model weights, although this is not a functional change in the codebase. This can help guide users on how to adapt the script for bulk processing. 🔄