### PR TITLE
Ignore

### DIFF
--- a/data/dhaka21.yaml
+++ b/data/dhaka21.yaml
@@ -10,8 +10,9 @@
 download: https://github.com/ultralytics/yolov5/releases/download/v1.0/coco128.zip
 
 # train and val data as 1) directory: path/images/, 2) file: path/images.txt, or 3) list: [path1/images/, path2/images/]
-train: ../coco128/images/train2017/  # 128 images
-val: ../coco128/images/train2017/  # 128 images
+train: ./train/  # 128 images
+val: ./valid/  # 128 images
+test: ./test/  # 128 images
 
 # number of classes
 nc: 80


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Transition from COCO128 dataset to Dhaka21 dataset configuration.

### 📊 Key Changes
- The dataset configuration file has been renamed from `coco128.yaml` to `dhaka21.yaml`.
- The file now points to new training, validation, and test image directories (`./train/`, `./valid/`, and `./test/`).

### 🎯 Purpose & Impact
- The purpose of this change appears to be a shift towards using a dataset named Dhaka21 for training and evaluation, possibly replacing or adding to the COCO128 dataset.
- Impacts users who rely on the default COCO128 dataset by providing an alternative or updated dataset.
- May introduce a new dataset for users to train their object detection models, potentially offering more variety or addressing specific needs not covered by COCO128.