### PR TITLE
python3.8 numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # pip install -U -r requirements.txt
 Cython
-numpy==1.17
+numpy==1.17.3
 opencv-python
 torch>=1.5.1
 matplotlib


### PR DESCRIPTION
numpy 1.17.3 is required for python3.8

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to NumPy version in requirements.

### 📊 Key Changes
- Updated the version of NumPy from 1.17 to 1.17.3 in the `requirements.txt` file.

### 🎯 Purpose & Impact
- Ensures compatibility with newer features and bug fixes introduced in NumPy 1.17.3.
- Helps maintain the reliability and efficiency of the library by using an updated version of a core dependency.
- Users may experience more stable performance or access to improved functionalities within NumPy.