### PR TITLE
Update get_voc.sh data URLs

### DIFF
--- a/data/scripts/get_voc.sh
+++ b/data/scripts/get_voc.sh
@@ -27,9 +27,9 @@ fi
 
 echo "Downloading VOC2007 trainval ..."
 # Download data
-curl -LO http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar
+curl -LO http://pjreddie.com/media/files/VOCtrainval_06-Nov-2007.tar
 echo "Downloading VOC2007 test data ..."
-curl -LO http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtest_06-Nov-2007.tar
+curl -LO http://pjreddie.com/media/files/VOCtest_06-Nov-2007.tar
 echo "Done downloading."
 
 # Extract data


### PR DESCRIPTION
The old VOC download address is not available. It is recommended to change to mirror

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Switched download source for VOC2007 dataset.

### 📊 Key Changes
- The source URL for downloading the VOC2007 trainval dataset has been updated.
- The source URL for downloading the VOC2007 test dataset has been changed.

### 🎯 Purpose & Impact
- These changes ensure the download links are working, as the previous URLs might be deprecated or less reliable.
- Users can now fetch the datasets without encountering download issues, allowing for smoother setup and experimentation with the YOLOv5 model. 🔄