### PR TITLE
Add section on downloading weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Python 3.8 or later with all [requirements.txt](https://github.com/ultralytics/y
 $ pip install -r requirements.txt
 ```
 
+## Download Weights
+
+To download weights, run the following command from the `yolov5` directory:
+```bash
+$ ./weights/download_weights.sh
+```
+
 
 ## Tutorials
 


### PR DESCRIPTION
I thought it would be a good idea to add this in.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added instructions for downloading model weights to README.

### 📊 Key Changes
- Included a new section in the README.md titled "Download Weights."
- Provided a command to download YOLOv5 weights using a shell script.

### 🎯 Purpose & Impact
- **Simplifies the setup process**: Users now have clear, concise directions for obtaining necessary model weights.
- **Enhances user experience**: New users are given straightforward guidance, fostering a smoother onboarding experience. 
- **Potential to increase adoption**: Making it easier to set up the model could lead to more developers choosing YOLOv5 for their projects.