### PR TITLE
mosaic4 bottom left image fix

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -661,7 +661,7 @@ def load_mosaic(self, index):
             x1b, y1b, x2b, y2b = 0, h - (y2a - y1a), min(w, x2a - x1a), h
         elif i == 2:  # bottom left
             x1a, y1a, x2a, y2a = max(xc - w, 0), yc, xc, min(s * 2, yc + h)
-            x1b, y1b, x2b, y2b = w - (x2a - x1a), 0, max(xc, w), min(y2a - y1a, h)
+            x1b, y1b, x2b, y2b = w - (x2a - x1a), 0, w, min(y2a - y1a, h)
         elif i == 3:  # bottom right
             x1a, y1a, x2a, y2a = xc, yc, min(xc + w, s * 2), min(s * 2, yc + h)
             x1b, y1b, x2b, y2b = 0, 0, min(w, x2a - x1a), min(y2a - y1a, h)


### PR DESCRIPTION
fix a bug in load_mosaic

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image stitching for data augmentation in YOLOv5.

### 📊 Key Changes
- Adjusted the calculation when stitching images together in the bottom left mosaic quadrant.

### 🎯 Purpose & Impact
- 🎨 **Purpose:** This change ensures that when images are combined to create a mosaic for training the YOLOv5 model, the bottom left image is correctly positioned without any overlap or gap.
- ✅ **Impact**: The potential impact is an increase in the accuracy of the YOLOv5 model by using better-formed training data, leading to improved performance in object detection tasks.