### PR TITLE
Handle multiple datasets

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -294,8 +294,8 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                     raise Exception('%s does not exist' % p)
             path = p  # *.npy dir
             self.img_files = [x.replace('/', os.sep) for x in f if os.path.splitext(x)[-1].lower() in img_formats]
-        except:
-            raise Exception('Error loading data from %s. See %s' % (path, help_url))
+        except Exception as e:
+            raise Exception('Error loading data from %s: %s\nSee %s' % (path, e, help_url))
 
         n = len(self.img_files)
         assert n > 0, 'No images found in %s. See %s' % (path, help_url)

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -280,16 +280,28 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
     def __init__(self, path, img_size=640, batch_size=16, augment=False, hyp=None, rect=False, image_weights=False,
                  cache_images=False, single_cls=False, stride=32, pad=0.0):
         try:
-            path = str(Path(path))  # os-agnostic
-            parent = str(Path(path).parent) + os.sep
-            if os.path.isfile(path):  # file
-                with open(path, 'r') as f:
-                    f = f.read().splitlines()
-                    f = [x.replace('./', parent) if x.startswith('./') else x for x in f]  # local to global path
-            elif os.path.isdir(path):  # folder
-                f = glob.iglob(path + os.sep + '*.*')
+            if type(path) is list:
+                # Multiple datasets handler
+                f = []
+                for subpath in path:
+                    with open(subpath, 'r') as t:
+                        subpath = str(Path(subpath))  # os-agnostic
+                        parent = str(Path(subpath).parent) + os.sep
+                        t = t.read().splitlines()
+                        t = [x.replace('./', parent) if x.startswith('./') else x for x in t]  # local to global path
+                        f += t
+                path = str(Path(path[0]))  # from now on treat multiple datasets as single
             else:
-                raise Exception('%s does not exist' % path)
+                path = str(Path(path))  # os-agnostic
+                parent = str(Path(path).parent) + os.sep
+                if os.path.isfile(path):  # file
+                    with open(path, 'r') as f:
+                        f = f.read().splitlines()
+                        f = [x.replace('./', parent) if x.startswith('./') else x for x in f]  # local to global path
+                elif os.path.isdir(path):  # folder
+                    f = glob.iglob(path + os.sep + '*.*')
+                else:
+                    raise Exception('%s does not exist' % path)
             self.img_files = [x.replace('/', os.sep) for x in f if os.path.splitext(x)[-1].lower() in img_formats]
         except:
             raise Exception('Error loading data from %s. See %s' % (path, help_url))

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -281,21 +281,19 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                  cache_images=False, single_cls=False, stride=32, pad=0.0):
         try:
             f = []
-            for subpath in path if isinstance(path, list) else [path]:
-                subpath = str(Path(subpath))  # os-agnostic
-                parent = str(Path(subpath).parent) + os.sep
-                if os.path.isfile(subpath):  # file
-                    with open(subpath, 'r') as t:
+            for p in path if isinstance(path, list) else [path]:
+                p = str(Path(p))  # os-agnostic
+                parent = str(Path(p).parent) + os.sep
+                if os.path.isfile(p):  # file
+                    with open(p, 'r') as t:
                         t = t.read().splitlines()
-                        t = [x.replace('./', parent) if x.startswith('./') else x for x in t]  # local to global path
-                        f += t
-                elif os.path.isdir(subpath):  # folder
-                    f = glob.iglob(subpath + os.sep + '*.*')
-                    # Maybe change this to f += glob.glob, this should allow handling also multiple folders
+                        f += [x.replace('./', parent) if x.startswith('./') else x for x in t]  # local to global path
+                elif os.path.isdir(p):  # folder
+                    f += glob.iglob(p + os.sep + '*.*')
                 else:
-                    raise Exception('%s does not exist' % subpath)
+                    raise Exception('%s does not exist' % p)
+            path = p  # *.npy dir
             self.img_files = [x.replace('/', os.sep) for x in f if os.path.splitext(x)[-1].lower() in img_formats]
-            path = subpath
         except:
             # Maybe avoid handling bare exceptions
             raise Exception('Error loading data from %s. See %s' % (path, help_url))

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -295,7 +295,6 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
             path = p  # *.npy dir
             self.img_files = [x.replace('/', os.sep) for x in f if os.path.splitext(x)[-1].lower() in img_formats]
         except:
-            # Maybe avoid handling bare exceptions
             raise Exception('Error loading data from %s. See %s' % (path, help_url))
 
         n = len(self.img_files)

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -295,15 +295,10 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                 else:
                     raise Exception('%s does not exist' % subpath)
             self.img_files = [x.replace('/', os.sep) for x in f if os.path.splitext(x)[-1].lower() in img_formats]
+            path = subpath
         except:
             # Maybe avoid handling bare exceptions
             raise Exception('Error loading data from %s. See %s' % (path, help_url))
-
-        # Still need to do this for compatibility with the .npy and shape file saves
-        if isinstance(path, list):
-            path = str(Path(path[0]))
-        else:
-            path = str(Path(path))
 
         n = len(self.img_files)
         assert n > 0, 'No images found in %s. See %s' % (path, help_url)


### PR DESCRIPTION
As described by the title i tried to make the dataloader compatible with multiple sources training, at the moment the only way to do this is to copy all the images in a single .txt file. I'd rather define a new yaml file with multiple sources, in my opinion this is a faster way to mix different data sources.

In order to avoid changing a lot of code just to do this i've made a little workaround to save the shapes and .npy files only in the first dataset folder.

The final yaml file will look like this: 
```yaml
train: [./a/train.txt, ./b/train.txt, ...]
val: [./a/val.txt, ./b/val.txt, ...]
test: [./a/test.txt, ./b/test.txt, ...]
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced dataset loading to accept lists of paths.

### 📊 Key Changes
- 🔄 The `LoadImagesAndLabels` class now accepts lists of file or directory paths as input.
- ✨ Supports multiple file paths and directory paths which allows for more flexibility in specifying data sources.
- 🚀 Improvements on error messaging to provide more context when loading issues occur.

### 🎯 Purpose & Impact
- 🤝 Allows users to input a variety of paths (both single and multiple) for their dataset, streamlining data input from diverse sources.
- 🔍 Helps users quickly identify the source of issues with descriptive error messages, potentially reducing debugging time.
- ☑️ Ensures compatibility across different operating systems by normalizing file paths.