### PR TITLE
Update train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -130,9 +130,12 @@ def train(hyp, tb_writer, opt, device):
 
         # load model
         try:
+            exclude = ['anchor']  # exclude keys
             ckpt['model'] = {k: v for k, v in ckpt['model'].float().state_dict().items()
-                             if k in model.state_dict() and model.state_dict()[k].shape == v.shape}
+                             if k in model.state_dict() and not any(x in k for x in exclude)
+                             and model.state_dict()[k].shape == v.shape}
             model.load_state_dict(ckpt['model'], strict=False)
+            print('Transferred %g/%g items from %s' % (len(ckpt['model']), len(model.state_dict()), weights))
         except KeyError as e:
             s = "%s is not compatible with %s. This may be due to model differences or %s may be out of date. " \
                 "Please delete or update %s and try again, or use --weights '' to train from scratch." \


### PR DESCRIPTION
Bug fix for accidental anchor transfer from pretrained --weight https://github.com/ultralytics/yolov5/issues/459

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model loading mechanisms in training scripts, improving flexibility and feedback.

### 📊 Key Changes
- ✂️ Introduced an exclude list that prevents certain parameters (like 'anchor') from being loaded into the model.
- 🧠 Updated model loading to dynamically filter out parameters based on the exclude list.
- 🖨️ Added informative print statement showing how many parameters were successfully loaded.

### 🎯 Purpose & Impact
- 🛠️ This change allows for more control over which parts of a pretrained model are transferred when initializing a model for training.
- 🔍 Users will now see clear output indicating the success of the parameter transfer, helping them diagnose and understand the loading process.
- 👨‍💻 For developers, this lays the groundwork for selectively updating model parameters and can help in experiments where only parts of a model need to be fine-tuned.