### PR TITLE
added arg parser for freezing parameters

### DIFF
--- a/train.py
+++ b/train.py
@@ -79,7 +79,7 @@ def train(hyp, opt, device, tb_writer=None):
         [freeze.append(x)for x in opt.freeze.split()]
     else:
         freeze = ['', ]
-    freeze = ['', ]  # parameter names to freeze (full or partial)
+     # parameter names to freeze (full or partial)
     if any(freeze):
         for k, v in model.named_parameters():
             if any(x in k for x in freeze):

--- a/train.py
+++ b/train.py
@@ -72,8 +72,13 @@ def train(hyp, opt, device, tb_writer=None):
         print('Transferred %g/%g items from %s' % (len(state_dict), len(model.state_dict()), weights))  # report
     else:
         model = Model(opt.cfg, ch=3, nc=nc).to(device)  # create
-
+    
     # Freeze
+    if opt.freeze !='':
+        freeze=[]
+        [freeze.append(x)for x in opt.freeze.split()]
+    else:
+        freeze = ['', ]
     freeze = ['', ]  # parameter names to freeze (full or partial)
     if any(freeze):
         for k, v in model.named_parameters():
@@ -402,6 +407,7 @@ if __name__ == '__main__':
     parser.add_argument('--sync-bn', action='store_true', help='use SyncBatchNorm, only available in DDP mode')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
     parser.add_argument('--logdir', type=str, default='runs/', help='logging directory')
+    parser.add_argument('--freeze', type=str, default='', help='freezing gradients')
     opt = parser.parse_args()
 
     # Resume


### PR DESCRIPTION
With reference to Fixes #679, adding a additional parameter as a string for argparser '--freeze'.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved layer freezing flexibility in the YOLOv5 training script.

### 📊 Key Changes
- Introduced an option to specify layer names to freeze during training via the new `--freeze` command line argument.
- Adjusted the model creation code to handle the specified layers to freeze, enhancing control over model training.

### 🎯 Purpose & Impact
- 🎨 Provides users with more control over the training process, allowing them to easily specify which layers of the model should not be updated during backpropagation.
- 🏃‍♂️ Can speed up training and potentially improve model performance by keeping certain pre-trained layers fixed, focusing training on other layers that may need more fine-tuning.
- 💾 May help in transfer learning scenarios where parts of the model are already well-optimized for the given task.