### PR TITLE
Use pathlib instead of low-level module

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -17,15 +17,14 @@ from utils.torch_utils import select_device, load_classifier, time_synchronized
 def detect(save_img=False):
     save_dir, source, weights, view_img, save_txt, imgsz = \
         Path(opt.save_dir), opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size
-    webcam = source.isnumeric() or source.startswith(('rtsp://', 'rtmp://', 'http://')) or source.endswith('.txt')
+    webcam = source.isnumeric() or source.endswith('.txt') or \
+             source.lower().startswith(('rtsp://', 'rtmp://', 'http://'))
 
     # Directories
     if save_dir == Path('runs/detect'):  # if default
         save_dir.mkdir(parents=True, exist_ok=True) # make base
         save_dir = Path(increment_dir(save_dir / 'exp', opt.name))  # increment run
-    if save_txt:
-        save_dir = save_dir / 'labels'
-    save_dir.mkdir(parents=True, exist_ok=True) # make new dir
+    (save_dir / 'labels' if save_txt else save_dir).mkdir(parents=True, exist_ok=True)  # make new dir
 
     # Initialize
     set_logging()

--- a/detect.py
+++ b/detect.py
@@ -22,7 +22,7 @@ def detect(save_img=False):
 
     # Directories
     if save_dir == Path('runs/detect'):  # if default
-        save_dir.mkdir(parents=True, exist_ok=True) # make base
+        save_dir.mkdir(parents=True, exist_ok=True)  # make base
         save_dir = Path(increment_dir(save_dir / 'exp', opt.name))  # increment run
     (save_dir / 'labels' if save_txt else save_dir).mkdir(parents=True, exist_ok=True)  # make new dir
 

--- a/detect.py
+++ b/detect.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 import time
 from pathlib import Path
 
@@ -22,9 +21,11 @@ def detect(save_img=False):
 
     # Directories
     if save_dir == Path('runs/detect'):  # if default
-        os.makedirs('runs/detect', exist_ok=True)  # make base
+        save_dir.mkdir(parents=True, exist_ok=True) # make base
         save_dir = Path(increment_dir(save_dir / 'exp', opt.name))  # increment run
-    os.makedirs(save_dir / 'labels' if save_txt else save_dir, exist_ok=True)  # make new dir
+    if save_txt:
+        save_dir = save_dir / 'labels'
+    save_dir.mkdir(parents=True, exist_ok=True) # make new dir
 
     # Initialize
     set_logging()

--- a/hubconf.py
+++ b/hubconf.py
@@ -29,7 +29,7 @@ def create(name, pretrained, channels, classes):
     Returns:
         pytorch model
     """
-    config = Path(__file__).parent / 'models' / f'{name}.yaml' # model.yaml path
+    config = Path(__file__).parent / 'models' / f'{name}.yaml'  # model.yaml path
     try:
         model = Model(config, channels, classes)
         if pretrained:

--- a/hubconf.py
+++ b/hubconf.py
@@ -6,7 +6,7 @@ Usage:
 """
 
 dependencies = ['torch', 'yaml']
-import os
+from pathlib import Path
 
 import torch
 
@@ -29,7 +29,7 @@ def create(name, pretrained, channels, classes):
     Returns:
         pytorch model
     """
-    config = os.path.join(os.path.dirname(__file__), 'models', f'{name}.yaml')  # model.yaml path
+    config = Path(__file__).parent / 'models' / f'{name}.yaml' # model.yaml path
     try:
         model = Model(config, channels, classes)
         if pretrained:

--- a/test.py
+++ b/test.py
@@ -49,9 +49,7 @@ def test(data,
         if save_dir == Path('runs/test'):  # if default
             save_dir.mkdir(parents=True, exist_ok=True) # make base
             save_dir = Path(increment_dir(save_dir / 'exp', opt.name))  # increment run
-        if save_txt:
-            save_dir = save_dir / 'labels'
-        save_dir.mkdir(parents=True, exist_ok=True)  # make new dir
+        (save_dir / 'labels' if save_txt else save_dir).mkdir(parents=True, exist_ok=True)  # make new dir
 
         # Load model
         model = attempt_load(weights, map_location=device)  # load FP32 model

--- a/test.py
+++ b/test.py
@@ -47,9 +47,11 @@ def test(data,
 
         # Directories
         if save_dir == Path('runs/test'):  # if default
-            os.makedirs('runs/test', exist_ok=True)  # make base
+            save_dir.mkdir(parents=True, exist_ok=True) # make base
             save_dir = Path(increment_dir(save_dir / 'exp', opt.name))  # increment run
-        os.makedirs(save_dir / 'labels' if save_txt else save_dir, exist_ok=True)  # make new dir
+        if save_txt:
+            save_dir = save_dir / 'labels'
+        save_dir.mkdir(parents=True, exist_ok=True)  # make new dir
 
         # Load model
         model = attempt_load(weights, map_location=device)  # load FP32 model

--- a/test.py
+++ b/test.py
@@ -47,7 +47,7 @@ def test(data,
 
         # Directories
         if save_dir == Path('runs/test'):  # if default
-            save_dir.mkdir(parents=True, exist_ok=True) # make base
+            save_dir.mkdir(parents=True, exist_ok=True)  # make base
             save_dir = Path(increment_dir(save_dir / 'exp', opt.name))  # increment run
         (save_dir / 'labels' if save_txt else save_dir).mkdir(parents=True, exist_ok=True)  # make new dir
 

--- a/train.py
+++ b/train.py
@@ -41,7 +41,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
     wdir.mkdir(parents=True, exist_ok=True)
     last = wdir / 'last.pt'
     best = wdir / 'best.pt'
-    results_file = str(log_dir / 'results.txt')
+    results_file = log_dir / 'results.txt'
     epochs, batch_size, total_batch_size, weights, rank = \
         opt.epochs, opt.batch_size, opt.total_batch_size, opt.weights, opt.global_rank
 

--- a/train.py
+++ b/train.py
@@ -38,7 +38,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
     logger.info(f'Hyperparameters {hyp}')
     log_dir = Path(tb_writer.log_dir) if tb_writer else Path(opt.logdir) / 'evolve'  # logging directory
     wdir = log_dir / 'weights'  # weights directory
-    os.makedirs(wdir, exist_ok=True)
+    wdir.mkdir(parents=True, exist_ok=True)
     last = wdir / 'last.pt'
     best = wdir / 'best.pt'
     results_file = str(log_dir / 'results.txt')
@@ -121,7 +121,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
     # Logging
     if wandb and wandb.run is None:
         id = ckpt.get('wandb_id') if 'ckpt' in locals() else None
-        wandb_run = wandb.init(config=opt, resume="allow", project="YOLOv5", name=os.path.basename(log_dir), id=id)
+        wandb_run = wandb.init(config=opt, resume="allow", project="YOLOv5", name=log_dir.stem, id=id)
 
     # Resume
     start_epoch, best_fitness = 0, 0.0
@@ -371,7 +371,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
         n = opt.name if opt.name.isnumeric() else ''
         fresults, flast, fbest = log_dir / f'results{n}.txt', wdir / f'last{n}.pt', wdir / f'best{n}.pt'
         for f1, f2 in zip([wdir / 'last.pt', wdir / 'best.pt', results_file], [flast, fbest, fresults]):
-            if os.path.exists(f1):
+            if f1.exists():
                 os.rename(f1, f2)  # rename
                 if str(f2).endswith('.pt'):  # is *.pt
                     strip_optimizer(f2)  # strip optimizer
@@ -520,7 +520,7 @@ if __name__ == '__main__':
             os.system('gsutil cp gs://%s/evolve.txt .' % opt.bucket)  # download evolve.txt if exists
 
         for _ in range(300):  # generations to evolve
-            if os.path.exists('evolve.txt'):  # if evolve.txt exists: select best hyps and mutate
+            if Path('evolve.txt').exists():  # if evolve.txt exists: select best hyps and mutate
                 # Select parent(s)
                 parent = 'single'  # parent selection method: 'single' or 'weighted'
                 x = np.loadtxt('evolve.txt', ndmin=2)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactor file I/O operations from `os` to `pathlib` for enhanced code simplicity and readability.

### 📊 Key Changes
- 🛠 Replaced `os.makedirs` with `Path.mkdir`, using the `pathlib` module for directory creation.
- 🔗 Changed file path concatenation to use `pathlib`'s `/` operator instead of `os.path.join`.
- ✂️ Removed `import os` statements, since `os` module functions are replaced by `pathlib`.
- 🌐 Ensured case-insensitive comparison for URL schemes (http/https) in `detect.py`.
- 📁 Used `.exists()` and `.isnumeric()` methods from `pathlib` for checking file existence and name formats.
- 🎨 Modified how project names are passed to WandB (from basename to stem) in `train.py`.

### 🎯 Purpose & Impact
- 📈 **Code Maintainability:** By using `pathlib`, the code is more Pythonic, readable, and maintainable.
- 🧑‍💻 **Developer Experience:** Simplifies the process of working with file paths for developers, making code contributions and understanding easier.
- 🚀 **Potential User Impact:** As these changes are internal code improvements, end-users will experience no direct impact, but may benefit indirectly from increased code reliability and future enhancements.