### PR TITLE
Fix ema attribute error in DDP mode

### DIFF
--- a/train.py
+++ b/train.py
@@ -164,7 +164,8 @@ def train(hyp, opt, device, tb_writer=None):
                                             world_size=opt.world_size, workers=opt.workers)
     mlc = np.concatenate(dataset.labels, 0)[:, 0].max()  # max label class
     nb = len(dataloader)  # number of batches
-    ema.updates = start_epoch * nb // accumulate  # set EMA updates
+    if rank in [-1, 0]:
+        ema.updates = start_epoch * nb // accumulate  # set EMA updates
     assert mlc < nc, 'Label class %g exceeds nc=%g in %s. Possible class labels are 0-%g' % (mlc, nc, opt.data, nc - 1)
 
     # Testloader

--- a/train.py
+++ b/train.py
@@ -164,12 +164,11 @@ def train(hyp, opt, device, tb_writer=None):
                                             world_size=opt.world_size, workers=opt.workers)
     mlc = np.concatenate(dataset.labels, 0)[:, 0].max()  # max label class
     nb = len(dataloader)  # number of batches
-    if rank in [-1, 0]:
-        ema.updates = start_epoch * nb // accumulate  # set EMA updates
     assert mlc < nc, 'Label class %g exceeds nc=%g in %s. Possible class labels are 0-%g' % (mlc, nc, opt.data, nc - 1)
 
     # Testloader
     if rank in [-1, 0]:
+        ema.updates = start_epoch * nb // accumulate  # set EMA updates
         testloader = create_dataloader(test_path, imgsz_test, total_batch_size, gs, opt,
                                        hyp=hyp, augment=False, cache=opt.cache_images, rect=True, rank=-1,
                                        world_size=opt.world_size, workers=opt.workers)[0]  # only runs on process 0


### PR DESCRIPTION
Fix ema error on non-master GPU. https://github.com/ultralytics/yolov5/pull/756#discussion_r471984048

```
Optimizer groups: 62 .bias, 70 conv.weight, 59 other
Scanning labels ../coco128/labels/train2017.cache (126 found, 0 missing, 2 empty, 0 duplicate, for 128 images): 128it [00:00, 16005.45it/s]
0it [00:00, ?it/s]Traceback (most recent call last):
  File "train.py", line 458, in <module>
    train(hyp, opt, device, tb_writer)
  File "train.py", line 167, in train
    ema.updates = start_epoch * nb // accumulate  # set EMA updates
AttributeError: 'NoneType' object has no attribute 'updates'
Scanning labels ../coco128/labels/train2017.cache (126 found, 0 missing, 2 empty, 0 duplicate, for 128 images): 128it [00:00, 16270.29it/s]
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of EMA (Exponential Moving Average) Update Initialization in YOLOv5 Training.

### 📊 Key Changes
- Moved the initialization of `ema.updates` to a different location within `train.py`.

### 🎯 Purpose & Impact
- **Improvement in code logic:** The EMA updates count is now set when testing rather than at the start to potentially ensure the correct calculation of EMA only after all training batches have been set up.
- This can lead to a clearer, more accurate training process, especially during resumed training sessions or when adjusting training batch sizes.
- **Impact to Users:** Users might observe more consistent and reliable model performance metrics especially when training is stopped and resumed, or when varying the number of training batches.