### PR TITLE
Fix utils.py nonzero() warning

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -599,7 +599,7 @@ def non_max_suppression(prediction, conf_thres=0.1, iou_thres=0.6, merge=False, 
 
         # Detections matrix nx6 (xyxy, conf, cls)
         if multi_label:
-            i, j = (x[:, 5:] > conf_thres).nonzero().t()
+            i, j = (x[:, 5:] > conf_thres).nonzero(as_tuple=False).t()
             x = torch.cat((box[i], x[i, j + 5, None], j[:, None].float()), 1)
         else:  # best class only
             conf, j = x[:, 5:].max(1, keepdim=True)


### PR DESCRIPTION
Simple update of nonzero() torch function to avoid warning message while running train.py.
This fix is similar to https://github.com/ultralytics/yolov5/commit/43a616a9551cd53f031c05688884927ba0c13513 at test.py lines 151 and 152.

Warning message that appears for me:
~/yolov5/utils/utils.py:601: UserWarning: This overload of nonzero is deprecated:
	nonzero()
Consider using one of the following signatures instead:
	nonzero(*, bool as_tuple) (Triggered internally at  /pytorch/torch/csrc/utils/python_arg_parser.cpp:766.)
  i, j = (x[:, 5:] > conf_thres).nonzero().t()

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced compatibility in non-max suppression algorithm.

### 📊 Key Changes
- Modified `non_max_suppression` function to fix the tuple unpacking error with `nonzero`.

### 🎯 Purpose & Impact
- 🛠 Ensures that the non-max suppression function, which is critical for detecting objects in images, works reliably across different versions of PyTorch by addressing a compatibility issue with the `nonzero` method. 
- 💻 Users can expect more robust performance and fewer bugs when running object detection tasks with different PyTorch versions.