### PR TITLE
feat: add rtmp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $ python detect.py --source 0  # webcam
                             path/  # directory
                             path/*.jpg  # glob
                             rtsp://170.93.143.139/rtplive/470011e600ef003a004ee33696235daa  # rtsp stream
+                            rtmp://192.168.1.105/live/test  # rtmp stream
                             http://112.50.243.8/PLTV/88888888/224/3221225900/1.m3u8  # http stream
 ```
 

--- a/detect.py
+++ b/detect.py
@@ -21,7 +21,7 @@ from utils.torch_utils import select_device, load_classifier, time_synchronized
 def detect(save_img=False):
     out, source, weights, view_img, save_txt, imgsz = \
         opt.output, opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size
-    webcam = source.isnumeric() or source.startswith('rtsp') or source.startswith('http') or source.endswith('.txt')
+    webcam = source.isnumeric() or source.startswith('rtsp') or source.startswith('rtmp') or source.startswith('http') or source.endswith('.txt')
 
     # Initialize
     set_logging()

--- a/detect.py
+++ b/detect.py
@@ -21,7 +21,7 @@ from utils.torch_utils import select_device, load_classifier, time_synchronized
 def detect(save_img=False):
     out, source, weights, view_img, save_txt, imgsz = \
         opt.output, opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size
-    webcam = source.isnumeric() or source.startswith('rtsp') or source.startswith('rtmp') or source.startswith('http') or source.endswith('.txt')
+    webcam = source.isnumeric() or source.startswith(('rtsp://', 'rtmp://', 'http://')) or source.endswith('.txt')
 
     # Initialize
     set_logging()


### PR DESCRIPTION
this PR adds support for RTMP streams. it is useful, becase RTMP is widely used.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced live stream support in YOLOv5 detection.

### 📊 Key Changes
- Added support for `rtmp://` live stream sources in README instructions.
- Updated the `detect.py` script to recognize `rtmp://` URLs as webcam sources.

### 🎯 Purpose & Impact
- **Purpose**: To expand the compatibility of live video stream input sources for real-time object detection.
- **Impact**: Users now have the option to input `RTMP` streams, commonly used in broadcasting, increasing the flexibility and use cases for YOLOv5 object detection. ✨

📹 Streamers and developers working with live feeds have more options for their setups, potentially benefiting real-time monitoring and interactive applications.