### PR TITLE
Resume with single arg

### DIFF
--- a/train.py
+++ b/train.py
@@ -406,6 +406,9 @@ if __name__ == '__main__':
         
         print(f'Resuming training from {last_run_dir}')
 
+        #update resume attribute to show what run this inherits from
+        resume_opt.resume = last_run_dir
+        
         #replace parsed args with opt from the run to resume from
         opt = resume_opt
 
@@ -424,7 +427,7 @@ if __name__ == '__main__':
 
     # Train
     if not opt.evolve:
-        tb_writer = SummaryWriter(log_dir=increment_dir('runs/exp', opt.name))
+        tb_writer = SummaryWriter(log_dir=increment_dir('runs' + os.sep + 'exp', opt.name))
         print('Start Tensorboard with "tensorboard --logdir=runs", view at http://localhost:6006/')
         train(hyp)
 

--- a/train.py
+++ b/train.py
@@ -384,19 +384,24 @@ if __name__ == '__main__':
 
     if opt.resume:
         last_run_dir = get_latest_run() if opt.resume == 'get_last' else opt.resume
-
+        
+        if not os.path.isdir(last_run_dir):
+            print('WARNING: --resume must point to a directory with an opt.yaml and weights/last.pt to resume from.')
+        
         try:
             with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
                 resume_opt = argparse.Namespace(**yaml.load(f, Loader=yaml.FullLoader))
+        except FileNotFoundError as e:
+            print(f'{e}. Ensure there is an opt.yaml in the runs/exp* directory you are resuming from.')
+            
+        last_weights = last_run_dir + os.sep + 'weights' + os.sep + 'last.pt'
+        resume_opt.weights = last_weights if os.path.isfile(last_weights) else print('WARNING: no weights/last.pt found to resume from.')
 
-            resume_opt.weights = last_run_dir + os.sep + 'weights' + os.sep + 'last.pt'
+        print(f'Resuming training from {last_run_dir}')
 
-            print(f'Resuming training from {last_run_dir}')
+        #replace parsed args with opt from the run to resume from
+        opt = resume_opt
 
-            #replace parsed args with opt from run to resume from
-            opt = resume_opt
-        except Exception as e:
-            print(f'Exception {e}. Ensure there is an opt.yaml in the runs/exp* directory you are resuming from.')
 
     opt.cfg = check_file(opt.cfg)  # check file
     opt.data = check_file(opt.data)  # check file

--- a/train.py
+++ b/train.py
@@ -382,6 +382,19 @@ if __name__ == '__main__':
     parser.add_argument('--single-cls', action='store_true', help='train as single-class dataset')
     opt = parser.parse_args()
 
+    if opt.resume:
+        last_run_dir = get_latest_run() if opt.resume == 'get_last' else opt.resume
+
+        with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
+            resume_opt = Namespace(**yaml.load(f, Loader=yaml.FullLoader))
+
+        resume_opt.weights = last_run_dir + os.sep + 'weights' + os.sep + 'last.pt'
+
+        print(f'Resuming training from {last_run_dir}')
+
+        #replace 
+        opt = resume_opt
+        
     last = get_latest_run() if opt.resume == 'get_last' else opt.resume  # resume from most recent run
     if last and not opt.weights:
         print(f'Resuming training from {last}')

--- a/train.py
+++ b/train.py
@@ -386,17 +386,24 @@ if __name__ == '__main__':
         last_run_dir = get_latest_run() if opt.resume == 'get_last' else opt.resume
         
         if not os.path.isdir(last_run_dir):
-            print('WARNING: --resume must point to a directory with an opt.yaml and weights/last.pt to resume from.')
+            raise NotADirectoryError('WARNING: --resume must point to a directory with an opt.yaml, hyp.yaml, and weights/last.pt to resume from.')
         
         try:
             with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
                 resume_opt = argparse.Namespace(**yaml.load(f, Loader=yaml.FullLoader))
         except FileNotFoundError as e:
             print(f'{e}. Ensure there is an opt.yaml in the runs/exp* directory you are resuming from.')
-            
+        
+        #set weights and hyp to values from original run
         last_weights = last_run_dir + os.sep + 'weights' + os.sep + 'last.pt'
-        resume_opt.weights = last_weights if os.path.isfile(last_weights) else print('WARNING: no weights/last.pt found to resume from.')
-
+        last_hyp = last_run_dir + os.sep + 'hyp.yaml'
+        
+        if os.path.exists(last_weights) and os.path.exists(last_hyp):
+            resume_opt.weights = last_weights 
+            resume_opt.hyp = last_hyp
+        else:
+            raise FileNotFoundError('WARNING: no weights/last.pt or hyp.yaml found to resume from.')
+        
         print(f'Resuming training from {last_run_dir}')
 
         #replace parsed args with opt from the run to resume from

--- a/train.py
+++ b/train.py
@@ -147,6 +147,10 @@ def train(hyp):
 
         del ckpt
 
+    # Warn users who try to --resume a completed run.
+    if start_epoch == epochs and opt.resume:
+      raise Warning('Previous training complete. Cannot resume. To use these weights in a new session use -- weights.')
+
     # Mixed precision training https://github.com/NVIDIA/apex
     if mixed_precision:
         model, optimizer = amp.initialize(model, optimizer, opt_level='O1', verbosity=0)

--- a/train.py
+++ b/train.py
@@ -385,16 +385,18 @@ if __name__ == '__main__':
     if opt.resume:
         last_run_dir = get_latest_run() if opt.resume == 'get_last' else opt.resume
 
-        with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
-            resume_opt = Namespace(**yaml.load(f, Loader=yaml.FullLoader))
+        try:
+            with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
+                resume_opt = Namespace(**yaml.load(f, Loader=yaml.FullLoader))
 
-        resume_opt.weights = last_run_dir + os.sep + 'weights' + os.sep + 'last.pt'
+            resume_opt.weights = last_run_dir + os.sep + 'weights' + os.sep + 'last.pt'
 
-        print(f'Resuming training from {last_run_dir}')
+            print(f'Resuming training from {last_run_dir}')
 
-        #replace parsed args with opt from run to resume from
-        opt = resume_opt
-
+            #replace parsed args with opt from run to resume from
+            opt = resume_opt
+        except Exception as e:
+            print(f'Exception {e}. Ensure there is an opt.yaml in the runs/exp* directory you are resuming from.')
 
     opt.cfg = check_file(opt.cfg)  # check file
     opt.data = check_file(opt.data)  # check file

--- a/train.py
+++ b/train.py
@@ -405,7 +405,7 @@ if __name__ == '__main__':
         if last_weights:
             resume_opt.weights = last_weights[0]
         else:
-          raise FileNotFoundError(f'No last*.pt found in {last_run_dir}weights to resume from.')
+          raise FileNotFoundError(f'No last*.pt found in {last_run_dir}/weights to resume from.')
 
         # set hyp to values from original run 
         last_hyp = last_run_dir + os.sep + 'hyp.yaml'

--- a/train.py
+++ b/train.py
@@ -426,7 +426,7 @@ if __name__ == '__main__':
         opt.hyp = check_file(opt.hyp)  # check file
         with open(opt.hyp) as f:
             hyp.update(yaml.load(f, Loader=yaml.FullLoader))  # update hyps
-    print(opt)
+    print(f'Training options:{opt}')
     opt.img_size.extend([opt.img_size[-1]] * (2 - len(opt.img_size)))  # extend to 2 sizes (train, test)
     device = torch_utils.select_device(opt.device, apex=mixed_precision, batch_size=opt.batch_size)
     if device.type == 'cpu':

--- a/train.py
+++ b/train.py
@@ -387,7 +387,7 @@ if __name__ == '__main__':
     parser.add_argument('--single-cls', action='store_true', help='train as single-class dataset')
     opt = parser.parse_args()
 
-    if opt.resume:
+    if opt.resume: # resume setup -----------------------------------------------
         last_run_dir = get_latest_run() if opt.resume == 'get_last' else opt.resume
         
         if not os.path.isdir(last_run_dir):
@@ -417,7 +417,7 @@ if __name__ == '__main__':
         
         #replace parsed args with opt from the run to resume from
         opt = resume_opt
-
+    # end resume setup ---------------------------------------------------------
 
     opt.cfg = check_file(opt.cfg)  # check file
     opt.data = check_file(opt.data)  # check file

--- a/train.py
+++ b/train.py
@@ -394,11 +394,8 @@ if __name__ == '__main__':
             raise NotADirectoryError('--resume must point to a directory with an opt.yaml, hyp.yaml, and weights/last*.pt to resume from.')
         
         # get opt from original run 
-        try:
-            with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
+        with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
                 resume_opt = argparse.Namespace(**yaml.load(f, Loader=yaml.FullLoader))
-        except FileNotFoundError as e:
-            raise FileNotFoundError(f'No opt.yaml in {last_run_dir} to resume from')
 
         # set weights to last*.pt from original run
         last_weights = glob.glob(last_run_dir + os.sep + 'weights' + os.sep + 'last*.pt')

--- a/train.py
+++ b/train.py
@@ -386,7 +386,7 @@ if __name__ == '__main__':
         last_run_dir = get_latest_run() if opt.resume == 'get_last' else opt.resume
         
         if not os.path.isdir(last_run_dir):
-            raise NotADirectoryError('WARNING: --resume must point to a directory with an opt.yaml, hyp.yaml, and weights/last.pt to resume from.')
+            raise NotADirectoryError('WARNING: --resume must point to a directory with an opt.yaml, hyp.yaml, and weights/last*.pt to resume from.')
         
         try:
             with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
@@ -395,14 +395,14 @@ if __name__ == '__main__':
             print(f'{e}. Ensure there is an opt.yaml in the runs/exp* directory you are resuming from.')
         
         #set weights and hyp to values from original run
-        last_weights = last_run_dir + os.sep + 'weights' + os.sep + 'last.pt'
+        last_weights = glob.glob(last_run_dir + os.sep + 'weights' + os.sep + 'last*.pt')[0]
         last_hyp = last_run_dir + os.sep + 'hyp.yaml'
         
         if os.path.exists(last_weights) and os.path.exists(last_hyp):
             resume_opt.weights = last_weights 
             resume_opt.hyp = last_hyp
         else:
-            raise FileNotFoundError('WARNING: no weights/last.pt or hyp.yaml found to resume from.')
+            raise FileNotFoundError('WARNING: no weights/last*.pt or hyp.yaml found to resume from.')
         
         print(f'Resuming training from {last_run_dir}')
 

--- a/train.py
+++ b/train.py
@@ -149,7 +149,8 @@ def train(hyp):
 
     # Warn users who try to --resume a completed run.
     if start_epoch == epochs and opt.resume:
-      raise Warning('Previous training complete. Cannot resume. To use these weights in a new session use -- weights.')
+        shutil.rmtree(log_dir)  # remove experiment dir
+        raise Warning('Previous training complete. Cannot resume. To use these weights in a new session use -- weights.')
 
     # Mixed precision training https://github.com/NVIDIA/apex
     if mixed_precision:

--- a/train.py
+++ b/train.py
@@ -397,7 +397,7 @@ if __name__ == '__main__':
             with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
                 resume_opt = argparse.Namespace(**yaml.load(f, Loader=yaml.FullLoader))
         except FileNotFoundError as e:
-            print(f'{e}. Ensure there is an opt.yaml in the runs/exp* directory you are resuming from.')
+            raise(f'{e}. Ensure there is an opt.yaml in the runs/exp* directory you are resuming from.')
         
         #set weights and hyp to values from original run
         last_weights = glob.glob(last_run_dir + os.sep + 'weights' + os.sep + 'last*.pt')[0]

--- a/train.py
+++ b/train.py
@@ -392,13 +392,10 @@ if __name__ == '__main__':
 
         print(f'Resuming training from {last_run_dir}')
 
-        #replace 
+        #replace parsed args with opt from run to resume from
         opt = resume_opt
-        
-    last = get_latest_run() if opt.resume == 'get_last' else opt.resume  # resume from most recent run
-    if last and not opt.weights:
-        print(f'Resuming training from {last}')
-    opt.weights = last if opt.resume and not opt.weights else opt.weights
+
+
     opt.cfg = check_file(opt.cfg)  # check file
     opt.data = check_file(opt.data)  # check file
     if opt.hyp:  # update hyps

--- a/train.py
+++ b/train.py
@@ -397,7 +397,8 @@ if __name__ == '__main__':
             with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
                 resume_opt = argparse.Namespace(**yaml.load(f, Loader=yaml.FullLoader))
         except FileNotFoundError as e:
-            raise(f'{e}. Ensure there is an opt.yaml in the runs/exp* directory you are resuming from.')
+            raise FileNotFoundError('Ensure there is an opt.yaml in the runs/exp* directory you are resuming from.')
+
         
         #set weights and hyp to values from original run
         last_weights = glob.glob(last_run_dir + os.sep + 'weights' + os.sep + 'last*.pt')[0]

--- a/train.py
+++ b/train.py
@@ -393,19 +393,20 @@ if __name__ == '__main__':
         if not os.path.isdir(last_run_dir):
             raise NotADirectoryError('--resume must point to a directory with an opt.yaml, hyp.yaml, and weights/last*.pt to resume from.')
         
+        # get opt from original run 
         try:
             with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
                 resume_opt = argparse.Namespace(**yaml.load(f, Loader=yaml.FullLoader))
         except FileNotFoundError as e:
             raise FileNotFoundError('Ensure there is an opt.yaml in the runs/exp* directory you are resuming from.')
 
-        
-        #set weights and hyp to values from original run
+        #set weights to last*.pt from original run
         last_weights = glob.glob(last_run_dir + os.sep + 'weights' + os.sep + 'last*.pt')[0]
+        resume_opt.weights = last_weights
+
+        # set hyp to values from original run 
         last_hyp = last_run_dir + os.sep + 'hyp.yaml'
-        
-        if os.path.exists(last_weights) and os.path.exists(last_hyp):
-            resume_opt.weights = last_weights 
+        if os.path.exists(last_hyp):
             resume_opt.hyp = last_hyp
         else:
             raise FileNotFoundError('no weights/last*.pt or hyp.yaml found to resume from.')

--- a/train.py
+++ b/train.py
@@ -386,7 +386,7 @@ if __name__ == '__main__':
         last_run_dir = get_latest_run() if opt.resume == 'get_last' else opt.resume
         
         if not os.path.isdir(last_run_dir):
-            raise NotADirectoryError('WARNING: --resume must point to a directory with an opt.yaml, hyp.yaml, and weights/last*.pt to resume from.')
+            raise NotADirectoryError('--resume must point to a directory with an opt.yaml, hyp.yaml, and weights/last*.pt to resume from.')
         
         try:
             with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
@@ -402,7 +402,7 @@ if __name__ == '__main__':
             resume_opt.weights = last_weights 
             resume_opt.hyp = last_hyp
         else:
-            raise FileNotFoundError('WARNING: no weights/last*.pt or hyp.yaml found to resume from.')
+            raise FileNotFoundError('no weights/last*.pt or hyp.yaml found to resume from.')
         
         print(f'Resuming training from {last_run_dir}')
 

--- a/train.py
+++ b/train.py
@@ -398,18 +398,21 @@ if __name__ == '__main__':
             with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
                 resume_opt = argparse.Namespace(**yaml.load(f, Loader=yaml.FullLoader))
         except FileNotFoundError as e:
-            raise FileNotFoundError('Ensure there is an opt.yaml in the runs/exp* directory you are resuming from.')
+            raise FileNotFoundError(f'No opt.yaml in {last_run_dir} to resume from')
 
-        #set weights to last*.pt from original run
-        last_weights = glob.glob(last_run_dir + os.sep + 'weights' + os.sep + 'last*.pt')[0]
-        resume_opt.weights = last_weights
+        # set weights to last*.pt from original run
+        last_weights = glob.glob(last_run_dir + os.sep + 'weights' + os.sep + 'last*.pt')
+        if last_weights:
+            resume_opt.weights = last_weights[0]
+        else:
+          raise FileNotFoundError(f'No last*.pt found in {last_run_dir}weights to resume from.')
 
         # set hyp to values from original run 
         last_hyp = last_run_dir + os.sep + 'hyp.yaml'
         if os.path.exists(last_hyp):
             resume_opt.hyp = last_hyp
         else:
-            raise FileNotFoundError('no weights/last*.pt or hyp.yaml found to resume from.')
+            raise FileNotFoundError(f'No hyp.yaml found in {last_run_dir} to resume from.')
         
         print(f'Resuming training from {last_run_dir}')
 

--- a/train.py
+++ b/train.py
@@ -368,7 +368,7 @@ if __name__ == '__main__':
     parser.add_argument('--img-size', nargs='+', type=int, default=[640, 640], help='train,test sizes')
     parser.add_argument('--rect', action='store_true', help='rectangular training')
     parser.add_argument('--resume', nargs='?', const='get_last', default=False,
-                        help='resume from given path/to/last.pt, or most recent run if blank.')
+                        help='resume from given path/to/runs/exp* directory, or most recent run if blank.')
     parser.add_argument('--nosave', action='store_true', help='only save final checkpoint')
     parser.add_argument('--notest', action='store_true', help='only test final epoch')
     parser.add_argument('--noautoanchor', action='store_true', help='disable autoanchor check')
@@ -387,7 +387,7 @@ if __name__ == '__main__':
 
         try:
             with open(last_run_dir + os.sep + 'opt.yaml', 'r') as f:
-                resume_opt = Namespace(**yaml.load(f, Loader=yaml.FullLoader))
+                resume_opt = argparse.Namespace(**yaml.load(f, Loader=yaml.FullLoader))
 
             resume_opt.weights = last_run_dir + os.sep + 'weights' + os.sep + 'last.pt'
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -39,7 +39,7 @@ def init_seeds(seed=0):
 
 def get_latest_run(search_dir='./runs'):
     # Return path to most recent 'last.pt' in /runs (i.e. to --resume from)
-    last_list = glob.glob(f'{search_dir}/**/last*.pt', recursive=True)
+    last_list = glob.glob(f'{search_dir}/*', recursive=False)
     return max(last_list, key=os.path.getctime)
 
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -38,7 +38,7 @@ def init_seeds(seed=0):
 
 
 def get_latest_run(search_dir='./runs'):
-    # Return path to most recent 'last.pt' in /runs (i.e. to --resume from)
+    # Return path to most recent experiment in /runs (i.e. to --resume from)
     last_list = glob.glob(f'{search_dir}/*', recursive=False)
     return max(last_list, key=os.path.getctime)
 


### PR DESCRIPTION
**Based on conversation regarding `--resume` functionality in #104**

This PR aims to reduce confusion and user error (exceptions, and undetected errors which cause poor training performance) when using the resume training functionality. This PR restricts users to only using `--resume` as intended. 

There are two use cases:
1) Search for the most recent run/exp* directory, and resume training from there. 
```
python train.py --resume
```

2) Resume from a specific unfinished training run. Useful when multiple training runs have been interrupted. 
```
python train.py --resume runs/exp*
```
Other additions:
* Checkpoint to warn users when they are attempting to resume an already completed run.
* Checks input resume dirs for necessary files for resuming. Need 3: `opt.yaml`, `hyp.yaml`, `last*.pt`
* Ignores all other args if `--resume` is used. This ensures users do not accidentally interfere with their training scheme. 

[Here](https://colab.research.google.com/drive/1y4VMjh8ucYfbE6b2SiJuH1LZ5kJMWj_d?usp=sharing) is a colab notebook with some examples. 

Happy to adjust implementation further based on discussion. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced `--resume` behavior with checks for completed runs and improved configuration restoration.

### 📊 Key Changes
- 🚫 If an attempt is made to resume a finished training run, the run's directory is removed and a warning is issued.
- ✏️ The help text for the `--resume` argument now specifies that it should point to an experiment directory, not a `.pt` file.
- 🔄 The resumption method in `train.py` was reworked to:
  - Ensure the provided `--resume` path points to a valid directory containing necessary files (e.g., `opt.yaml`, `hyp.yaml`, and weights).
  - Load and apply options (`opt`) and hyperparameters (`hyp`) from the original run.
  - Set the path to the weights file from the last checkpoint of the original run.
- 📁 The updated behavior creates a better link between the resumed run and its parent, eliminating confusion and potential mistakes when resuming training.
  
### 🎯 Purpose & Impact
- The update prevents users from inadvertently trying to resume a run that has already concluded, which could lead to data loss.
- By automating the lifting of configurations from previous runs, this PR simplifies the process of resuming, making it more error-proof and user-friendly.
- Users benefit from a more robust and intuitive resume functionality, increasing the effectiveness of iterative training sessions and saving time during the machine learning model development lifecycle.