### PR TITLE
Adding --output and --save-conf options to test.py

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -19,15 +19,15 @@ from utils.torch_utils import select_device, load_classifier, time_synchronized
 
 def detect(save_img=False):
     out, source, weights, view_img, save_txt, imgsz = \
-        opt.output, opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size
+        opt.save_dir, opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size
     webcam = source.isnumeric() or source.startswith(('rtsp://', 'rtmp://', 'http://')) or source.endswith('.txt')
 
     # Initialize
     set_logging()
     device = select_device(opt.device)
-    if os.path.exists(out):
-        shutil.rmtree(out)  # delete output folder
-    os.makedirs(out)  # make new output folder
+    if os.path.exists(out):  # output dir
+        shutil.rmtree(out)  # delete dir
+    os.makedirs(out)  # make new dir
     half = device.type != 'cpu'  # half precision only supported on CUDA
 
     # Load model
@@ -148,14 +148,14 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--weights', nargs='+', type=str, default='yolov5s.pt', help='model.pt path(s)')
     parser.add_argument('--source', type=str, default='inference/images', help='source')  # file/folder, 0 for webcam
-    parser.add_argument('--output', type=str, default='inference/output', help='output folder')  # output folder
     parser.add_argument('--img-size', type=int, default=640, help='inference size (pixels)')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='object confidence threshold')
     parser.add_argument('--iou-thres', type=float, default=0.45, help='IOU threshold for NMS')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--view-img', action='store_true', help='display results')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
-    parser.add_argument('--save-conf', action='store_true', help='output confidences in --save-txt labels')
+    parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
+    parser.add_argument('--save-dir', type=str, default='inference/output', help='directory to save results')
     parser.add_argument('--classes', nargs='+', type=int, help='filter by class: --class 0, or --class 0 2 3')
     parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS')
     parser.add_argument('--augment', action='store_true', help='augmented inference')

--- a/test.py
+++ b/test.py
@@ -265,8 +265,8 @@ if __name__ == '__main__':
     parser.add_argument('--augment', action='store_true', help='augmented inference')
     parser.add_argument('--verbose', action='store_true', help='report mAP by class')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
-    parser.add_argument('--save-conf', action='store_true', help='put confidence score next to class in label*.txt')
-    parser.add_argument('--output', type=str, default='', help='output folder')  # output folder
+    parser.add_argument('--save-conf', action='store_true', help='output confidences in --save-txt labels')
+    parser.add_argument('--output', type=str, default='', help='output folder to save results')
     opt = parser.parse_args()
     opt.save_json |= opt.data.endswith('coco.yaml')
     opt.data = check_file(opt.data)  # check file

--- a/test.py
+++ b/test.py
@@ -44,10 +44,10 @@ def test(data,
         device = select_device(opt.device, batch_size=batch_size)
         save_txt = opt.save_txt  # save *.txt labels
         if save_txt:
-            out = save_dir / 'output'
+            out = save_dir / 'autolabels'
             if os.path.exists(out):
-                shutil.rmtree(out)  # delete output folder
-            os.makedirs(out)  # make new output folder
+                shutil.rmtree(out)  # delete dir
+            os.makedirs(out)  # make new dir
 
         # Remove previous
         for f in glob.glob(str(save_dir / 'test_batch*.jpg')):
@@ -265,8 +265,8 @@ if __name__ == '__main__':
     parser.add_argument('--augment', action='store_true', help='augmented inference')
     parser.add_argument('--verbose', action='store_true', help='report mAP by class')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
-    parser.add_argument('--save-conf', action='store_true', help='output confidences in --save-txt labels')
-    parser.add_argument('--output', type=str, default='', help='output folder to save results')
+    parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
+    parser.add_argument('--save-dir', type=str, default='runs/test', help='directory to save results')
     opt = parser.parse_args()
     opt.save_json |= opt.data.endswith('coco.yaml')
     opt.data = check_file(opt.data)  # check file
@@ -283,7 +283,7 @@ if __name__ == '__main__':
              opt.single_cls,
              opt.augment,
              opt.verbose,
-             save_dir=Path(opt.output),
+             save_dir=Path(opt.save_dir),
              save_txt=opt.save_txt,
              save_conf=opt.save_conf,
              )

--- a/test.py
+++ b/test.py
@@ -43,15 +43,17 @@ def test(data,
         set_logging()
         device = select_device(opt.device, batch_size=batch_size)
         save_txt = opt.save_txt  # save *.txt labels
+
+        # Remove previous
+        if os.path.exists(save_dir):
+            shutil.rmtree(save_dir)  # delete dir
+        os.makedirs(save_dir)  # make new dir
+
         if save_txt:
             out = save_dir / 'autolabels'
             if os.path.exists(out):
                 shutil.rmtree(out)  # delete dir
             os.makedirs(out)  # make new dir
-
-        # Remove previous
-        for f in glob.glob(str(save_dir / 'test_batch*.jpg')):
-            os.remove(f)
 
         # Load model
         model = attempt_load(weights, map_location=device)  # load FP32 model
@@ -287,6 +289,8 @@ if __name__ == '__main__':
              save_txt=opt.save_txt,
              save_conf=opt.save_conf,
              )
+
+        print('Results saved to %s' % opt.save_dir)
 
     elif opt.task == 'study':  # run over a range of settings and save/plot
         for weights in ['yolov5s.pt', 'yolov5m.pt', 'yolov5l.pt', 'yolov5x.pt']:


### PR DESCRIPTION
Cleaner PR to replace https://github.com/ultralytics/yolov5/pull/1175

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of result saving in object detection and testing scripts.

### 📊 Key Changes
- `save_dir` variable unified across detection and test scripts.
- Directory creation logic centralized to ensure result directories are created only once.
- Conditional inclusion of confidence scores in saved text files controlled by `--save-conf` flag.
- Enhanced code clarity and maintainability.

### 🎯 Purpose & Impact
- 📁 Unifies result directory setup across different scripts, making it easier for users to locate and manage output files.
- 🛠️ Simplifies the codebase, reducing potential bugs related to directory handling.
- ✂️ Reduces redundant code for directory creation, which streamlines the workflow.
- 📈 Allows for optional saving of confidence scores in result text files, providing more detailed output for analysis if needed.
- 👀 Enhances the user experience, as results are saved in a predictable manner and output is customizable.