### PR TITLE
Fixes voc download script

### DIFF
--- a/data/scripts/get_voc.sh
+++ b/data/scripts/get_voc.sh
@@ -163,48 +163,29 @@ f = open('../tmp/train.txt', 'r')
 lines = f.readlines()
 
 for line in lines:
-    #print(line.split('/')[-1][:-1])
-    line = "/".join(line.split('/')[2:])
-    #print(line)
-    if (os.path.exists("../" + line[:-1])):
-        os.system("cp ../"+ line[:-1] + " ../VOC/images/train")
+    line = "/".join(line.split('/')[-5:]).strip()
+    if (os.path.exists("../" + line)):
+        os.system("cp ../"+ line + " ../VOC/images/train")
         
-print(os.path.exists('../tmp/train.txt'))
-f = open('../tmp/train.txt', 'r')
-lines = f.readlines()
-
-for line in lines:
-    #print(line.split('/')[-1][:-1])
-    line = "/".join(line.split('/')[2:])
     line = line.replace('JPEGImages', 'labels')
     line = line.replace('jpg', 'txt')
-    #print(line)
-    if (os.path.exists("../" + line[:-1])):
-        os.system("cp ../"+ line[:-1] + " ../VOC/labels/train")
+    if (os.path.exists("../" + line)):
+        os.system("cp ../"+ line + " ../VOC/labels/train")
+
 
 print(os.path.exists('../tmp/2007_test.txt'))
 f = open('../tmp/2007_test.txt', 'r')
 lines = f.readlines()
 
 for line in lines:
-    #print(line.split('/')[-1][:-1])
-    line = "/".join(line.split('/')[2:])
-    
-    if (os.path.exists("../" + line[:-1])):
-        os.system("cp ../"+ line[:-1] + " ../VOC/images/val")
-
-print(os.path.exists('../tmp/2007_test.txt'))
-f = open('../tmp/2007_test.txt', 'r')
-lines = f.readlines()
-
-for line in lines:
-    #print(line.split('/')[-1][:-1])
-    line = "/".join(line.split('/')[2:])
+    line = "/".join(line.split('/')[-5:]).strip()
+    if (os.path.exists("../" + line)):
+        os.system("cp ../"+ line + " ../VOC/images/val")
+        
     line = line.replace('JPEGImages', 'labels')
     line = line.replace('jpg', 'txt')
-    #print(line)
-    if (os.path.exists("../" + line[:-1])):
-        os.system("cp ../"+ line[:-1] + " ../VOC/labels/val")
+    if (os.path.exists("../" + line)):
+        os.system("cp ../"+ line + " ../VOC/labels/val")
 
 END
 


### PR DESCRIPTION
### Problem

The script does not copy the files from the `tmp` folder to the `VOC` folder. It just downloads the files then deletes it back..


### Context

The script was hardcoded to expect directories in a certain way for them to copy files from the `tmp` folder to the `VOC` folder. I assume this was supposed to be used in docker where directory is `/usr/src/app` and remove the first two out. However, for other systems, they are most likely not located like so.

https://github.com/ultralytics/yolov5/blob/987c2268490a6220ac14a1325e76774c60ea4f47/data/scripts/get_voc.sh#L167

### Solution

`line = "/".join(line.split('/')[-5:]) ` 

Because looking at the train files, you'd want the last 5.

`/path/to/dir/tmp/VOCdevkit/VOC2007/JPEGImages/000012.jpg`

I also did a bit of cleaning up with the python portion.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlined the PASCAL VOC dataset setup script for efficiency and readability. 🚀

### 📊 Key Changes
- 💡 Simplified path handling by reducing the number of operations to join and trim paths.
- 🔗 Updated the script to correctly find and copy files based on the fixed path structure.
- 🧹 Removed repetitive code blocks and replaced them with succinct, clear code lines.

### 🎯 Purpose & Impact
- 🛠 The purpose of these changes is to make the script more robust and easier to maintain.
- 🚀 Impact includes improved performance due to more efficient file handling and increased readability for future developers working on this script.
- 👨‍💻 For the users of the script, this results in a smoother experience while setting up the VOC datasets for object detection tasks using YOLOv5.