### PR TITLE
Add Multi-Node support for DDP Training

### DIFF
--- a/train.py
+++ b/train.py
@@ -51,8 +51,8 @@ def train(hyp, tb_writer, opt, device):
     last = wdir + 'last.pt'
     best = wdir + 'best.pt'
     results_file = log_dir + os.sep + 'results.txt'
-    epochs, batch_size, total_batch_size, weights, local_rank, rank = opt.epochs, \
-            opt.batch_size, opt.total_batch_size, opt.weights, opt.local_rank, opt.global_rank
+    epochs, batch_size, total_batch_size, weights, rank = \
+            opt.epochs, opt.batch_size, opt.total_batch_size, opt.weights, opt.global_rank
     # TODO: Init DDP logging. Only the first process is allowed to log.
     # Since I see lots of print here, the logging configuration is skipped here. We may see repeated outputs.
 
@@ -178,7 +178,7 @@ def train(hyp, tb_writer, opt, device):
 
     # DDP mode
     if device.type != 'cpu' and rank != -1:
-        model = DDP(model, device_ids=[local_rank], output_device=(local_rank))
+        model = DDP(model, device_ids=[opt.local_rank], output_device=(opt.local_rank))
 
     # Trainloader
     dataloader, dataset = create_dataloader(train_path, imgsz, batch_size, gs, opt, hyp=hyp, augment=True,

--- a/train.py
+++ b/train.py
@@ -65,7 +65,6 @@ def train(hyp, opt, device, tb_writer=None):
         opt.epochs, opt.batch_size, opt.total_batch_size, opt.weights, opt.global_rank
     
     # TODO: Use DDP logging. Only the first process is allowed to log.
-    
     # Save run settings
     with open(Path(log_dir) / 'hyp.yaml', 'w') as f:
         yaml.dump(hyp, f, sort_keys=False)
@@ -455,6 +454,7 @@ if __name__ == '__main__':
     opt.total_batch_size = opt.batch_size
     opt.world_size = 1
     opt.global_rank = -1
+    
     # DDP mode
     if opt.local_rank != -1:
         assert torch.cuda.device_count() > opt.local_rank


### PR DESCRIPTION
Fix #501 .

- [x] Unit test (CPU, Single GPU, DP mode, 2 GPU DDP mode)

- [x] Single machine, two terminal

- [x] Multiple machines, one terminal each 

It works on my single machine from two different terminals.

Command:
```bash
# node 1
$ python -m torch.distributed.launch --nproc_per_node=2 --nnodes=2 --node_rank=0 --master_addr="192.168.1.1" --master_port=1234 train.py --weights yolov5s.pt --cfg yolov5s.yaml --epochs 1 --img 320 --device 0,1
```
```bash
# node 2
$ python -m torch.distributed.launch --nproc_per_node=2 --nnodes=2 --node_rank=1 --master_addr="192.168.1.1" --master_port=1234 train.py --weights yolov5s.pt --cfg yolov5s.yaml --epochs 1 --img 320 --device 2,3
```

Please set the ip and port to somewhere that is not blocked if you are running from two machines.
If you are running from one machine, you can omit the `master_addr` and `port`.

Would it be necessary to run it on COCO2017 to see the training time decrease?

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Distributed Data Parallel (DDP) support with rank handling in training code.

### 📊 Key Changes
- Changed `opt.local_rank` to `opt.global_rank` to better represent the variable's intent.
- Updated DDP model device assignment to use `opt.local_rank` instead of `rank`.
- Modified rank verification for git status checking and Tensorboard initialization to accommodate a broader range of environments.
- Initialized `opt.global_rank` with a default value and updated it within the DDP setup.

### 🎯 Purpose & Impact
- Ensures more understandable and maintainable code by using `global_rank`, which reflects its usage more accurately than `local_rank`.
- The changes improve support for various distributed training setups, potentially offering a smoother experience for users training models on multiple GPUs.
- May lead to fewer errors and easier debugging when users configure distributed training environments.