### PR TITLE
W&B evolution bug fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -323,7 +323,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                                                  dataloader=testloader,
                                                  save_dir=log_dir,
                                                  plots=epoch == 0 or final_epoch,  # plot first and last
-                                                 log_imgs=opt.log_imgs)
+                                                 log_imgs=opt.log_imgs if wandb else 0)
 
             # Write
             with open(results_file, 'a') as f:
@@ -475,7 +475,6 @@ if __name__ == '__main__':
 
                 assert os.environ.get('WANDB_DISABLED') != 'true'
             except (ImportError, AssertionError):
-                opt.log_imgs = 0
                 logger.info("Install Weights & Biases for experiment logging via 'pip install wandb' (recommended)")
 
         train(hyp, opt, device, tb_writer, wandb)


### PR DESCRIPTION
W&B bug fix for playing nice with hyperparameter evolution. Addresses bug https://github.com/ultralytics/yolov5/issues/1356.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved integration with Weights & Biases in the YOLOv5 training script.

### 📊 Key Changes
- Modified the number of logged images to zero when WandB (Weights & Biases) is not used.
- Removed code that automatically sets image logging to zero when WandB import fails or is disabled.

### 🎯 Purpose & Impact
- Ensures that image logging only occurs if WandB is active, preventing unnecessary logging and saving resources. 🛠️
- Cleans up the training script by removing an automated override, putting more control into the hands of the user. 🧑‍💻
- Non-WandB users won't have potential overhead from image logging, leading to potentially faster and cleaner training runs. ⏱
- Users intending to use WandB need to ensure it's properly installed and enabled to take full advantage of image logging features. 🔍