### PR TITLE
Class frequency not calculated on resuming training

### DIFF
--- a/train.py
+++ b/train.py
@@ -186,7 +186,7 @@ def train(hyp, opt, device, tb_writer=None):
     model.names = names
 
     # Class frequency
-    if rank in [-1, 0]:
+    if not opt.resume and rank in [-1, 0]:
         labels = np.concatenate(dataset.labels, 0)
         c = torch.tensor(labels[:, 0])  # classes
         # cf = torch.bincount(c.long(), minlength=nc) + 1.
@@ -196,9 +196,9 @@ def train(hyp, opt, device, tb_writer=None):
             # tb_writer.add_hparams(hyp, {})  # causes duplicate https://github.com/ultralytics/yolov5/pull/384
             tb_writer.add_histogram('classes', c, 0)
 
-        # Check anchors
-        if not opt.noautoanchor:
-            check_anchors(dataset, model=model, thr=hyp['anchor_t'], imgsz=imgsz)
+    # Check anchors
+    if not opt.noautoanchor:
+        check_anchors(dataset, model=model, thr=hyp['anchor_t'], imgsz=imgsz)
 
     # Start training
     t0 = time.time()

--- a/train.py
+++ b/train.py
@@ -185,18 +185,18 @@ def train(hyp, opt, device, tb_writer=None):
     model.class_weights = labels_to_class_weights(dataset.labels, nc).to(device)  # attach class weights
     model.names = names
 
-    # Class frequency
-    if rank in [-1, 0]:
-        if not opt.resume:
-            labels = np.concatenate(dataset.labels, 0)
-            c = torch.tensor(labels[:, 0])  # classes
-            # cf = torch.bincount(c.long(), minlength=nc) + 1.
-            # model._initialize_biases(cf.to(device))
-            plot_labels(labels, save_dir=log_dir)
-            if tb_writer:
-                # tb_writer.add_hparams(hyp, {})  # causes duplicate https://github.com/ultralytics/yolov5/pull/384
-                tb_writer.add_histogram('classes', c, 0)
-        # Check anchors
+    # Classes and Anchors
+    if rank in [-1, 0] and not opt.resume:
+        labels = np.concatenate(dataset.labels, 0)
+        c = torch.tensor(labels[:, 0])  # classes
+        # cf = torch.bincount(c.long(), minlength=nc) + 1.  # frequency
+        # model._initialize_biases(cf.to(device))
+        plot_labels(labels, save_dir=log_dir)
+        if tb_writer:
+            # tb_writer.add_hparams(hyp, {})  # causes duplicate https://github.com/ultralytics/yolov5/pull/384
+            tb_writer.add_histogram('classes', c, 0)
+
+        # Anchors
         if not opt.noautoanchor:
             check_anchors(dataset, model=model, thr=hyp['anchor_t'], imgsz=imgsz)
 

--- a/train.py
+++ b/train.py
@@ -186,19 +186,19 @@ def train(hyp, opt, device, tb_writer=None):
     model.names = names
 
     # Class frequency
-    if not opt.resume and rank in [-1, 0]:
-        labels = np.concatenate(dataset.labels, 0)
-        c = torch.tensor(labels[:, 0])  # classes
-        # cf = torch.bincount(c.long(), minlength=nc) + 1.
-        # model._initialize_biases(cf.to(device))
-        plot_labels(labels, save_dir=log_dir)
-        if tb_writer:
-            # tb_writer.add_hparams(hyp, {})  # causes duplicate https://github.com/ultralytics/yolov5/pull/384
-            tb_writer.add_histogram('classes', c, 0)
-
-    # Check anchors
-    if not opt.noautoanchor:
-        check_anchors(dataset, model=model, thr=hyp['anchor_t'], imgsz=imgsz)
+    if rank in [-1, 0]:
+        if not opt.resume:
+            labels = np.concatenate(dataset.labels, 0)
+            c = torch.tensor(labels[:, 0])  # classes
+            # cf = torch.bincount(c.long(), minlength=nc) + 1.
+            # model._initialize_biases(cf.to(device))
+            plot_labels(labels, save_dir=log_dir)
+            if tb_writer:
+                # tb_writer.add_hparams(hyp, {})  # causes duplicate https://github.com/ultralytics/yolov5/pull/384
+                tb_writer.add_histogram('classes', c, 0)
+        # Check anchors
+        if not opt.noautoanchor:
+            check_anchors(dataset, model=model, thr=hyp['anchor_t'], imgsz=imgsz)
 
     # Start training
     t0 = time.time()


### PR DESCRIPTION
Calculation of class frequency is not needed when resuming training.
Anchors can still be recalculated whether resuming or not.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to model initialization and data logging in training routine.

### 📊 Key Changes
- Reorganized sections related to class weights, label plotting, and anchor checking.
- Condition for label and anchor processing now excludes `opt.resume` to prevent redundancy when resuming training.

### 🎯 Purpose & Impact
- 🚀 Enhances the starting conditions for model training by clearly separating class weights and anchor checks.
- 📈 Improves data logging accuracy by preventing duplicate entries in TensorBoard when resuming a training session.
- 🧠 Provides a cleaner setup process for users restarting training, ensuring that initializations only occur for fresh starts, leading to more efficient and error-free training sessions.