### PR TITLE
maybe a typo in torch_utils.py

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -185,7 +185,7 @@ class ModelEMA:
         self.updates += 1
         d = self.decay(self.updates)
         with torch.no_grad():
-            if type(model) in (nn.parallel.DataParallel, nn.parallel.DistributedDataParallel):
+            if type(model) in (nn.DataParallel, nn.parallel.DistributedDataParallel):
                 msd, esd = model.module.state_dict(), self.ema.module.state_dict()
             else:
                 msd, esd = model.state_dict(), self.ema.state_dict()


### PR DESCRIPTION
i guess DataParallel should belong to nn not nn.parallel

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving EMA (Exponential Moving Average) update compatibility for PyTorch parallelism.

### 📊 Key Changes
- Adjusted the conditional check to include `nn.DataParallel` alongside `nn.parallel.DistributedDataParallel` during EMA updates.

### 🎯 Purpose & Impact
- 🔧 Ensures that EMA updates work seamlessly with models using PyTorch's `DataParallel` wrapper, not just the ones using the distributed version.
- ⚙️ Provides a more robust EMA model update, potentially improving model performance and accuracy for users utilizing parallel processing.