### PR TITLE
Fix redundant outputs via Logging in DDP training

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -1,5 +1,6 @@
 import argparse
 import math
+import logging
 from copy import deepcopy
 from pathlib import Path
 
@@ -12,7 +13,7 @@ from utils.general import check_anchor_order, make_divisible, check_file
 from utils.torch_utils import (
     time_synchronized, fuse_conv_and_bn, model_info, scale_img, initialize_weights, select_device)
 
-
+logger = logging.getLogger(__name__)
 class Detect(nn.Module):
     def __init__(self, nc=80, anchors=(), ch=()):  # detection layer
         super(Detect, self).__init__()
@@ -169,7 +170,7 @@ class Model(nn.Module):
 
 
 def parse_model(d, ch):  # model_dict, input_channels(3)
-    print('\n%3s%18s%3s%10s  %-40s%-30s' % ('', 'from', 'n', 'params', 'module', 'arguments'))
+    logger.info('\n%3s%18s%3s%10s  %-40s%-30s' % ('', 'from', 'n', 'params', 'module', 'arguments'))
     anchors, nc, gd, gw = d['anchors'], d['nc'], d['depth_multiple'], d['width_multiple']
     na = (len(anchors[0]) // 2) if isinstance(anchors, list) else anchors  # number of anchors
     no = na * (nc + 5)  # number of outputs = anchors * (classes + 5)
@@ -224,7 +225,7 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
         t = str(m)[8:-2].replace('__main__.', '')  # module type
         np = sum([x.numel() for x in m_.parameters()])  # number params
         m_.i, m_.f, m_.type, m_.np = i, f, t, np  # attach index, 'from' index, type, number params
-        print('%3s%18s%3s%10.0f  %-40s%-30s' % (i, f, n, np, t, args))  # print
+        logger.info('%3s%18s%3s%10.0f  %-40s%-30s' % (i, f, n, np, t, args))  # print
         save.extend(x % i for x in ([f] if isinstance(f, int) else f) if x != -1)  # append to savelist
         layers.append(m_)
         ch.append(c2)

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -14,6 +14,7 @@ from utils.torch_utils import (
     time_synchronized, fuse_conv_and_bn, model_info, scale_img, initialize_weights, select_device)
 
 logger = logging.getLogger(__name__)
+
 class Detect(nn.Module):
     def __init__(self, nc=80, anchors=(), ch=()):  # detection layer
         super(Detect, self).__init__()

--- a/train.py
+++ b/train.py
@@ -406,6 +406,7 @@ if __name__ == '__main__':
     opt = parser.parse_args()
 
     set_logging(opt.local_rank)
+    
     # Resume
     if opt.resume:
         last = get_latest_run() if opt.resume == 'get_last' else opt.resume  # resume from most recent run

--- a/train.py
+++ b/train.py
@@ -31,7 +31,7 @@ from utils.torch_utils import init_seeds, ModelEMA, select_device, intersect_dic
 logger = logging.getLogger(__name__)
 
 def train(hyp, opt, device, tb_writer=None):
-    logger.info(f'Hyperparameter {hyp}')
+    logger.info(f'Hyperparameters {hyp}')
     log_dir = Path(tb_writer.log_dir) if tb_writer else Path(opt.logdir) / 'evolve'  # logging directory
     wdir = str(log_dir / 'weights') + os.sep  # weights directory
     os.makedirs(wdir, exist_ok=True)

--- a/train.py
+++ b/train.py
@@ -31,7 +31,7 @@ from utils.torch_utils import init_seeds, ModelEMA, select_device, intersect_dic
 logger = logging.getLogger(__name__)
 
 def train(hyp, opt, device, tb_writer=None):
-    logger.info(f"Hyperparameter {hyp}")
+    logger.info(f'Hyperparameter {hyp}')
     log_dir = Path(tb_writer.log_dir) if tb_writer else Path(opt.logdir) / 'evolve'  # logging directory
     wdir = str(log_dir / 'weights') + os.sep  # weights directory
     os.makedirs(wdir, exist_ok=True)
@@ -406,8 +406,8 @@ if __name__ == '__main__':
 
     # Set DDP variables
     opt.total_batch_size = opt.batch_size
-    opt.world_size = int(os.environ["WORLD_SIZE"]) if "WORLD_SIZE" in os.environ else 1
-    opt.global_rank = int(os.environ["RANK"]) if "RANK" in os.environ else -1
+    opt.world_size = int(os.environ['WORLD_SIZE']) if 'WORLD_SIZE' in os.environ else 1
+    opt.global_rank = int(os.environ['RANK']) if 'RANK' in os.environ else -1
     set_logging(opt.global_rank)
 
     # Resume

--- a/train.py
+++ b/train.py
@@ -234,7 +234,8 @@ def train(hyp, opt, device, tb_writer=None):
             dataloader.sampler.set_epoch(epoch)
         pbar = enumerate(dataloader)
         logging.info(('\n' + '%10s' * 8) % ('Epoch', 'gpu_mem', 'GIoU', 'obj', 'cls', 'total', 'targets', 'img_size'))
-        if rank in [-1, 0]: pbar = tqdm(pbar, total=nb)  # progress bar
+        if rank in [-1, 0]:
+            pbar = tqdm(pbar, total=nb)  # progress bar
         optimizer.zero_grad()
         for i, (imgs, targets, paths, _) in pbar:  # batch -------------------------------------------------------------
             ni = i + nb * epoch  # number integrated batches (since train start)

--- a/train.py
+++ b/train.py
@@ -71,7 +71,7 @@ def train(hyp, opt, device, tb_writer=None):
         state_dict = ckpt['model'].float().state_dict()  # to FP32
         state_dict = intersect_dicts(state_dict, model.state_dict(), exclude=exclude)  # intersect
         model.load_state_dict(state_dict, strict=False)  # load
-        print('Transferred %g/%g items from %s' % (len(state_dict), len(model.state_dict()), weights))  # report
+        logging.info('Transferred %g/%g items from %s' % (len(state_dict), len(model.state_dict()), weights))  # report
     else:
         model = Model(opt.cfg, ch=3, nc=nc).to(device)  # create
 
@@ -233,9 +233,8 @@ def train(hyp, opt, device, tb_writer=None):
         if rank != -1:
             dataloader.sampler.set_epoch(epoch)
         pbar = enumerate(dataloader)
-        if rank in [-1, 0]:
-            print(('\n' + '%10s' * 8) % ('Epoch', 'gpu_mem', 'GIoU', 'obj', 'cls', 'total', 'targets', 'img_size'))
-            pbar = tqdm(pbar, total=nb)  # progress bar
+        logging.info(('\n' + '%10s' * 8) % ('Epoch', 'gpu_mem', 'GIoU', 'obj', 'cls', 'total', 'targets', 'img_size'))
+        if rank in [-1, 0]: pbar = tqdm(pbar, total=nb)  # progress bar
         optimizer.zero_grad()
         for i, (imgs, targets, paths, _) in pbar:  # batch -------------------------------------------------------------
             ni = i + nb * epoch  # number integrated batches (since train start)

--- a/train.py
+++ b/train.py
@@ -406,8 +406,8 @@ if __name__ == '__main__':
 
     # Set DDP variables
     opt.total_batch_size = opt.batch_size
-    opt.world_size = os.environ["WORLD_SIZE"] if "WORLD_SIZE" in os.environ else 1
-    opt.global_rank = os.environ["RANK"] if "RANK" in os.environ else -1
+    opt.world_size = int(os.environ["WORLD_SIZE"]) if "WORLD_SIZE" in os.environ else 1
+    opt.global_rank = int(os.environ["RANK"]) if "RANK" in os.environ else -1
     set_logging(opt.global_rank)
 
     # Resume

--- a/train.py
+++ b/train.py
@@ -158,7 +158,7 @@ def train(hyp, opt, device, tb_writer=None):
 
     # Trainloader
     dataloader, dataset = create_dataloader(train_path, imgsz, batch_size, gs, opt, hyp=hyp, augment=True,
-                                            cache=opt.cache_images, rect=opt.rect, local_rank=rank,
+                                            cache=opt.cache_images, rect=opt.rect, rank=rank,
                                             world_size=opt.world_size)
     mlc = np.concatenate(dataset.labels, 0)[:, 0].max()  # max label class
     nb = len(dataloader)  # number of batches
@@ -168,7 +168,7 @@ def train(hyp, opt, device, tb_writer=None):
     if rank in [-1, 0]:
         # local_rank is set to -1. Because only the first process is expected to do evaluation.
         testloader = create_dataloader(test_path, imgsz_test, total_batch_size, gs, opt, hyp=hyp, augment=False,
-                                       cache=opt.cache_images, rect=True, local_rank=-1, world_size=opt.world_size)[0]
+                                       cache=opt.cache_images, rect=True, rank=-1, world_size=opt.world_size)[0]
 
     # Model parameters
     hyp['cls'] *= nc / 80.  # scale coco-tuned hyp['cls'] to current dataset
@@ -406,7 +406,7 @@ if __name__ == '__main__':
     opt = parser.parse_args()
 
     set_logging(opt.local_rank)
-    
+
     # Resume
     if opt.resume:
         last = get_latest_run() if opt.resume == 'get_last' else opt.resume  # resume from most recent run

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -47,9 +47,9 @@ def exif_size(img):
 
 
 def create_dataloader(path, imgsz, batch_size, stride, opt, hyp=None, augment=False, cache=False, pad=0.0, rect=False,
-                      local_rank=-1, world_size=1):
+                      rank=-1, world_size=1):
     # Make sure only the first process in DDP process the dataset first, and the following others can use the cache.
-    with torch_distributed_zero_first(local_rank):
+    with torch_distributed_zero_first(rank):
         dataset = LoadImagesAndLabels(path, imgsz, batch_size,
                                       augment=augment,  # augment images
                                       hyp=hyp,  # augmentation hyperparameters
@@ -57,11 +57,12 @@ def create_dataloader(path, imgsz, batch_size, stride, opt, hyp=None, augment=Fa
                                       cache_images=cache,
                                       single_cls=opt.single_cls,
                                       stride=int(stride),
-                                      pad=pad)
+                                      pad=pad,
+                                      rank=rank)
 
     batch_size = min(batch_size, len(dataset))
     nw = min([os.cpu_count() // world_size, batch_size if batch_size > 1 else 0, 8])  # number of workers
-    train_sampler = torch.utils.data.distributed.DistributedSampler(dataset) if local_rank != -1 else None
+    train_sampler = torch.utils.data.distributed.DistributedSampler(dataset) if rank != -1 else None
     dataloader = torch.utils.data.DataLoader(dataset,
                                              batch_size=batch_size,
                                              num_workers=nw,
@@ -292,7 +293,7 @@ class LoadStreams:  # multiple IP or RTSP cameras
 
 class LoadImagesAndLabels(Dataset):  # for training/testing
     def __init__(self, path, img_size=640, batch_size=16, augment=False, hyp=None, rect=False, image_weights=False,
-                 cache_images=False, single_cls=False, stride=32, pad=0.0):
+                 cache_images=False, single_cls=False, stride=32, pad=0.0, rank=-1):
         try:
             f = []  # image files
             for p in path if isinstance(path, list) else [path]:
@@ -372,8 +373,9 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         # Cache labels
         create_datasubset, extract_bounding_boxes, labels_loaded = False, False, False
         nm, nf, ne, ns, nd = 0, 0, 0, 0, 0  # number missing, found, empty, datasubset, duplicate
-        pbar = tqdm(self.label_files)
-        for i, file in enumerate(pbar):
+        pbar = enumerate(self.label_files)
+        if (rank in [-1, 0]): pbar = tqdm(pbar)    
+        for i, file in pbar:
             l = self.labels[i]  # label
             if l.shape[0]:
                 assert l.shape[1] == 5, '> 5 label columns: %s' % file
@@ -420,8 +422,9 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                 ne += 1  # print('empty labels for image %s' % self.img_files[i])  # file empty
                 # os.system("rm '%s' '%s'" % (self.img_files[i], self.label_files[i]))  # remove
 
-            pbar.desc = 'Scanning labels %s (%g found, %g missing, %g empty, %g duplicate, for %g images)' % (
-                cache_path, nf, nm, ne, nd, n)
+            if (rank in [-1,0]):
+                pbar.desc = 'Scanning labels %s (%g found, %g missing, %g empty, %g duplicate, for %g images)' % (
+                    cache_path, nf, nm, ne, nd, n)
         if nf == 0:
             s = 'WARNING: No labels found in %s. See %s' % (os.path.dirname(file) + os.sep, help_url)
             print(s)

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -374,7 +374,8 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         create_datasubset, extract_bounding_boxes, labels_loaded = False, False, False
         nm, nf, ne, ns, nd = 0, 0, 0, 0, 0  # number missing, found, empty, datasubset, duplicate
         pbar = enumerate(self.label_files)
-        if (rank in [-1, 0]): pbar = tqdm(pbar)    
+        if rank in [-1, 0]:
+            pbar = tqdm(pbar)
         for i, file in pbar:
             l = self.labels[i]  # label
             if l.shape[0]:
@@ -422,7 +423,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                 ne += 1  # print('empty labels for image %s' % self.img_files[i])  # file empty
                 # os.system("rm '%s' '%s'" % (self.img_files[i], self.label_files[i]))  # remove
 
-            if (rank in [-1,0]):
+            if rank in [-1,0]:
                 pbar.desc = 'Scanning labels %s (%g found, %g missing, %g empty, %g duplicate, for %g images)' % (
                     cache_path, nf, nm, ne, nd, n)
         if nf == 0:

--- a/utils/general.py
+++ b/utils/general.py
@@ -47,12 +47,11 @@ def torch_distributed_zero_first(local_rank: int):
 
 
 def set_logging(rank=-1):
-    # Setup logging
     logging.basicConfig(
         format="%(message)s",
-        datefmt="%d/%m/%Y %H:%M:%S",
         level=logging.INFO if rank in [-1, 0] else logging.WARN,
     )
+
 
 def init_seeds(seed=0):
     random.seed(seed)

--- a/utils/general.py
+++ b/utils/general.py
@@ -5,6 +5,7 @@ import random
 import shutil
 import subprocess
 import time
+import logging
 from contextlib import contextmanager
 from copy import copy
 from pathlib import Path
@@ -44,6 +45,14 @@ def torch_distributed_zero_first(local_rank: int):
     if local_rank == 0:
         torch.distributed.barrier()
 
+
+def set_logging(rank=-1):
+    # Setup logging
+    logging.basicConfig(
+        format="%(message)s",
+        datefmt="%d/%m/%Y %H:%M:%S",
+        level=logging.INFO if rank in [-1, 0] else logging.WARN,
+    )
 
 def init_seeds(seed=0):
     random.seed(seed)

--- a/utils/general.py
+++ b/utils/general.py
@@ -49,8 +49,7 @@ def torch_distributed_zero_first(local_rank: int):
 def set_logging(rank=-1):
     logging.basicConfig(
         format="%(message)s",
-        level=logging.INFO if rank in [-1, 0] else logging.WARN,
-    )
+        level=logging.INFO if rank in [-1, 0] else logging.WARN)
 
 
 def init_seeds(seed=0):

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -9,6 +9,7 @@ import torch.backends.cudnn as cudnn
 import torch.nn as nn
 import torch.nn.functional as F
 import torchvision.models as models
+
 logger = logging.getLogger(__name__)
 
 def init_seeds(seed=0):

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -45,9 +45,9 @@ def select_device(device='', batch_size=None):
             logger.info("%sdevice%g _CudaDeviceProperties(name='%s', total_memory=%dMB)" %
                   (s, i, x[i].name, x[i].total_memory / c))
     else:
-        print('Using CPU')
+        logger.info('Using CPU')
 
-    print('')  # skip a line
+    logger.info('')  # skip a line
     return torch.device('cuda:0' if cuda else 'cpu')
 
 

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -1,6 +1,7 @@
 import math
 import os
 import time
+import logging
 from copy import deepcopy
 
 import torch
@@ -8,7 +9,7 @@ import torch.backends.cudnn as cudnn
 import torch.nn as nn
 import torch.nn.functional as F
 import torchvision.models as models
-
+logger = logging.getLogger(__name__)
 
 def init_seeds(seed=0):
     torch.manual_seed(seed)
@@ -40,7 +41,7 @@ def select_device(device='', batch_size=None):
         for i in range(0, ng):
             if i == 1:
                 s = ' ' * len(s)
-            print("%sdevice%g _CudaDeviceProperties(name='%s', total_memory=%dMB)" %
+            logger.info("%sdevice%g _CudaDeviceProperties(name='%s', total_memory=%dMB)" %
                   (s, i, x[i].name, x[i].total_memory / c))
     else:
         print('Using CPU')
@@ -142,7 +143,7 @@ def model_info(model, verbose=False):
     except:
         fs = ''
 
-    print('Model Summary: %g layers, %g parameters, %g gradients%s' % (len(list(model.parameters())), n_p, n_g, fs))
+    logger.info('Model Summary: %g layers, %g parameters, %g gradients%s' % (len(list(model.parameters())), n_p, n_g, fs))
 
 
 def load_classifier(name='resnet101', n=2):


### PR DESCRIPTION
This PR fixes #463 second point. 
Tested on coco128
```python
python -m torch.distributed.launch --nproc_per_node 2 train.py --weights yolov5s.pt --cfg yolov5s.yaml --epochs 1 --img 320
```

<details>
<summary>Old output (current master)</summary>

```
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
*****************************************
Using CUDA Apex device0 _CudaDeviceProperties(name='Tesla V100-SXM2-32GB', total_memory=32480MB)
                device1 _CudaDeviceProperties(name='Tesla V100-SXM2-32GB', total_memory=32480MB)

Using CUDA Apex device0 _CudaDeviceProperties(name='Tesla V100-SXM2-32GB', total_memory=32480MB)
                device1 _CudaDeviceProperties(name='Tesla V100-SXM2-32GB', total_memory=32480MB)

Namespace(batch_size=8, bucket='', cache_images=False, cfg='./models/yolov5s.yaml', data='data/coco128.yaml', device='0,1', epochs=1, evolve=False, hyp='', img_size=[320, 320], local_rank=1, multi_scale=False, name='', noautoanchor=False, nosave=False, notest=False, rect=False, resume=False, single_cls=False, sync_bn=False, total_batch_size=16, weights='yolov5s.pt', world_size=2)
Hyperparameters {'optimizer': 'SGD', 'lr0': 0.01, 'momentum': 0.937, 'weight_decay': 0.0005, 'giou': 0.05, 'cls': 0.5, 'cls_pw': 1.0, 'obj': 1.0, 'obj_pw': 1.0, 'iou_t': 0.2, 'anchor_t': 4.0, 'fl_gamma': 0.0, 'hsv_h': 0.015, 'hsv_s': 0.7, 'hsv_v': 0.4, 'degrees': 0.0, 'translate': 0.0, 'scale': 0.5, 'shear': 0.0}
Namespace(batch_size=8, bucket='', cache_images=False, cfg='./models/yolov5s.yaml', data='data/coco128.yaml', device='0,1', epochs=1, evolve=False, hyp='', img_size=[320, 320], local_rank=0, multi_scale=False, name='', noautoanchor=False, nosave=False, notest=False, rect=False, resume=False, single_cls=False, sync_bn=False, total_batch_size=16, weights='yolov5s.pt', world_size=2)
Start Tensorboard with "tensorboard --logdir=runs", view at http://localhost:6006/

                 from  n    params  module                                  arguments                     
  0                -1  1      3520  models.common.Focus                     [3, 32, 3]                    
  1                -1  1     18560  models.common.Conv                      [32, 64, 3, 2]                
  2                -1  1     19904  models.common.BottleneckCSP             [64, 64, 1]                   
  3                -1  1     73984  models.common.Conv                      [64, 128, 3, 2]               
  4                -1  1    161152  models.common.BottleneckCSP             [128, 128, 3]                 
  5                -1  1    295424  models.common.Conv                      [128, 256, 3, 2]              
  6                -1  1    641792  models.common.BottleneckCSP             [256, 256, 3]                 
  7                -1  1   1180672  models.common.Conv                      [256, 512, 3, 2]              
  8                -1  1    656896  models.common.SPP                       [512, 512, [5, 9, 13]]        
  9                -1  1   1248768  models.common.BottleneckCSP             [512, 512, 1, False]          
 10                -1  1    131584  models.common.Conv                      [512, 256, 1, 1]              
 11                -1  1         0  torch.nn.modules.upsampling.Upsample    [None, 2, 'nearest']          
 12           [-1, 6]  1         0  models.common.Concat                    [1]                           
 13                -1  1    378624  models.common.BottleneckCSP             [512, 256, 1, False]          
 14                -1  1     33024  models.common.Conv                      [256, 128, 1, 1]              
 15                -1  1         0  torch.nn.modules.upsampling.Upsample    [None, 2, 'nearest']          
 16           [-1, 4]  1         0  models.common.Concat                    [1]                           
 17                -1  1     95104  models.common.BottleneckCSP             [256, 128, 1, False]          
 18                -1  1    147712  models.common.Conv                      [128, 128, 3, 2]              
 19          [-1, 14]  1         0  models.common.Concat                    [1]                           
 20                -1  1    313088  models.common.BottleneckCSP             [256, 256, 1, False]          
 21                -1  1    590336  models.common.Conv                      [256, 256, 3, 2]              
 22          [-1, 10]  1         0  models.common.Concat                    [1]                           
 23                -1  1   1248768  models.common.BottleneckCSP             [512, 512, 1, False]          
 24      [17, 20, 23]  1    229245  models.yolo.Detect                      [80, [[10, 13, 16, 30, 33, 23], [30, 61, 62, 45, 59, 119], [116, 90, 156, 198, 373, 326]], [128, 256, 512]]
Model Summary: 191 layers, 7.46816e+06 parameters, 7.46816e+06 gradients

Hyperparameters {'optimizer': 'SGD', 'lr0': 0.01, 'momentum': 0.937, 'weight_decay': 0.0005, 'giou': 0.05, 'cls': 0.5, 'cls_pw': 1.0, 'obj': 1.0, 'obj_pw': 1.0, 'iou_t': 0.2, 'anchor_t': 4.0, 'fl_gamma': 0.0, 'hsv_h': 0.015, 'hsv_s': 0.7, 'hsv_v': 0.4, 'degrees': 0.0, 'translate': 0.0, 'scale': 0.5, 'shear': 0.0}

                 from  n    params  module                                  arguments                     
  0                -1  1      3520  models.common.Focus                     [3, 32, 3]                    
  1                -1  1     18560  models.common.Conv                      [32, 64, 3, 2]                
  2                -1  1     19904  models.common.BottleneckCSP             [64, 64, 1]                   
  3                -1  1     73984  models.common.Conv                      [64, 128, 3, 2]               
  4                -1  1    161152  models.common.BottleneckCSP             [128, 128, 3]                 
  5                -1  1    295424  models.common.Conv                      [128, 256, 3, 2]              
  6                -1  1    641792  models.common.BottleneckCSP             [256, 256, 3]                 
  7                -1  1   1180672  models.common.Conv                      [256, 512, 3, 2]              
  8                -1  1    656896  models.common.SPP                       [512, 512, [5, 9, 13]]        
  9                -1  1   1248768  models.common.BottleneckCSP             [512, 512, 1, False]          
 10                -1  1    131584  models.common.Conv                      [512, 256, 1, 1]              
 11                -1  1         0  torch.nn.modules.upsampling.Upsample    [None, 2, 'nearest']          
 12           [-1, 6]  1         0  models.common.Concat                    [1]                           
 13                -1  1    378624  models.common.BottleneckCSP             [512, 256, 1, False]          
 14                -1  1     33024  models.common.Conv                      [256, 128, 1, 1]              
 15                -1  1         0  torch.nn.modules.upsampling.Upsample    [None, 2, 'nearest']          
 16           [-1, 4]  1         0  models.common.Concat                    [1]                           
 17                -1  1     95104  models.common.BottleneckCSP             [256, 128, 1, False]          
 18                -1  1    147712  models.common.Conv                      [128, 128, 3, 2]              
 19          [-1, 14]  1         0  models.common.Concat                    [1]                           
 20                -1  1    313088  models.common.BottleneckCSP             [256, 256, 1, False]          
 21                -1  1    590336  models.common.Conv                      [256, 256, 3, 2]              
 22          [-1, 10]  1         0  models.common.Concat                    [1]                           
 23                -1  1   1248768  models.common.BottleneckCSP             [512, 512, 1, False]          
 24      [17, 20, 23]  1    229245  models.yolo.Detect                      [80, [[10, 13, 16, 30, 33, 23], [30, 61, 62, 45, 59, 119], [116, 90, 156, 198, 373, 326]], [128, 256, 512]]
Model Summary: 191 layers, 7.46816e+06 parameters, 7.46816e+06 gradients

Optimizer groups: 62 .bias, 70 conv.weight, 59 other
Optimizer groups: 62 .bias, 70 conv.weight, 59 other
Transferred 368/370 items from yolov5s.pt
Transferred 368/370 items from yolov5s.pt
Scanning labels ../coco128/labels/train2017.cache (126 found, 0 missing, 2 empty
Scanning labels ../coco128/labels/train2017.cache (126 found, 0 missing, 2 empty
Scanning labels ../coco128/labels/train2017.cache (126 found, 0 missing, 2 empty

Analyzing anchors... Best Possible Recall (BPR) = 0.9591. Attempting to generate improved anchors, please wait...
WARNING: Extremely small objects found. 35 of 929 labels are < 3 pixels in width or height.
Running kmeans for 9 anchors on 927 points...
thr=0.25: 0.9731 best possible recall, 3.74 anchors past thr
n=9, img_size=320, metric_all=0.261/0.654-mean/best, past_thr=0.471-mean: 9,12,  32,19,  27,47,  73,43,  53,91,  77,161,  161,107,  174,237,  299,195
Evolving anchors with Genetic Algorithm: fitness = 0.6627: 100%|█| 1000/1000 [00
thr=0.25: 0.9957 best possible recall, 3.79 anchors past thr
n=9, img_size=320, metric_all=0.262/0.662-mean/best, past_thr=0.473-mean: 7,8,  17,12,  24,31,  58,39,  50,86,  71,146,  148,116,  144,240,  293,213
New anchors saved to model. Update model *.yaml to use these anchors in the future.

Image sizes 320 train, 320 test
Using 8 dataloader workers
Starting training for 1 epochs...

     Epoch   gpu_mem      GIoU       obj       cls     total   targets  img_size
       0/0    0.721G   0.08034    0.1729   0.03942    0.2927        55       320
               Class      Images     Targets           P           R      mAP@.5
                 all         128         929       0.172        0.65        0.44        0.24
Optimizer stripped from runs/exp1/weights/last.pt, 15.1MB
1 epochs completed in 0.011 hours.

```

</details>

<details>
<summary>New output</summary>

```
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
*****************************************

Using CUDA Apex device0 _CudaDeviceProperties(name='Tesla V100-SXM2-32GB', total_memory=32480MB)
                device1 _CudaDeviceProperties(name='Tesla V100-SXM2-32GB', total_memory=32480MB)

Namespace(batch_size=8, bucket='', cache_images=False, cfg='./models/yolov5s.yaml', data='data/coco128.yaml', device='0,1', epochs=1, evolve=False, hyp='', img_size=[320, 320], local_rank=0, multi_scale=False, name='', noautoanchor=False, nosave=False, notest=False, rect=False, resume=False, single_cls=False, sync_bn=False, total_batch_size=16, weights='yolov5s.pt', world_size=2)
Start Tensorboard with "tensorboard --logdir=runs", view at http://localhost:6006/

Hyperparameter {'optimizer': 'SGD', 'lr0': 0.01, 'momentum': 0.937, 'weight_decay': 0.0005, 'giou': 0.05, 'cls': 0.5, 'cls_pw': 1.0, 'obj': 1.0, 'obj_pw': 1.0, 'iou_t': 0.2, 'anchor_t': 4.0, 'fl_gamma': 0.0, 'hsv_h': 0.015, 'hsv_s': 0.7, 'hsv_v': 0.4, 'degrees': 0.0, 'translate': 0.0, 'scale': 0.5, 'shear': 0.0}

                 from  n    params  module                                  arguments                     
  0                -1  1      3520  models.common.Focus                     [3, 32, 3]                    
  1                -1  1     18560  models.common.Conv                      [32, 64, 3, 2]                
  2                -1  1     19904  models.common.BottleneckCSP             [64, 64, 1]                   
  3                -1  1     73984  models.common.Conv                      [64, 128, 3, 2]               
  4                -1  1    161152  models.common.BottleneckCSP             [128, 128, 3]                 
  5                -1  1    295424  models.common.Conv                      [128, 256, 3, 2]              
  6                -1  1    641792  models.common.BottleneckCSP             [256, 256, 3]                 
  7                -1  1   1180672  models.common.Conv                      [256, 512, 3, 2]              
  8                -1  1    656896  models.common.SPP                       [512, 512, [5, 9, 13]]        
  9                -1  1   1248768  models.common.BottleneckCSP             [512, 512, 1, False]          
 10                -1  1    131584  models.common.Conv                      [512, 256, 1, 1]              
 11                -1  1         0  torch.nn.modules.upsampling.Upsample    [None, 2, 'nearest']          
 12           [-1, 6]  1         0  models.common.Concat                    [1]                           
 13                -1  1    378624  models.common.BottleneckCSP             [512, 256, 1, False]          
 14                -1  1     33024  models.common.Conv                      [256, 128, 1, 1]              
 15                -1  1         0  torch.nn.modules.upsampling.Upsample    [None, 2, 'nearest']          
 16           [-1, 4]  1         0  models.common.Concat                    [1]                           
 17                -1  1     95104  models.common.BottleneckCSP             [256, 128, 1, False]          
 18                -1  1    147712  models.common.Conv                      [128, 128, 3, 2]              
 19          [-1, 14]  1         0  models.common.Concat                    [1]                           
 20                -1  1    313088  models.common.BottleneckCSP             [256, 256, 1, False]          
 21                -1  1    590336  models.common.Conv                      [256, 256, 3, 2]              
 22          [-1, 10]  1         0  models.common.Concat                    [1]                           
 23                -1  1   1248768  models.common.BottleneckCSP             [512, 512, 1, False]          
 24      [17, 20, 23]  1    229245  models.yolo.Detect                      [80, [[10, 13, 16, 30, 33, 23], [30, 61, 62, 45, 59, 119], [116, 90, 156, 198, 373, 326]], [128, 256, 512]]
Model Summary: 191 layers, 7.46816e+06 parameters, 7.46816e+06 gradients

Optimizer groups: 62 .bias, 70 conv.weight, 59 other
Transferred 368/370 items from yolov5s.pt
Scanning labels ../coco128/labels/train2017.cache (126 found, 0 missing, 2 empty
Scanning labels ../coco128/labels/train2017.cache (126 found, 0 missing, 2 empty
Scanning labels ../coco128/labels/train2017.cache (126 found, 0 missing, 2 empty

Analyzing anchors... Best Possible Recall (BPR) = 0.9591. Attempting to generate improved anchors, please wait...
WARNING: Extremely small objects found. 35 of 929 labels are < 3 pixels in width or height.
Running kmeans for 9 anchors on 927 points...
thr=0.25: 0.9731 best possible recall, 3.74 anchors past thr
n=9, img_size=320, metric_all=0.261/0.654-mean/best, past_thr=0.471-mean: 9,12,  32,19,  27,47,  73,43,  53,91,  77,161,  161,107,  174,237,  299,195
Evolving anchors with Genetic Algorithm: fitness = 0.6627: 100%|█| 1000/1000 [00
thr=0.25: 0.9957 best possible recall, 3.79 anchors past thr
n=9, img_size=320, metric_all=0.262/0.662-mean/best, past_thr=0.473-mean: 7,8,  17,12,  24,31,  58,39,  50,86,  71,146,  148,116,  144,240,  293,213
New anchors saved to model. Update model *.yaml to use these anchors in the future.

Image sizes 320 train, 320 test
Using 8 dataloader workers
Starting training for 1 epochs...

     Epoch   gpu_mem      GIoU       obj       cls     total   targets  img_size
       0/0    0.721G   0.08035    0.1729   0.03942    0.2926        55       320
               Class      Images     Targets           P           R      mAP@.5
                 all         128         929       0.173       0.649       0.441       0.241
Optimizer stripped from runs/exp15/weights/last.pt, 15.1MB
1 epochs completed in 0.010 hours.
```

</details>

The `Old Output` looks somewhat clean still because it is only outputting from 2 devices. 4 or 8 creates a mess.

I'm not sure whether I should set to use `logging` for everywhere for consistency, or only in the places that are affected by multi-gpu training.

- [x] Decide whether to change to `logging` everywhere or not. (Decision: Only multi-gpu areas)

- [x] Wait for `test`/`detect` refactor for multi-gpu

- [x] Wait for merge multi-node ddp support

- [x] Fix logging for multi-node

Edit: There is a "Scanning labels.." which repeats but it's part of tqdm, and not print. Not sure how to handle it right now.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging information for better tracking of model training processes.

### 📊 Key Changes
- Added `logging` module imports to various files.
- Replaced `print` statements with `logger.info` to standardize logging.
- Added `set_logging` function to configure logging based on rank (necessary for distributed training setups).
- Modified function signatures to use a shared `rank` variable for consistency.
- Introduced logic to centralize the setting of DDP (Distributed Data Parallel) variables at the start of `train.py`.
- Updated `create_dataloader` methods across `train.py` and `datasets.py` to ensure correct data processing in distributed environments.

### 🎯 Purpose & Impact
- **Purpose:** The updates ensure that information during model training and dataset processing is logged efficiently. They streamline logging for better readability and management, especially when training models in distributed systems.
- **Impact:** Users will benefit from clearer and more consistent logs, which are especially valuable for debugging and tracking the training of machine learning models at scale. The changes also promote clean coding practices and the efficient operation of distributed training sessions. 🧑‍💻🔍🌐