### PR TITLE
Update utils/google_utils.py

### DIFF
--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -28,7 +28,7 @@ def attempt_download(weights):
         #    return
 
         try:  # GitHub
-            url = 'https://github.com/ultralytics/yolov5/releases/download/v2.0/' + file
+            url = 'https://github.com/ultralytics/yolov5/releases/download/v3.0/' + file
             print('Downloading %s to %s...' % (url, weights))
             if platform.system() == 'Darwin':  # avoid MacOS python requests certificate error
                 r = os.system('curl -L %s -o %s' % (url, weights))


### PR DESCRIPTION
To download weights from v3.0 instead of v2.0

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update model download URL to use the latest release.

### 📊 Key Changes
- Changed the base URL for downloading model weights from `v2.0` to `v3.0`.

### 🎯 Purpose & Impact
- Ensures users download the most recent and improved model weights.
- This may lead to better performance and features from the newer models, providing a better experience for developers and end-users alike. 🚀