### PR TITLE
Add contrast to conf/class against bbox rectangle color

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -985,7 +985,7 @@ def plot_one_box(x, img, color=None, label=None, line_thickness=None):
         t_size = cv2.getTextSize(label, 0, fontScale=tl / 3, thickness=tf)[0]
         c2 = c1[0] + t_size[0], c1[1] - t_size[1] - 3
         cv2.rectangle(img, c1, c2, color, -1, cv2.LINE_AA)  # filled
-        cv2.putText(img, label, (c1[0], c1[1] - 2), 0, tl / 3, [225, 255, 255], thickness=tf, lineType=cv2.LINE_AA)
+        cv2.putText(img, label, (c1[0], c1[1] - 2), 0, tl / 3, [(255 - c) for c in color], thickness=tf, lineType=cv2.LINE_AA) # add contrast of conf/class with bbox rectangle 
 
 
 def plot_wh_methods():  # from utils.general import *; plot_wh_methods()


### PR DESCRIPTION
I was making inferences and noticed a small problem. The RGB values for the color of bounding box rectangle is randomly generated and can sometimes be very light (yellow, for instance). Since the confidence score and class label were always white, it made it difficult to be read in the light bounding box rectangle.

An example inference screenshot is attached below! (in some cases the color generated was even lighter or closer to white (label color)).

![Screenshot (52)](https://user-images.githubusercontent.com/57761675/93613282-16e52180-f9ea-11ea-9ff6-f28f8c6b84b4.png)

What I did is basically take the "invert" of the color of the rectangle to be the font-color of the confidence and class name. This way the colors for both the rectangle and label can never be the same or close to each other, making it much easier to read the confidence score and class label! 

Updated bounding boxes are much easier to read even with light background color:

![Screenshot (50)](https://user-images.githubusercontent.com/57761675/93612748-50695d00-f9e9-11ea-894b-a11e31e306f7.png)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved text visibility on bounding boxes in YOLOv5 visualizations.

### 📊 Key Changes
- Modification to `cv2.putText()` in `plot_one_box` function to dynamically adjust text color based on bounding box color.

### 🎯 Purpose & Impact
- **Purpose:** To enhance readability of labels (i.e., confidence scores and class names) on bounding boxes by ensuring a better contrast between text color and bounding box color.
- **Impact:** Users will experience clearer visual outputs from the model, leading to easier interpretation of results. This is especially useful in situations where bounding boxes are densely packed or when working with images with variable lighting and background colors.