### PR TITLE
Generalized regression renaming

### DIFF
--- a/data/hyp.finetune.yaml
+++ b/data/hyp.finetune.yaml
@@ -15,7 +15,7 @@ weight_decay: 0.00036
 warmup_epochs: 2.0
 warmup_momentum: 0.5
 warmup_bias_lr: 0.05
-giou: 0.0296
+box: 0.0296
 cls: 0.243
 cls_pw: 0.631
 obj: 0.301

--- a/data/hyp.scratch.yaml
+++ b/data/hyp.scratch.yaml
@@ -10,7 +10,7 @@ weight_decay: 0.0005  # optimizer weight decay 5e-4
 warmup_epochs: 3.0  # warmup epochs (fractions ok)
 warmup_momentum: 0.8  # warmup initial momentum
 warmup_bias_lr: 0.1  # warmup initial bias lr
-giou: 0.05  # box loss gain
+box: 0.05  # box loss gain
 cls: 0.5  # cls loss gain
 cls_pw: 1.0  # cls BCELoss positive_weight
 obj: 1.0  # obj loss gain (scale with pixels)

--- a/sotabench.py
+++ b/sotabench.py
@@ -113,7 +113,7 @@ def test(data,
 
             # Compute loss
             if training:  # if model has loss hyperparameters
-                loss += compute_loss([x.float() for x in train_out], targets, model)[1][:3]  # GIoU, obj, cls
+                loss += compute_loss([x.float() for x in train_out], targets, model)[1][:3]  # box, obj, cls
 
             # Run NMS
             t = time_synchronized()

--- a/test.py
+++ b/test.py
@@ -106,7 +106,7 @@ def test(data,
 
             # Compute loss
             if training:  # if model has loss hyperparameters
-                loss += compute_loss([x.float() for x in train_out], targets, model)[1][:3]  # GIoU, obj, cls
+                loss += compute_loss([x.float() for x in train_out], targets, model)[1][:3]  # box, obj, cls
 
             # Run NMS
             t = time_synchronized()


### PR DESCRIPTION
This PR substitutes 'GIoU' and 'giou' with 'box' throughout YOLOv5. This change is required as we currently use CIoU for box regression criterion rather than GIoU, and using the general term 'box' allows for future changes in the regression criterion without requiring subsequent renaming.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update loss terminology from GIoU to box for clarity in codebase.

### 📊 Key Changes
- Renamed `giou` loss to `box` loss across various configuration and code files.
- Updated comments and logging to reflect the change from `GIoU` to `box`.
- Loss calculation logic now refers to `iou` loss instead of `giou`.

### 🎯 Purpose & Impact
- **Clarifies Loss terminology:** Simplifies understanding by using a more generic term `box` which encompasses different IoU-based loss methods (like CIoU which is actually used).
- **Consistency:** Maintains consistency in how loss is referred to within the code, potentially reducing confusion.
- **No Functional Change:** The update is predominantly cosmetic, as it does not alter the underlying logic; the functional impact on users is minimal.