### PR TITLE
Added option to not open on save

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -140,7 +140,7 @@ def detect(save_img=False):
 
     if save_txt or save_img:
         print('Results saved to %s' % Path(out))
-        if platform.system() == 'Darwin' and not opt.update:  # MacOS
+        if platform.system() == 'Darwin' and not opt.update and opt.no_open_on_save:  # MacOS
             os.system('open ' + save_path)
 
     print('Done. (%.3fs)' % (time.time() - t0))
@@ -156,6 +156,7 @@ if __name__ == '__main__':
     parser.add_argument('--iou-thres', type=float, default=0.5, help='IOU threshold for NMS')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--view-img', action='store_true', help='display results')
+    parser.add_argument('--no-open-on-save', action='store_false', help='')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
     parser.add_argument('--classes', nargs='+', type=int, help='filter by class: --class 0, or --class 0 2 3')
     parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS')

--- a/detect.py
+++ b/detect.py
@@ -140,8 +140,6 @@ def detect(save_img=False):
 
     if save_txt or save_img:
         print('Results saved to %s' % Path(out))
-        if platform.system() == 'Darwin' and not opt.update and opt.no_open_on_save:  # MacOS
-            os.system('open ' + save_path)
 
     print('Done. (%.3fs)' % (time.time() - t0))
 
@@ -156,7 +154,6 @@ if __name__ == '__main__':
     parser.add_argument('--iou-thres', type=float, default=0.5, help='IOU threshold for NMS')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--view-img', action='store_true', help='display results')
-    parser.add_argument('--no-open-on-save', action='store_false', help='')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
     parser.add_argument('--classes', nargs='+', type=int, help='filter by class: --class 0, or --class 0 2 3')
     parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS')


### PR DESCRIPTION
Thanks for your great work on this. I was fairly annoyed by having to open the output img when running detect.py. Hence this PR which contains the argument option `--no-open-on-save`. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Removed auto-opening of results folder on MacOS after detection.

### 📊 Key Changes
- Deleted the conditional statement which triggered opening the output folder automatically on MacOS.

### 🎯 Purpose & Impact
- This change simplifies the codebase by removing an operating system-specific feature, keeping user experience consistent across all platforms.
- MacOS users will need to manually open the results folder after detections, as the folder will no longer pop up automatically. This allows users to have control over when to view results and may be beneficial for those running batch processes or in environments where such pop-ups would be disruptive.