### PR TITLE
Move hyp and opt yaml save to top of train()

### DIFF
--- a/train.py
+++ b/train.py
@@ -52,6 +52,12 @@ def train(hyp):
     best = wdir + 'best.pt'
     results_file = log_dir + os.sep + 'results.txt'
 
+    # Save run settings
+    with open(Path(log_dir) / 'hyp.yaml', 'w') as f:
+        yaml.dump(hyp, f, sort_keys=False)
+    with open(Path(log_dir) / 'opt.yaml', 'w') as f:
+        yaml.dump(vars(opt), f, sort_keys=False)
+        
     epochs = opt.epochs  # 300
     batch_size = opt.batch_size  # 64
     weights = opt.weights  # initial training weights
@@ -170,12 +176,6 @@ def train(hyp):
     model.gr = 1.0  # giou loss ratio (obj_loss = 1.0 or giou)
     model.class_weights = labels_to_class_weights(dataset.labels, nc).to(device)  # attach class weights
     model.names = data_dict['names']
-
-    # Save run settings
-    with open(Path(log_dir) / 'hyp.yaml', 'w') as f:
-        yaml.dump(hyp, f, sort_keys=False)
-    with open(Path(log_dir) / 'opt.yaml', 'w') as f:
-        yaml.dump(vars(opt), f, sort_keys=False)
 
     # Class frequency
     labels = np.concatenate(dataset.labels, 0)


### PR DESCRIPTION
Fixes bug where scaled values were saved in hyp.yaml, which would cause continuity issues with --resume. Thanks to @jundengdeng for spotting the error in #104 .

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved log directory organization in YOLOv5's training script.

### 📊 Key Changes
- Moved the code snippet responsible for saving the run settings (`hyp.yaml` and `opt.yaml`) to an earlier stage in the `train.py` script.

### 🎯 Purpose & Impact
- **Purpose**: Ensures that run settings are saved before initializing the model and starting the training, making run configuration transparent and easily accessible right from the start of the training process.
- **Impact**: Users can immediately verify training configurations and ensure reproducibility of their experiments. In case the training process encounters an issue early on, the necessary settings are already stored, which helps in debugging or re-running the experiment. 📈🔍