### PR TITLE
autoshape() update for PIL greyscale inputs

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -1,6 +1,7 @@
 # This file contains modules common to various models
 
 import math
+
 import numpy as np
 import torch
 import torch.nn as nn

--- a/models/common.py
+++ b/models/common.py
@@ -145,7 +145,8 @@ class autoShape(nn.Module):
         shape0, shape1 = [], []  # image and inference shapes
         batch = range(len(x))  # batch size
         for i in batch:
-            x[i] = np.array(x[i])[:, :, :3]  # up to 3 channels if png
+            x[i] = np.array(x[i])  # to numpy
+            x[i] = x[i][:, :, :3] if x[i].ndim == 3 else np.tile(x[i][:, :, None], 3)  # enforce 3ch input
             s = x[i].shape[:2]  # HWC
             shape0.append(s)  # image shape
             g = (size / max(s))  # gain


### PR DESCRIPTION
This PR improves autoshape robustness to PIL grescale images. cv2 greyscale images are expanded to RGB on cv2.imread() automatically, so after this PR PyTorch Hub inference should be robust to greyscale images for both PIL and OpenCV sources.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image channel handling in preprocessing.

### 📊 Key Changes
- Added conversion from various input image channel formats to the consistent 3-channel format required by the model.

### 🎯 Purpose & Impact
- 🎨 Ensures robustness in handling inputs such as grayscale images, which might otherwise have fewer channels than expected.
- 🔧 Improves model compatibility and user experience by automatically adjusting images to meet model requirements.
- 🚀 Potential to streamline preprocessing for users, reducing errors and simplifying the pipeline for image data preparation.