### PR TITLE
Add Project Directory structure

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -22,6 +22,7 @@ def detect(save_img=False):
 
     # Directories
     if save_dir == Path('runs/detect'):  # if default
+        save_dir = opt.project / save_dir
         save_dir.mkdir(parents=True, exist_ok=True)  # make base
         save_dir = Path(increment_dir(save_dir / 'exp', opt.name))  # increment run
     (save_dir / 'labels' if save_txt else save_dir).mkdir(parents=True, exist_ok=True)  # make new dir
@@ -162,6 +163,8 @@ if __name__ == '__main__':
     parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS')
     parser.add_argument('--augment', action='store_true', help='augmented inference')
     parser.add_argument('--update', action='store_true', help='update all models')
+    parser.add_argument('--project', type=str, default='YOLOv5', help='name of the project: i.e. {project}/runs/{N}_{name}')
+
     opt = parser.parse_args()
     print(opt)
 

--- a/test.py
+++ b/test.py
@@ -47,6 +47,7 @@ def test(data,
 
         # Directories
         if save_dir == Path('runs/test'):  # if default
+            save_dir = opt.project / save_dir
             save_dir.mkdir(parents=True, exist_ok=True)  # make base
             save_dir = Path(increment_dir(save_dir / 'exp', opt.name))  # increment run
         (save_dir / 'labels' if save_txt else save_dir).mkdir(parents=True, exist_ok=True)  # make new dir
@@ -289,6 +290,8 @@ if __name__ == '__main__':
     parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
     parser.add_argument('--save-dir', type=str, default='runs/test', help='directory to save results')
     parser.add_argument('--name', default='', help='name to append to --save-dir: i.e. runs/{N} -> runs/{N}_{name}')
+    parser.add_argument('--project', type=str, default='YOLOv5', help='name of the project: i.e. {project}/runs/{N}_{name}')
+
     opt = parser.parse_args()
     opt.save_json |= opt.data.endswith('coco.yaml')
     opt.data = check_file(opt.data)  # check file

--- a/train.py
+++ b/train.py
@@ -121,7 +121,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
     # Logging
     if wandb and wandb.run is None:
         id = ckpt.get('wandb_id') if 'ckpt' in locals() else None
-        wandb_run = wandb.init(config=opt, resume="allow", project="YOLOv5", name=log_dir.stem, id=id)
+        wandb_run = wandb.init(config=opt, resume="allow", project=opt.project, name=log_dir.stem, id=id)
 
     # Resume
     start_epoch, best_fitness = 0, 0.0
@@ -414,6 +414,7 @@ if __name__ == '__main__':
     parser.add_argument('--name', default='', help='name to append to --save-dir: i.e. runs/{N} -> runs/{N}_{name}')
     parser.add_argument('--log-imgs', type=int, default=10, help='number of images for W&B logging, max 100')
     parser.add_argument('--workers', type=int, default=8, help='maximum number of dataloader workers')
+    parser.add_argument('--project', type=str, default='YOLOv5', help='name of the project')
 
     opt = parser.parse_args()
 

--- a/train.py
+++ b/train.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 def train(hyp, opt, device, tb_writer=None, wandb=None):
     logger.info(f'Hyperparameters {hyp}')
-    log_dir = Path(tb_writer.log_dir) if tb_writer else Path(opt.logdir) / 'evolve'  # logging directory
+    log_dir = Path(tb_writer.log_dir) if tb_writer else Path(opt.project) / Path(opt.logdir) / 'evolve'  # logging directory
     wdir = log_dir / 'weights'  # weights directory
     wdir.mkdir(parents=True, exist_ok=True)
     last = wdir / 'last.pt'
@@ -414,7 +414,7 @@ if __name__ == '__main__':
     parser.add_argument('--name', default='', help='name to append to --save-dir: i.e. runs/{N} -> runs/{N}_{name}')
     parser.add_argument('--log-imgs', type=int, default=10, help='number of images for W&B logging, max 100')
     parser.add_argument('--workers', type=int, default=8, help='maximum number of dataloader workers')
-    parser.add_argument('--project', type=str, default='YOLOv5', help='name of the project')
+    parser.add_argument('--project', type=str, default='YOLOv5', help='name of the project: i.e. {project}/runs/{N}_{name}')
 
     opt = parser.parse_args()
 
@@ -441,7 +441,7 @@ if __name__ == '__main__':
         opt.data, opt.cfg, opt.hyp = check_file(opt.data), check_file(opt.cfg), check_file(opt.hyp)  # check files
         assert len(opt.cfg) or len(opt.weights), 'either --cfg or --weights must be specified'
         opt.img_size.extend([opt.img_size[-1]] * (2 - len(opt.img_size)))  # extend to 2 sizes (train, test)
-        log_dir = increment_dir(Path(opt.logdir) / 'exp', opt.name)  # runs/exp1
+        log_dir = increment_dir(Path(opt.project) / Path(opt.logdir) / 'exp', opt.name)  # runs/exp1
 
     # DDP mode
     device = select_device(opt.device, batch_size=opt.batch_size)

--- a/utils/general.py
+++ b/utils/general.py
@@ -60,7 +60,7 @@ def init_seeds(seed=0):
     init_torch_seeds(seed)
 
 
-def get_latest_run(search_dir='./runs'):
+def get_latest_run(search_dir='./'):
     # Return path to most recent 'last.pt' in /runs (i.e. to --resume from)
     last_list = glob.glob(f'{search_dir}/**/last*.pt', recursive=True)
     return max(last_list, key=os.path.getctime) if last_list else ''


### PR DESCRIPTION
## This PR adds support for organizing your runs by the projects
you can pass the project name as `--project` argparse.
### Old directory convention
`runs/[train/test/detect]/ex{N}_{name}`
### New convention introduced by this PR
`{project}/runs/[train/test/detect]/ex{N}_{name}`

@glenn-jocher This is the convention that I'm using to get this PR started. It'll be easier to discuss the edits, modifications and edge cases here.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of custom project directories for model outputs in Ultralytics YOLOv5.

### 📊 Key Changes
- Added a new `--project` argument across detection, testing, and training scripts allowing for custom project naming.
- Changed default save directories in `detect.py`, `test.py`, and `train.py` to utilize the `--project` argument, enabling structured project-specific output paths.
- Modified `get_latest_run` function in `utils/general.py` to search for the most recent run in a more generalized directory.

### 🎯 Purpose & Impact
- 🎨 Allows users to organize their outputs in custom project directories, enhancing project management and file organization.
- 🔍 Facilitates easier resumption of work with models by providing a more intuitive way to locate the latest run through the updated search functionality.
- 🚀 Potential to improve user workflow, particularly for those working on multiple projects, by simplifying the distinction between different sets of results, training sessions, or experiments.