### PR TITLE
GhostConv() bug fix

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -67,8 +67,8 @@ class GhostConv(nn.Module):
     def __init__(self, c1, c2, k=1, s=1, g=1, act=True):  # ch_in, ch_out, kernel, stride, groups
         super(GhostConv, self).__init__()
         c_ = c2 // 2  # hidden channels
-        self.cv1 = Conv(c1, c_, k, s, g, act)
-        self.cv2 = Conv(c_, c_, 5, 1, c_, act)
+        self.cv1 = Conv(c1, c_, k, s, None, g, act)
+        self.cv2 = Conv(c_, c_, 5, 1, None, c_, act)
 
     def forward(self, x):
         y = self.cv1(x)


### PR DESCRIPTION
The parameters of Conv function:
```python
def __init__(self, c1, c2, k=1, s=1, p=None, g=1, act=True): 
```
But in ghost conv:
```python
class GhostConv(nn.Module):
    # Ghost Convolution https://github.com/huawei-noah/ghostnet
    def __init__(self, c1, c2, k=1, s=1, g=1, act=True):  # ch_in, ch_out, kernel, stride, groups
        super(GhostConv, self).__init__()
        c_ = c2 // 2  # hidden channels
        self.cv1 = Conv(c1, c_, k, s, g, act)
        self.cv2 = Conv(c_, c_, 5, 1, c_, act)
```
The parameter p is ignored.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of GhostConv layer initialization in YOLOv5's experimental model structures.

### 📊 Key Changes
- Modified the `GhostConv` class constructors for `cv1` and `cv2` methods.
- Adjusted the arguments passed to `Conv` function, specifically the groups (`g`) parameter.

### 🎯 Purpose & Impact
- 🛠️ The update corrects the parameter passing by explicitly assigning `None` where a default value is expected, enhancing code readability and maintainability.
- ✨ This change may improve model training stability and future proof the code by adhering to expected function signatures.
- 🔍 Users can expect cleaner code inside the `GhostConv` class, possibly leading to fewer bugs and a small enhancement in performance or stability.