### PR TITLE
Fix bug #541 #542

### DIFF
--- a/train.py
+++ b/train.py
@@ -377,7 +377,7 @@ def train(hyp, tb_writer, opt, device):
 
                 # Save last, best and delete
                 torch.save(ckpt, last)
-                if (best_fitness == fi) and not final_epoch:
+                if (best_fitness == fi): 
                     torch.save(ckpt, best)
                 del ckpt
         # end epoch ----------------------------------------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -377,7 +377,7 @@ def train(hyp, tb_writer, opt, device):
 
                 # Save last, best and delete
                 torch.save(ckpt, last)
-                if (best_fitness == fi): 
+                if best_fitness == fi: 
                     torch.save(ckpt, best)
                 del ckpt
         # end epoch ----------------------------------------------------------------------------------------------------

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -346,8 +346,8 @@ def bbox_iou(box1, box2, x1y1x2y2=True, GIoU=False, DIoU=False, CIoU=False):
             elif CIoU:  # https://github.com/Zzh-tju/DIoU-SSD-pytorch/blob/master/utils/box/box_utils.py#L47
                 v = (4 / math.pi ** 2) * torch.pow(torch.atan(w2 / h2) - torch.atan(w1 / h1), 2)
                 with torch.no_grad():
-                    alpha = v / (1 - iou + v)
-                return iou - (rho2 / c2 + v * alpha)  # CIoU
+                    alpha = v / (1 - iou + v + 1e-16)
+                return iou - (rho2 / c2 + v * alpha )  # CIoU
 
     return iou
 


### PR DESCRIPTION
Fix bugs  #541 and #542 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement in model checkpointing logic and numerical stability in CIoU calculation.

### 📊 Key Changes
- Modified checkpointing logic to always save the 'best' model irrespective of the final epoch.
- Adjusted the CIoU calculation to prevent potential division by zero by adding a small value (1e-16).

### 🎯 Purpose & Impact
- **Model Checkpointing:** By always saving the model with the best fitness score, users can be sure they have the highest performing model saved, regardless of when the training ends.
- **CIoU Stability:** The small constant added in the CIoU calculation ensures numerical stability, preventing errors during training that can occur due to dividing by zero.

🔍 This will lead to more reliable and robust training of YOLOv5 models, enhancing user experience by ensuring that the best model is retained and improving the robustness of bounding box calculations.