### PR TITLE
single command --resume

### DIFF
--- a/train.py
+++ b/train.py
@@ -419,8 +419,7 @@ if __name__ == '__main__':
         ckpt = opt.resume if isinstance(opt.resume, str) else get_latest_run()  # specified or most recent path
         assert os.path.isfile(ckpt), 'ERROR: --resume checkpoint does not exist'
         with open(Path(ckpt).parent.parent / 'opt.yaml') as f:
-            for k, v in yaml.load(f, Loader=yaml.FullLoader).items():  # load opt
-                setattr(opt, k, v)
+            opt = argparse.Namespace(**yaml.load(f, Loader=yaml.FullLoader))  # replace
         opt.cfg, opt.weights = '', ckpt
         logger.info('Resuming training from %s' % ckpt)
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -61,7 +61,7 @@ def init_seeds(seed=0):
 def get_latest_run(search_dir='./runs'):
     # Return path to most recent 'last.pt' in /runs (i.e. to --resume from)
     last_list = glob.glob(f'{search_dir}/**/last*.pt', recursive=True)
-    return max(last_list, key=os.path.getctime)
+    return max(last_list, key=os.path.getctime) if last_list else ''
 
 
 def check_git_status():


### PR DESCRIPTION
Allows single argument resume. Loads prior training opt.yaml, overriding any differences on --resume.

```bash
python train.py --resume  # resume from most recent run
python train.py --resume runs/exp5/weights/last.pt  # resume from specified checkpoint
```

Tested in Colab notebook on coco128:
<img width="1464" alt="Screen Shot 2020-08-16 at 11 42 25 PM" src="https://user-images.githubusercontent.com/26833433/90365212-5353e500-e01a-11ea-9f39-9fa3733bb15a.png">



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced resume capabilities and consolidated training configuration in YOLOv5.

### 📊 Key Changes
- Removed outdated TODO comment about using DDP logging.
- Added an assertion to check if the model is already fully trained when attempting to resume training.
- Streamlined the creation of dataloaders by reducing redundancy in the `create_dataloader` call.
- Introduced an update for the Exponential Moving Average (EMA) based on the start epoch.
- Improved clarity in the training loop by simplifying `if ema is not None` to `if ema`.
- Added learning rate logging for TensorBoard visualizations.
- Refined the '--resume' argument handling in training script to allow for a smoother resumption process.
- Assured necessary YOLOv5 files exist and provided options for hyperparameter and configuration files based on whether weights are preloaded.

### 🎯 Purpose & Impact
- Ensuring users cannot resume training sessions when the model has already completed the set epochs prevents time and resource wastage. 🛑
- Clearer code and unified parameter usage improve readability and maintenance. 💡
- Updates to EMA initialization and TensorBoard logging offer better insight into model performance over time. 📈
- The altered resume logic provides a more robust and straightforward mechanism for restarting interrupted training sessions, reducing user friction. ⏯️
- The changes enforce a check to make sure the necessary configuration is in place before training starts, making model setup more fail-proof. ⚙️