### PR TITLE
Add confidence score to label txt files 

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -18,8 +18,8 @@ from utils.torch_utils import select_device, load_classifier, time_synchronized
 
 
 def detect(save_img=False):
-    out, source, weights, view_img, save_txt, imgsz, save_conf = \
-        opt.output, opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size, opt.save_conf
+    out, source, weights, view_img, save_txt, imgsz = \
+        opt.output, opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size
     webcam = source.isnumeric() or source.startswith(('rtsp://', 'rtmp://', 'http://')) or source.endswith('.txt')
 
     # Initialize
@@ -104,12 +104,10 @@ def detect(save_img=False):
                 for *xyxy, conf, cls in reversed(det):
                     if save_txt:  # Write to file
                         xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
+                        line = (cls, conf, *xywh) if opt.save_conf else (cls, *xywh)  # label format
                         with open(txt_path + '.txt', 'a') as f:
-                            if save_conf:
-                                f.write(('%g ' * 6 + '\n') % (cls, conf, *xywh))  # label format includes conf
-                            else: 
-                                f.write(('%g ' * 5 + '\n') % (cls, *xywh))  # label format does not include conf
-
+                            f.write(('%g ' * len(line) + '\n') % line)
+                            
                     if save_img or view_img:  # Add bbox to image
                         label = '%s %.2f' % (names[int(cls)], conf)
                         plot_one_box(xyxy, im0, label=label, color=colors[int(cls)], line_thickness=3)

--- a/detect.py
+++ b/detect.py
@@ -164,7 +164,7 @@ if __name__ == '__main__':
     parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS')
     parser.add_argument('--augment', action='store_true', help='augmented inference')
     parser.add_argument('--update', action='store_true', help='update all models')
-    parser.add_argument('--save-conf', action='store_true', help='put confidence score next to class in label*.txt')
+    parser.add_argument('--save-conf', action='store_true', help='output confidences in --save-txt labels')
     opt = parser.parse_args()
     print(opt)
 

--- a/detect.py
+++ b/detect.py
@@ -160,11 +160,11 @@ if __name__ == '__main__':
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--view-img', action='store_true', help='display results')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
+    parser.add_argument('--save-conf', action='store_true', help='output confidences in --save-txt labels')
     parser.add_argument('--classes', nargs='+', type=int, help='filter by class: --class 0, or --class 0 2 3')
     parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS')
     parser.add_argument('--augment', action='store_true', help='augmented inference')
     parser.add_argument('--update', action='store_true', help='update all models')
-    parser.add_argument('--save-conf', action='store_true', help='output confidences in --save-txt labels')
     opt = parser.parse_args()
     print(opt)
 

--- a/detect.py
+++ b/detect.py
@@ -19,8 +19,8 @@ from utils.torch_utils import select_device, load_classifier, time_synchronized
 
 
 def detect(save_img=False):
-    out, source, weights, view_img, save_txt, imgsz = \
-        opt.output, opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size
+    out, source, weights, view_img, save_txt, imgsz, save_conf = \
+        opt.output, opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size, opt.save_conf
     webcam = source.isnumeric() or source.startswith('rtsp') or source.startswith('http') or source.endswith('.txt')
 
     # Initialize
@@ -106,7 +106,10 @@ def detect(save_img=False):
                     if save_txt:  # Write to file
                         xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
                         with open(txt_path + '.txt', 'a') as f:
-                            f.write(('%g ' * 5 + '\n') % (cls, *xywh))  # label format
+                            if save_conf:
+                                f.write(('%g ' * 6 + '\n') % (cls, conf, *xywh))  # label format includes conf
+                            else: 
+                                f.write(('%g ' * 5 + '\n') % (cls, *xywh))  # label format does not include conf
 
                     if save_img or view_img:  # Add bbox to image
                         label = '%s %.2f' % (names[int(cls)], conf)
@@ -161,6 +164,7 @@ if __name__ == '__main__':
     parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS')
     parser.add_argument('--augment', action='store_true', help='augmented inference')
     parser.add_argument('--update', action='store_true', help='update all models')
+    parser.add_argument('--save-conf', action='store_true', help='put confidence score next to class in label*.txt')
     opt = parser.parse_args()
     print(opt)
 

--- a/detect.py
+++ b/detect.py
@@ -107,7 +107,6 @@ def detect(save_img=False):
                         line = (cls, conf, *xywh) if opt.save_conf else (cls, *xywh)  # label format
                         with open(txt_path + '.txt', 'a') as f:
                             f.write(('%g ' * len(line) + '\n') % line)
-                            
                     if save_img or view_img:  # Add bbox to image
                         label = '%s %.2f' % (names[int(cls)], conf)
                         plot_one_box(xyxy, im0, label=label, color=colors[int(cls)], line_thickness=3)

--- a/detect.py
+++ b/detect.py
@@ -107,6 +107,7 @@ def detect(save_img=False):
                         line = (cls, conf, *xywh) if opt.save_conf else (cls, *xywh)  # label format
                         with open(txt_path + '.txt', 'a') as f:
                             f.write(('%g ' * len(line) + '\n') % line)
+
                     if save_img or view_img:  # Add bbox to image
                         label = '%s %.2f' % (names[int(cls)], conf)
                         plot_one_box(xyxy, im0, label=label, color=colors[int(cls)], line_thickness=3)

--- a/utils/general.py
+++ b/utils/general.py
@@ -985,7 +985,7 @@ def plot_one_box(x, img, color=None, label=None, line_thickness=None):
         t_size = cv2.getTextSize(label, 0, fontScale=tl / 3, thickness=tf)[0]
         c2 = c1[0] + t_size[0], c1[1] - t_size[1] - 3
         cv2.rectangle(img, c1, c2, color, -1, cv2.LINE_AA)  # filled
-        cv2.putText(img, label, (c1[0], c1[1] - 2), 0, tl / 3, [(255 - c) for c in color], thickness=tf, lineType=cv2.LINE_AA) # add contrast of conf/class with bbox rectangle 
+        cv2.putText(img, label, (c1[0], c1[1] - 2), 0, tl / 3, [225, 255, 255], thickness=tf, lineType=cv2.LINE_AA)
 
 
 def plot_wh_methods():  # from utils.general import *; plot_wh_methods()

--- a/utils/general.py
+++ b/utils/general.py
@@ -985,7 +985,7 @@ def plot_one_box(x, img, color=None, label=None, line_thickness=None):
         t_size = cv2.getTextSize(label, 0, fontScale=tl / 3, thickness=tf)[0]
         c2 = c1[0] + t_size[0], c1[1] - t_size[1] - 3
         cv2.rectangle(img, c1, c2, color, -1, cv2.LINE_AA)  # filled
-        cv2.putText(img, label, (c1[0], c1[1] - 2), 0, tl / 3, [225, 255, 255], thickness=tf, lineType=cv2.LINE_AA)
+        cv2.putText(img, label, (c1[0], c1[1] - 2), 0, tl / 3, [(255 - c) for c in color], thickness=tf, lineType=cv2.LINE_AA) # add contrast of conf/class with bbox rectangle 
 
 
 def plot_wh_methods():  # from utils.general import *; plot_wh_methods()


### PR DESCRIPTION
Added a feature where any user is able to optionally save the confidence scores of each bounding box in txt files during inference. Sometimes the user may need to acquire the bounding box confidence scores and they did not have an option before. 

I hope this PR is helpful! 👍 😃 ✌️ 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced detection output with confidence scores in saved text files 🔍✨

### 📊 Key Changes
- Added an option to include confidence scores in saved text files (`--save-conf` option).
- Modified the text file writing process to accommodate the new confidence score format.

### 🎯 Purpose & Impact
- **Purpose:** Enables users to save the detection confidence scores alongside the detected class and bounding box coordinates, providing more detailed detection information.
- **Impact:** Users who require detailed prediction results for analysis or post-processing gain an insightful new feature, potentially improving use cases such as data analysis and model performance evaluation. 📈