### PR TITLE
Corrected path of validation dataset

### DIFF
--- a/data/coco128.yaml
+++ b/data/coco128.yaml
@@ -9,7 +9,7 @@
 
 # train and val datasets (image directory or *.txt file with image paths)
 train: ../coco128/images/train2017/
-val: ../coco128/images/train2017/
+val: ../coco128/images/val2017/
 
 # number of classes
 nc: 80


### PR DESCRIPTION
The previous path to the validation dataset in the _coco128.yaml_ was

`val: ../coco128/images/train2017/`

which has been corrected in this PR to

`val: ../coco128/images/val2017/`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved dataset configuration for better model validation.

### 📊 Key Changes
- Changed the validation dataset path from `train2017/` to `val2017/`.

### 🎯 Purpose & Impact
- The purpose of this change is to ensure that the model is being validated on the correct dataset, which was previously incorrectly set to the training set.
- This will lead to more accurate evaluation metrics for the model, as validation will be performed on unseen data.
- Users can expect improved model performance due to better training practices 🚀.