### PR TITLE
Update CoreML model conversion to do pixel scaling as well

### DIFF
--- a/models/export.py
+++ b/models/export.py
@@ -61,7 +61,8 @@ if __name__ == '__main__':
         import coremltools as ct
 
         print('\nStarting CoreML export with coremltools %s...' % ct.__version__)
-        model = ct.convert(ts, inputs=[ct.ImageType(name='images', shape=img.shape)])  # convert
+        # convert model from torchscript and apply pixel scaling as per detect.py
+        model = ct.convert(ts, inputs=[ct.ImageType(name='images', shape=img.shape, scale=1/255.0, bias=[0, 0, 0])])
         f = opt.weights.replace('.pt', '.mlmodel')  # filename
         model.save(f)
         print('CoreML export success, saved as %s' % f)


### PR DESCRIPTION
Hi

As agreed in #133 , in order to do proper inference with a model converted to CoreML, one has to also pass pixel scaling (if there is any done).

In **detect.py**, there is this specified:

```
img /= 255.0  # 0 - 255 to 0.0 - 1.0
```

I have updated the CoreML model conversion step to do this as well.

Cheers

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved CoreML model export with scaling in Ultralytics YOLOv5.

### 📊 Key Changes
- Updated the CoreML export process to apply pixel scaling during conversion.
- Explicitly set the image input scale to `1/255.0` with a zero bias.

### 🎯 Purpose & Impact
- Ensures the CoreML model processes input images with the same scaling as used in YOLOv5's `detect.py`.
- 📈 This change leads to more consistent performance between CoreML models and their original YOLOv5 counterparts.
- Helps users deploy models to iOS devices with correct preprocessing parameters automatically set.