### PR TITLE
Fix curl download on Windows

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8]
-        model: ['yolov5s', 'yolov5m', 'yolov5l', 'yolov5x']  # models to test
+        model: ['yolov5s']  # models to test
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     timeout-minutes: 50

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8]
-        model: ['yolov5s']  # models to test
+        model: ['yolov5s', 'yolov5m', 'yolov5l', 'yolov5x']  # models to test
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     timeout-minutes: 50

--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -3,6 +3,7 @@
 # from google.cloud import storage
 
 import os
+import platform
 import time
 from pathlib import Path
 
@@ -27,7 +28,7 @@ def attempt_download(weights):
 
         if not (r == 0 and os.path.exists(weights) and os.path.getsize(weights) > 1E6):  # weights exist and > 1MB
             os.remove(weights) if os.path.exists(weights) else None  # remove partial downloads
-            s = "curl -L -o %s 'storage.googleapis.com/ultralytics/yolov5/ckpt/%s'" % (weights, file)
+            s = 'curl -L -o %s "storage.googleapis.com/ultralytics/yolov5/ckpt/%s"' % (weights, file)
             r = os.system(s)  # execute, capture return values
 
             # Error check
@@ -46,7 +47,9 @@ def gdrive_download(id='1n_oKgR81BJtqk75b00eAjdv03qVCQn2f', name='coco128.zip'):
     os.remove('cookie') if os.path.exists('cookie') else None
 
     # Attempt file download
-    os.system("curl -c ./cookie -s -L \"drive.google.com/uc?export=download&id=%s\" > /dev/null" % id)
+    out = "NUL" if (platform.system() == "Windows") else "/dev/null"
+    
+    os.system("curl -c ./cookie -s -L \"drive.google.com/uc?export=download&id=%s\" > %s " % (id, out))
     if os.path.exists('cookie'):  # large file
         s = "curl -Lb ./cookie \"drive.google.com/uc?export=download&confirm=`awk '/download/ {print $NF}' ./cookie`&id=%s\" -o %s" % (
             id, name)

--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -36,12 +36,6 @@ def attempt_download(weights):
                 os.remove(weights) if os.path.exists(weights) else None  # remove partial downloads
                 raise Exception(msg)
 
-def getToken(cookie="./cookie"):
-    with open(cookie) as f:
-        for line in f:
-            if ("download" in line):
-                return line.split()[-1]
-    return ""
 
 def gdrive_download(id='1n_oKgR81BJtqk75b00eAjdv03qVCQn2f', name='coco128.zip'):
     # Downloads a file from Google Drive, accepting presented query
@@ -58,7 +52,7 @@ def gdrive_download(id='1n_oKgR81BJtqk75b00eAjdv03qVCQn2f', name='coco128.zip'):
     os.system('curl -c ./cookie -s -L "drive.google.com/uc?export=download&id=%s" > %s ' % (id, out))
     if os.path.exists('cookie'):  # large file
         s = 'curl -Lb ./cookie "drive.google.com/uc?export=download&confirm=%s&id=%s" -o %s' % (
-            getToken(), id, name)
+            get_token(), id, name)
     else:  # small file
         s = 'curl -s -L -o %s "drive.google.com/uc?export=download&id=%s"' % (name, id)
     r = os.system(s)  # execute, capture return values
@@ -78,6 +72,14 @@ def gdrive_download(id='1n_oKgR81BJtqk75b00eAjdv03qVCQn2f', name='coco128.zip'):
 
     print('Done (%.1fs)' % (time.time() - t))
     return r
+
+
+def get_token(cookie="./cookie"):
+    with open(cookie) as f:
+        for line in f:
+            if "download" in line:
+                return line.split()[-1]
+    return ""
 
 
 # def upload_blob(bucket_name, source_file_name, destination_blob_name):

--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -36,6 +36,12 @@ def attempt_download(weights):
                 os.remove(weights) if os.path.exists(weights) else None  # remove partial downloads
                 raise Exception(msg)
 
+def getToken(cookie="./cookie"):
+    with open(cookie) as f:
+        for line in f:
+            if ("download" in line):
+                return line.split()[-1]
+    return ""
 
 def gdrive_download(id='1n_oKgR81BJtqk75b00eAjdv03qVCQn2f', name='coco128.zip'):
     # Downloads a file from Google Drive, accepting presented query
@@ -49,10 +55,10 @@ def gdrive_download(id='1n_oKgR81BJtqk75b00eAjdv03qVCQn2f', name='coco128.zip'):
     # Attempt file download
     out = "NUL" if (platform.system() == "Windows") else "/dev/null"
     
-    os.system("curl -c ./cookie -s -L \"drive.google.com/uc?export=download&id=%s\" > %s " % (id, out))
+    os.system('curl -c ./cookie -s -L "drive.google.com/uc?export=download&id=%s" > %s ' % (id, out))
     if os.path.exists('cookie'):  # large file
-        s = "curl -Lb ./cookie \"drive.google.com/uc?export=download&confirm=`awk '/download/ {print $NF}' ./cookie`&id=%s\" -o %s" % (
-            id, name)
+        s = 'curl -Lb ./cookie "drive.google.com/uc?export=download&confirm=%s&id=%s" -o %s' % (
+            getToken(), id, name)
     else:  # small file
         s = 'curl -s -L -o %s "drive.google.com/uc?export=download&id=%s"' % (name, id)
     r = os.system(s)  # execute, capture return values

--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -47,8 +47,7 @@ def gdrive_download(id='1n_oKgR81BJtqk75b00eAjdv03qVCQn2f', name='coco128.zip'):
     os.remove('cookie') if os.path.exists('cookie') else None
 
     # Attempt file download
-    out = "NUL" if (platform.system() == "Windows") else "/dev/null"
-    
+    out = "NUL" if platform.system() == "Windows" else "/dev/null"
     os.system('curl -c ./cookie -s -L "drive.google.com/uc?export=download&id=%s" > %s ' % (id, out))
     if os.path.exists('cookie'):  # large file
         s = 'curl -Lb ./cookie "drive.google.com/uc?export=download&confirm=%s&id=%s" -o %s' % (


### PR DESCRIPTION
This addresses Issue #654 .

This fixes curl download to both google storage apis and google drive on Windows (outside on mainland China).

CI result: https://github.com/NanoCode012/yolov5/runs/957308936 
It fully succeeded once. I'm not sure why it is running again.

I removed the "test" commit with ci-testing.yml . If you need it, feel free to add it back as well as other changes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved cross-platform file download handling in Ultralytics YOLOv5 utilities.

### 📊 Key Changes
- 🖥️ Added `platform` module import for detecting the operating system.
- 💾 Modified `curl` commands for better compatibility and error handling.
- 🛠️ Introduced a new function `get_token()` to extract download tokens for large file handling.
- ✅ Adjusted file download output to support Windows (`"NUL"`) and Unix (`"/dev/null"`) systems.

### 🎯 Purpose & Impact
- 🚀 Enhance platform compatibility ensuring download scripts work smoothly on different operating systems.
- 🐛 Reduce potential download issues by handling large file downloads more reliably.
- 🔧 Streamline error checking by centralizing token extraction in one function, potentially making maintenance and updates easier.
- 👥 Users should experience more consistent behavior and less download-related errors, regardless of their operating system.