### PR TITLE
PyTorch 1.7.0 Compatibility Updates

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -108,3 +108,11 @@ def yolov5x(pretrained=False, channels=3, classes=80):
 
 if __name__ == '__main__':
     model = create(name='yolov5s', pretrained=True, channels=3, classes=80)  # example
+    model = model.fuse().eval().autoshape()  # for autoshaping of PIL/cv2/np inputs and NMS
+
+    # Verify inference
+    from PIL import Image
+
+    img = Image.open('inference/images/zidane.jpg')
+    y = model(img)
+    print(y[0].shape)

--- a/models/experimental.py
+++ b/models/experimental.py
@@ -136,6 +136,13 @@ def attempt_load(weights, map_location=None):
         attempt_download(w)
         model.append(torch.load(w, map_location=map_location)['model'].float().fuse().eval())  # load FP32 model
 
+    # Compatibility updates
+    for m in model.modules():
+        if type(m) in [nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6]:
+            m.inplace = True  # pytorch 1.7.0 compatibility
+        elif type(m) is Conv:
+            m._non_persistent_buffers_set = set()  # pytorch 1.6.0 compatibility
+
     if len(model) == 1:
         return model[-1]  # return model
     else:

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -165,7 +165,6 @@ class Model(nn.Module):
         print('Fusing layers... ')
         for m in self.model.modules():
             if type(m) is Conv and hasattr(m, 'bn'):
-                m._non_persistent_buffers_set = set()  # pytorch 1.6.0 compatability
                 m.conv = fuse_conv_and_bn(m.conv, m.bn)  # update conv
                 delattr(m, 'bn')  # remove batchnorm
                 m.forward = m.fuseforward  # update forward

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -74,7 +74,7 @@ def initialize_weights(model):
         elif t is nn.BatchNorm2d:
             m.eps = 1e-3
             m.momentum = 0.03
-        elif t in [nn.LeakyReLU, nn.ReLU, nn.ReLU6]:
+        elif t in [nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6]:
             m.inplace = True
 
 


### PR DESCRIPTION
This PR adds torch 1.7.0 compatibility updates, and relocates 1.6.0 legacy compatibility updates to attempt_load() in experimental.py. Will update official models as well for 1.7.0 compatibility and attach to a v3.1 release soon.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements for model loading and inference compatibility in YOLOv5.

### 📊 Key Changes
- Added autoshaping, evaluation, and fusing to the YOLOv5 model example in `hubconf.py`.
- Enriched `attempt_load` function in `experimental.py` with compatibility features for different PyTorch versions.
- Removed redundant compatibility code in `yolo.py` after fusing convolution and batch normalization layers.
- Expanded activation function updates in `torch_utils.py` for initialization to include `nn.Hardswish`.

### 🎯 Purpose & Impact
- Ensuring YOLOv5 models work smoother with various input types and different PyTorch versions.
- 🚀 Potential impact includes easier model deployment, especially for users working with different versions of PyTorch or different image input formats, fostering broader adoption and user convenience.