### PR TITLE
fix padding for rectangular inference

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -731,7 +731,7 @@ def letterbox(img, new_shape=(640, 640), color=(114, 114, 114), auto=True, scale
     new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
     dw, dh = new_shape[1] - new_unpad[0], new_shape[0] - new_unpad[1]  # wh padding
     if auto:  # minimum rectangle
-        dw, dh = np.mod(dw, 64), np.mod(dh, 64)  # wh padding
+        dw, dh = np.mod(dw, 32), np.mod(dh, 32)  # wh padding
     elif scaleFill:  # stretch
         dw, dh = 0.0, 0.0
         new_unpad = (new_shape[1], new_shape[0])


### PR DESCRIPTION
Image size will be padded to minimum multiple of 32 for rectangular inference.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image padding granularity in YOLOv5 pre-processing.

### 📊 Key Changes
- Modified the padding calculation in the `letterbox` function within `datasets.py`.
- Padding values are now a multiple of 32 instead of 64.

### 🎯 Purpose & Impact
- 📈 This change enhances the flexibility in image processing by allowing finer-grained padding, which can improve model accuracy as it provides more precise scaling options.
- 🔍 Users may notice improved detection performance, especially with small objects, due to less distortion during image resizing.
- 🚀 Models could potentially train and infer slightly faster as a result of the reduced padding in some cases.