### PR TITLE
Fix save error for multi-gpu in ema

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -201,5 +201,5 @@ class ModelEMA:
     def update_attr(self, model):
         # Update EMA attributes
         for k, v in model.__dict__.items():
-            if not k.startswith('_') and k != 'module':
+            if not k.startswith('_') and k not in ["module", "process_group", "reducer"]:
                 setattr(self.ema, k, v)

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -201,5 +201,5 @@ class ModelEMA:
     def update_attr(self, model):
         # Update EMA attributes
         for k, v in model.__dict__.items():
-            if not k.startswith('_') and k not in ["module", "process_group", "reducer"]:
+            if not k.startswith('_') and k not in ["process_group", "reducer"]:
                 setattr(self.ema, k, v)


### PR DESCRIPTION
Fixes #279
Do not save 3 key pairs to ema attrib. Tested with cpu,1,2 gpu

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved attribute copying for model averaging in YOLOv5.

### 📊 Key Changes
- Updated the exclusion criteria for attributes during the Exponential Moving Average (EMA) update process in `torch_utils.py`.

### 🎯 Purpose & Impact
- 🛠️ **Purpose:** This change aims to prevent unnecessary attributes (like `process_group` and `reducer`) from being copied during the EMA update, which could potentially lead to errors or unintended behavior.
- 👍 **Impact:** Users will experience more reliable and accurate model averaging during training, leading to better model performance and stability.