### PR TITLE
Multi-threaded image caching

### DIFF
--- a/data/scripts/get_voc.sh
+++ b/data/scripts/get_voc.sh
@@ -25,7 +25,7 @@ end=$(date +%s)
 runtime=$((end - start))
 echo "Completed in" $runtime "seconds"
 
-echo "Spliting dataset..."
+echo "Splitting dataset..."
 python3 - "$@" <<END
 import xml.etree.ElementTree as ET
 import pickle

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ tqdm>=4.41.0
 # pycocotools>=2.0
 
 # export --------------------------------------
-# packaging  # for coremltools
 # coremltools==4.0
 # onnx>=1.7.0
 # scikit-learn==0.19.2  # for coreml quantization

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -477,7 +477,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         if cache_images:
             gb = 0  # Gigabytes of cached images
             self.img_hw0, self.img_hw = [None] * n, [None] * n
-            results = ThreadPool(8).imap_unordered(lambda x: load_image(*x), zip(repeat(self), range(n)))  # 8 threads
+            results = ThreadPool(8).imap(lambda x: load_image(*x), zip(repeat(self), range(n)))  # 8 threads
             pbar = tqdm(enumerate(results), total=n)
             for i, x in pbar:
                 self.imgs[i], self.img_hw0[i], self.img_hw[i] = x  # img, hw_original, hw_resized = load_image(self, i)


### PR DESCRIPTION
This PR implements Multi-threaded image caching in the train and test dataloaders using 8 threads, replacing the current single-threaded caching `for` loop.

Validation testing on a custom dataset (13,000 1920x1080p images) produced caching speed improvement from 8:00 minutes to 1:45 minutes, a 5X speed improvement. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements in VOC dataset script, housekeeping in requirements, and enhanced image caching for datasets.

### 📊 Key Changes
- 🔤 Fixed a typo in the `get_voc.sh` script ("Spliting" to "Splitting").
- 🧹 Removed an unused dependency (`packaging`) from `requirements.txt`.
- 💻 Modified image caching in `datasets.py` to use 8 concurrent threads, improving loading efficiency.

### 🎯 Purpose & Impact
- ✅ Enhances user experience by correcting script outputs, avoiding any confusion.
- 🧽 Keeps the requirement list clean, which may reduce installation times and potential conflicts.
- 🚀 Improves performance by parallelizing image caching, potentially speeding up the data preparation phase for users working with large datasets.