### PR TITLE
[bug fix] potential problem if img fed to model is in rectangular shape

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -679,8 +679,8 @@ def letterbox(img, new_shape=(640, 640), color=(114, 114, 114), auto=True, scale
         dw, dh = np.mod(dw, 64), np.mod(dh, 64)  # wh padding
     elif scaleFill:  # stretch
         dw, dh = 0.0, 0.0
-        new_unpad = new_shape
-        ratio = new_shape[0] / shape[1], new_shape[1] / shape[0]  # width, height ratios
+        new_unpad = (new_shape[1], new_shape[0])
+        ratio = new_shape[1] / shape[1], new_shape[0] / shape[0]  # width, height ratios
 
     dw /= 2  # divide padding into 2 sides
     dh /= 2

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -173,7 +173,7 @@ def xywh2xyxy(x):
 def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None):
     # Rescale coords (xyxy) from img1_shape to img0_shape
     if ratio_pad is None:  # calculate from img0_shape
-        gain = max(img1_shape) / max(img0_shape)  # gain  = old / new
+        gain = min(img1_shape[0] / img0_shape[0], img1_shape[1] / img0_shape[1])  # gain  = old / new
         pad = (img1_shape[1] - img0_shape[1] * gain) / 2, (img1_shape[0] - img0_shape[0] * gain) / 2  # wh padding
     else:
         gain = ratio_pad[0][0]


### PR DESCRIPTION
Hello! I made the PR of bug #266 
I also noticed that, in **utils/utils.scale_coords**, the **gain** calculation is quite confusing. 
````
gain = max(img1_shape) / max(img0_shape)  # gain  = old / new
````
It might be incorrect if the image to the model **img1** is in rectangular shape but the original image **img0** is in squre, or **img1** is larger in width but **img0** is larger in height.
Actually **gain** and **pad** here should be exactly idendity to the **r** and **(dw, dh)** in **utils/datasets.letterbox**, since it's just the reverse operation. **So I also modified this part.**

But still, there are several round operations in **utils/datasets.letterbox**, but the reverse operation of **utils/utils.scale_coords** uses exact float number, which may cause some slight error. So if possible, I hope to change to use **ratio_pad** in **utils/utils.scale_coords** to directly set the **ratio** and **pad** from **utils/datasets.letterbox**.

And actually in my own application, I will use some images with very large width/height ratio, and that's why I am focusing on this width/height process. But currently **train.py** only do preprocess to resize and pad the raw image to square. This is acceptable but not preferrable. If possible, I hope to have the feature of allowing rectangular shaped images for training.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to image resizing and coordinate scaling logic in YOLOv5's data preprocessing.

### 📊 Key Changes
- 🛠 Fixed the `new_unpad` calculation in `letterbox` function to correctly reflect (height, width) ordering.
- 🔍 Adjusted the `gain` calculation in `scale_coords` to use the minimum scale factor between width and height, rather than the maximum of the two dimensions.

### 🎯 Purpose & Impact
- 📏 The `letterbox` change ensures the aspect ratio is maintained during image resizing without padding errors.
- 📐 The `scale_coords` adjustment provides more accurate bounding box coordinates after scaling, important for object detection accuracy.
- 🐛 These changes combine to fix aspect ratio distortion and improve the precision of object detection, leading to potentially better performance of the YOLOv5 models in various applications.