### PR TITLE
comment missing arg

### DIFF
--- a/train.py
+++ b/train.py
@@ -471,7 +471,7 @@ if __name__ == '__main__':
                 'obj_pw': (1, 0.5, 2.0),  # obj BCELoss positive_weight
                 'iou_t': (0, 0.1, 0.7),  # IoU training threshold
                 'anchor_t': (1, 2.0, 8.0),  # anchor-multiple threshold
-                'anchors': (2, 2.0, 10.0),  # anchors per output grid (0 to ignore)
+                #'anchors': (2, 2.0, 10.0),  # anchors per output grid (0 to ignore)
                 'fl_gamma': (0, 0.0, 2.0),  # focal loss gamma (efficientDet default gamma=1.5)
                 'hsv_h': (1, 0.0, 0.1),  # image HSV-Hue augmentation (fraction)
                 'hsv_s': (1, 0.0, 0.9),  # image HSV-Saturation augmentation (fraction)


### PR DESCRIPTION
the case is that with this call:
```
python train.py \
  --img-size 608 \
  --epochs 40 \
  --single-cls \
  --cfg ./models/${model}.yaml \
  --weights ./weights/${model}.pt \
  --logdir /data/logs/${model} \
  --data ./data/my-data.yaml \
  --evolve
```
I get following error:
```
Namespace(adam=False, batch_size=56, bucket='', cache_images=False, cfg='./models/yolov5s.yaml', data='./data/shops_pd2-3.yaml', device='0', epochs=40, evolve=True, global_rank=-1, hyp='data/hyp.scratch.yaml', image_weights=False, img_size=[608, 608], local_rank=-1, logdir='/data/Project_Video/RESULTS/Yolo-v5/shops-ppl_yolov5s', multi_scale=False, name='pd2-3_evolve', noautoanchor=False, nosave=False, notest=False, rect=False, resume=False, single_cls=True, sync_bn=False, total_batch_size=56, weights='./weights/yolov5s.pt', workers=28, world_size=1)
  0%|                                                                                                                                                                                                                 | 0/150 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "train.py", line 524, in <module>
    hyp[k] = max(hyp[k], v[1])  # lower limit
KeyError: 'anchors'
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced hyperparameter flexibility in YOLOv5 training.

### 📊 Key Changes
- The 'anchors' hyperparameter line in the training script has been commented out.

### 🎯 Purpose & Impact
- 🛠 Purpose: The change appears to simplify the hyperparameter space by removing an option that could be left at its default or was potentially unused or unnecessary. This can make the training process more straightforward.
- 🚀 Impact: Users might experience a more streamlined hyperparameter set, possibly improving ease of use by reducing the number of hyperparameters they need to consider when configuring their training runs. The change might also indicate a shift towards more automated or internally managed anchor settings that require less manual tuning.