### PR TITLE
Remove non-ascii that breaks pdb single-stepping

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -82,7 +82,7 @@ def detect(save_img=False):
             save_path = str(Path(out) / Path(p).name)
             txt_path = str(Path(out) / Path(p).stem) + ('_%g' % dataset.frame if dataset.mode == 'video' else '')
             s += '%gx%g ' % img.shape[2:]  # print string
-            gn = torch.tensor(im0.shape)[[1, 0, 1, 0]]  #  normalization gain whwh
+            gn = torch.tensor(im0.shape)[[1, 0, 1, 0]]  # normalization gain whwh
             if det is not None and len(det):
                 # Rescale boxes from img_size to im0 size
                 det[:, :4] = scale_coords(img.shape[2:], det[:, :4], im0.shape).round()


### PR DESCRIPTION
You have a non-breaking space in the comment field. I use pdb to single-step to see intermediate
states, and this char rases EncodingError each time I hit that line.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of variable naming in the object detection scaling process.

### 📊 Key Changes
- Introduced a new variable `gn` (short for 'gain') to store the normalization factors for width and height in the image.
- This variable is used for scaling the detection boxes from the processed image size back to the original image size.

### 🎯 Purpose & Impact
- 🧠 **Purpose**: The change appears to be a small code refinement for the sake of clarity and maintainability. By using a descriptively named variable (`gn` for gain), the code's intent is clearer to those reading it, potentially reducing confusion and errors in the scaling process of detected objects.
- 💡 **Impact**: This update is expected to have no direct impact on end-users, as it is a behind-the-scenes code quality improvement. Users can expect the same functionality and performance in object detection, with improved code readability for developers contributing to or learning from the codebase.