### PR TITLE
Adding torchscript export

### DIFF
--- a/models/torchscript_export.py
+++ b/models/torchscript_export.py
@@ -1,0 +1,38 @@
+"""Exports a pytorch *.pt model to *.torchscript format
+
+Usage:
+    $ export PYTHONPATH="$PWD" && python models/torchscript_export.py --weights ./weights/yolov5s.pt --img 640 --batch 1
+"""
+
+import argparse
+
+
+from models.common import *
+from utils import google_utils
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--weights', type=str, default='./yolov5s.pt', help='weights path')
+    parser.add_argument('--img-size', nargs='+', type=int, default=[640, 640], help='image size')
+    parser.add_argument('--batch-size', type=int, default=1, help='batch size')
+    opt = parser.parse_args()
+    print(opt)
+
+    # Parameters
+    f = opt.weights.replace('.pt', '.torchscript')  # onnx filename
+    img = torch.zeros((opt.batch_size, 3, *opt.img_size))  # image size, (1, 3, 320, 192) iDetection
+
+    # Load pytorch model
+    google_utils.attempt_download(opt.weights)
+    model = torch.load(opt.weights, map_location=torch.device('cpu'))['model'].float()
+    model.eval()
+
+    # Don't fuse layers, it won't work with torchscript exports
+    #model.fuse()
+
+    # Export to jit/torchscript
+    model.model[-1].export = True  # set Detect() layer export=True
+    _ = model(img)  # dry run
+
+    traced_script_module = torch.jit.trace(model, img)
+    traced_script_module.save(f)


### PR DESCRIPTION
Adding my script that performs torchscript export, as reference by this issue: https://github.com/ultralytics/yolov5/issues/179

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
New TorchScript export functionality for YOLOv5 models.

### 📊 Key Changes
- 🧩 Introduced a new script (`torchscript_export.py`) to convert `.pt` models to the TorchScript format `.torchscript`.
- 📝 Added usage instructions and argument parsing for specifying model weights, image size, and batch size.
- 🔧 Set up model loading and preparation steps to ensure it's ready for TorchScript conversion.

### 🎯 Purpose & Impact
- 🚀 Enables deployment of YOLOv5 models in environments where Python is not available or feasible, thus expanding the model's applicability.
- 💨 Provides a straightforward mechanism to convert models, which could streamline workflows for users needing to run models in optimized, production-ready environments.