### PR TITLE
Fix increment_dir to use run_xxx for logdir

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -948,7 +948,7 @@ def increment_dir(dir, comment=''):
     dir = str(Path(dir))  # os-agnostic
     d = sorted(glob.glob(dir + '*'))  # directories
     if len(d):
-        n = max([int(x[len(dir):x.find('_') if '_' in x else None]) for x in d]) + 1  # increment
+        n = max([int(x[len(dir):x.find('_') if '_' in Path(x).name else None]) for x in d]) + 1  # increment
     return dir + str(n) + ('_' + comment if comment else '')
 
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -948,7 +948,7 @@ def increment_dir(dir, comment=''):
     dir = str(Path(dir))  # os-agnostic
     d = sorted(glob.glob(dir + '*'))  # directories
     if len(d):
-        n = max([int(x[len(dir):x.find('_') if '_' in Path(x).name else None]) for x in d]) + 1  # increment
+        n = max([int(x[len(dir):x.rfind('_') if '_' in Path(x).name else None]) for x in d]) + 1  # increment
     return dir + str(n) + ('_' + comment if comment else '')
 
 


### PR DESCRIPTION
This PR fixes index slicing underflow in retraining with logdir in the form of `run_xxx`.
After this PR, one can use `run_xxx` for logdir.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved directory-naming logic within the YOLOv5 codebase.

### 📊 Key Changes
- Updated the `increment_dir` function in `utils/general.py` to be more reliable when handling directory names.

### 🎯 Purpose & Impact
- **Purpose:** To ensure that when a directory's name is incremented, the function correctly identifies the suffix number regardless of path complexities.
- **Impact:** Users will experience fewer errors and more predictable behavior when the system automatically creates directories to prevent naming conflicts. This change enhances the file-management aspect of the model training process.