### PR TITLE
Fix unrecognized local rank argument

### DIFF
--- a/train.py
+++ b/train.py
@@ -433,7 +433,7 @@ if __name__ == '__main__':
     parser.add_argument('--single-cls', action='store_true', help='train as single-class dataset')
     parser.add_argument('--adam', action='store_true', help='use torch.optim.Adam() optimizer')
     parser.add_argument('--sync-bn', action='store_true', help='use SyncBatchNorm, only available in DDP mode')
-    parser.add_argument('--local-rank', type=int, default=-1, help='DDP parameter, do not modify')
+    parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
     parser.add_argument('--logdir', type=str, default='runs/', help='logging directory')
     opt = parser.parse_args()
 


### PR DESCRIPTION
Due to one small mistake in 93684531c6e71547667ee19df6ddb94af3c8c80d , we get unrecognized local_rank error.

https://github.com/ultralytics/yolov5/blob/3fcd365ba38613dee17995e9baf2fa5117727d4b/train.py#L436

DDP does **not** work now! Reason is because `torch.distributed.launch` supplies `local_rank` argument. When you changed it, it broke functionality.

Command to replicate now:
```bash
python -m torch.distributed.launch --master_port 9990 --nproc_per_node 2 train.py --weights $x.pt --cfg models/$x.yaml --epochs 3 --img 320 --device 0,1 # DDP train
```

Error
```
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
*****************************************
usage: train.py [-h] [--cfg CFG] [--data DATA] [--hyp HYP] [--epochs EPOCHS]
                [--batch-size BATCH_SIZE] [--img-size IMG_SIZE [IMG_SIZE ...]]
                [--rect] [--resume [RESUME]] [--nosave] [--notest]
                [--noautoanchor] [--evolve] [--bucket BUCKET] [--cache-images]
                [--weights WEIGHTS] [--name NAME] [--device DEVICE]
                [--multi-scale] [--single-cls] [--adam] [--sync-bn]
                [--local-rank LOCAL_RANK] [--logdir LOGDIR]
train.py: error: unrecognized arguments: --local_rank=1
usage: train.py [-h] [--cfg CFG] [--data DATA] [--hyp HYP] [--epochs EPOCHS]
                [--batch-size BATCH_SIZE] [--img-size IMG_SIZE [IMG_SIZE ...]]
                [--rect] [--resume [RESUME]] [--nosave] [--notest]
                [--noautoanchor] [--evolve] [--bucket BUCKET] [--cache-images]
                [--weights WEIGHTS] [--name NAME] [--device DEVICE]
                [--multi-scale] [--single-cls] [--adam] [--sync-bn]
                [--local-rank LOCAL_RANK] [--logdir LOGDIR]
train.py: error: unrecognized arguments: --local_rank=0
```

Also, for logging PR, will take a bit longer.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved command-line argument consistency in YOLOv5 training script.

### 📊 Key Changes
- Changed the `--local-rank` command-line argument from `--local-rank` to `--local_rank` in `train.py`.

### 🎯 Purpose & Impact
- 🎨 Unifies argument naming conventions, enhancing consistency across the codebase.
- 🔧 May impact any scripts, tools, or user practices that expect the old argument name.
- ✔️ Minor change overall, but helpful for new users to encounter predictable patterns when using command-line arguments.