### PR TITLE
Move generated *.json annotations into runs/test

### DIFF
--- a/test.py
+++ b/test.py
@@ -222,10 +222,11 @@ def test(data,
 
     # Save JSON
     if save_json and len(jdict):
-        f = save_dir / f"detections_val2017_{Path(weights[0]).stem if isinstance(weights, list) else ''}_results.json"
-        print('\nCOCO mAP with pycocotools... saving %s...' % f)  # filename
-        with open(f, 'w') as file:
-            json.dump(jdict, file)
+        w = Path(weights[0] if isinstance(weights, list) else weights).stem if weights is not None else ''  # weights
+        file = save_dir / f"detections_val2017_{w}_results.json"  # predicted annotations file
+        print('\nCOCO mAP with pycocotools... saving %s...' % file)
+        with open(file, 'w') as f:
+            json.dump(jdict, f)
 
         try:  # https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocoEvalDemo.ipynb
             from pycocotools.coco import COCO
@@ -233,7 +234,7 @@ def test(data,
 
             imgIds = [int(Path(x).stem) for x in dataloader.dataset.img_files]
             cocoGt = COCO(glob.glob('../coco/annotations/instances_val*.json')[0])  # initialize COCO ground truth api
-            cocoDt = cocoGt.loadRes(f)  # initialize COCO pred api
+            cocoDt = cocoGt.loadRes(str(file))  # initialize COCO pred api
             cocoEval = COCOeval(cocoGt, cocoDt, 'bbox')
             cocoEval.params.imgIds = imgIds  # image IDs to evaluate
             cocoEval.evaluate()

--- a/test.py
+++ b/test.py
@@ -222,9 +222,8 @@ def test(data,
 
     # Save JSON
     if save_json and len(jdict):
-        f = 'detections_val2017_%s_results.json' % \
-            (weights.split(os.sep)[-1].replace('.pt', '') if isinstance(weights, str) else '')  # filename
-        print('\nCOCO mAP with pycocotools... saving %s...' % f)
+        f = save_dir / f"detections_val2017_{Path(weights[0]).stem if isinstance(weights, list) else ''}_results.json"
+        print('\nCOCO mAP with pycocotools... saving %s...' % f)  # filename
         with open(f, 'w') as file:
             json.dump(jdict, file)
 


### PR DESCRIPTION
This PR moves prediction annotation json files into new runs/test directory on pycocotools testing.

<img width="1282" alt="Screenshot 2020-10-25 at 18 05 56" src="https://user-images.githubusercontent.com/26833433/97113763-c5b50580-16ec-11eb-81fa-37a1bbfb7166.png">


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved JSON file handling and naming in YOLOv5 testing script.

### 📊 Key Changes
- Changed how the JSON detection results file is named when saving.
- Updated the file handling to accommodate different types (list, str, None) of the `weights` parameter.
- Simplified the result file path construction using `Path` from `pathlib`.
- Ensured the `loadRes` method receives the proper string file path.

### 🎯 Purpose & Impact
- 🎨 Enhances consistency in file naming for easier identification and organization of output files.
- 🛠 Fixes potential issues with file paths when `weights` parameter varies in type, improving robustness.
- 📈 May facilitate better integration with other tools and post-processing due to standardized file naming.
- 👥 Affects users who save JSON detections, making their workflow smoother and their outputs more predictable.