### PR TITLE
detect.py run using .yaml source

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import cv2
 import torch
 import torch.backends.cudnn as cudnn
+import yaml
 from numpy import random
 
 from models.experimental import attempt_load
@@ -22,6 +23,7 @@ def detect(save_img=False):
     out, source, weights, view_img, save_txt, imgsz = \
         opt.output, opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size
     webcam = source.isnumeric() or source.startswith('rtsp') or source.startswith('http') or source.endswith('.txt')
+    from_yaml = source.endswith('.yaml')
 
     # Initialize
     set_logging()
@@ -50,6 +52,11 @@ def detect(save_img=False):
         view_img = True
         cudnn.benchmark = True  # set True to speed up constant image size inference
         dataset = LoadStreams(source, img_size=imgsz)
+    elif from_yaml:
+        save_img = True
+        with open(source) as f:
+            data_dict = yaml.load(f, Loader=yaml.FullLoader)
+        dataset = LoadImages(data_dict['inf'], img_size=imgsz, from_yaml=True)
     else:
         save_img = True
         dataset = LoadImages(source, img_size=imgsz)

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -106,7 +106,7 @@ class InfiniteDataLoader(torch.utils.data.dataloader.DataLoader):
 
 
 class LoadImages:  # for inference
-    def __init__(self, path, img_size=640):
+    def __init__(self, path, img_size=640, from_yaml=False):
         p = str(Path(path))  # os-agnostic
         p = os.path.abspath(p)  # absolute path
         if '*' in p:
@@ -114,7 +114,14 @@ class LoadImages:  # for inference
         elif os.path.isdir(p):
             files = sorted(glob.glob(os.path.join(p, '*.*')))  # dir
         elif os.path.isfile(p):
-            files = [p]  # files
+            if from_yaml:
+                f = []
+                with open(p, 'r') as t:
+                    t = t.read().splitlines()
+                    f += [x for x in t]
+                files = sorted([x.replace('/', os.sep) for x in f])
+            else:
+                files = [p]  # files
         else:
             raise Exception('ERROR: %s does not exist' % p)
 


### PR DESCRIPTION
I want to operate inference through detect.py on files spanning `several folders`, but currently .txt files are recognized as webcam.
Many people seemed to have the same needs as me, so I made a pull request.

When yaml file is put as source path, inf tab is parsed and the value of inf tab is set source path.

1) If the path is a folder or *, the existing logic is used.
2) If the path is a file and from_yaml is true, it is recognized as a case of reading the file in which paths are stored, and the file is parsed to create an img list.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image loading in YOLOv5: YAML support for inference sources 🖼️🔍

### 📊 Key Changes
- Introduced YAML file support as an input source for image paths in `detect.py`.
- Modified `LoadImages` class in `utils/datasets.py` to handle file paths from YAML files.
- Added a conditional check in `detect.py` to load datasets from a YAML file if the source ends with '.yaml'.

### 🎯 Purpose & Impact
- 🎁 **Purpose:** This change allows users to specify a list of image paths for inference using a YAML file, making it easier to manage and execute batch detections on multiple images.
- 💡 **Impact:** Users can now streamline their inference process, providing a more organized way to feed image data into the model, especially when working with large numbers of images. This is conducive to automation and integration into larger systems.