### PR TITLE
fix LR bug

### DIFF
--- a/train.py
+++ b/train.py
@@ -101,6 +101,9 @@ def train(hyp):
         optim.SGD(pg0, lr=hyp['lr0'], momentum=hyp['momentum'], nesterov=True)
     optimizer.add_param_group({'params': pg1, 'weight_decay': hyp['weight_decay']})  # add pg1 with weight_decay
     optimizer.add_param_group({'params': pg2})  # add pg2 (biases)
+    # Scheduler https://arxiv.org/pdf/1812.01187.pdf
+    lf = lambda x: (((1 + math.cos(x * math.pi / epochs)) / 2) ** 1.0) * 0.9 + 0.1  # cosine
+    scheduler = lr_scheduler.LambdaLR(optimizer, lr_lambda=lf)
     print('Optimizer groups: %g .bias, %g conv.weight, %g other' % (len(pg2), len(pg1), len(pg0)))
     del pg0, pg1, pg2
 
@@ -144,9 +147,7 @@ def train(hyp):
     if mixed_precision:
         model, optimizer = amp.initialize(model, optimizer, opt_level='O1', verbosity=0)
 
-    # Scheduler https://arxiv.org/pdf/1812.01187.pdf
-    lf = lambda x: (((1 + math.cos(x * math.pi / epochs)) / 2) ** 1.0) * 0.9 + 0.1  # cosine
-    scheduler = lr_scheduler.LambdaLR(optimizer, lr_lambda=lf)
+
     scheduler.last_epoch = start_epoch - 1  # do not move
     # https://discuss.pytorch.org/t/a-problem-occured-when-resuming-an-optimizer/28822
     # plot_lr_scheduler(optimizer, scheduler, epochs)


### PR DESCRIPTION
lr_scheduler.LambdaLR will do self.step() with default last_epoch = -1 when we initialize it, so this code will reset LR if  it's at the bottom of loading optimizer.



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved learning rate scheduler initialization in YOLOv5 training script.

### 📊 Key Changes
- Relocated learning rate scheduler (`LambdaLR`) initialization to an earlier point in the setup of the optimizer.

### 🎯 Purpose & Impact
- **Enhanced code organization**: By positioning the scheduler setup closer to the optimizer configuration, the change makes the training code easier to follow.
- **Potential for extended configurations**: This could pave the way for more complex scheduler configurations that may rely on newly added optimizer parameter groups.
- **Impact on users**: No direct user impact in using YOLOv5, but developers examining or modifying the training process will experience a cleaner and potentially more flexible setup.