### PR TITLE
--save-txt store_true fix

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -154,7 +154,7 @@ if __name__ == '__main__':
     parser.add_argument('--iou-thres', type=float, default=0.45, help='IOU threshold for NMS')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--view-img', action='store_true', help='display results')
-    parser.add_argument('--save-txt', action='store_false', help='save results to *.txt')
+    parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
     parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
     parser.add_argument('--save-dir', type=str, default='runs/detect', help='directory to save results')
     parser.add_argument('--name', default='', help='name to append to --save-dir: i.e. runs/{N} -> runs/{N}_{name}')


### PR DESCRIPTION
This PR returns detect.py to default not saving labels. To save labels --save-txt.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization to enable text file output by default during detection.

### 📊 Key Changes
- Modified the `--save-txt` argument in `detect.py` to store detection results in text format by default.

### 🎯 Purpose & Impact
- **Purpose:** Streamlines the process for users who want to have an easy access to the detection results in a text file without additional configuration.
- **Impact:** Enhances user experience by saving an extra step for those who regularly save detection outputs, but could lead to unexpected behavior for users unaware of this change. It's now important to explicitly disable this feature if text output is not desired. 📝💾