### PR TITLE
Trailing --save-txt whitespace bug fix

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -107,7 +107,7 @@ def detect(save_img=False):
                         xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
                         line = (cls, *xywh, conf) if opt.save_conf else (cls, *xywh)  # label format
                         with open(txt_path + '.txt', 'a') as f:
-                            f.write((('%g ' * len(line)).rstrip() + '\n') % line)
+                            f.write(('%g ' * len(line)).rstrip() % line + '\n')
 
                     if save_img or view_img:  # Add bbox to image
                         label = '%s %.2f' % (names[int(cls)], conf)

--- a/detect.py
+++ b/detect.py
@@ -107,7 +107,7 @@ def detect(save_img=False):
                         xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
                         line = (cls, *xywh, conf) if opt.save_conf else (cls, *xywh)  # label format
                         with open(txt_path + '.txt', 'a') as f:
-                            f.write(('%g ' * len(line) + '\n') % line)
+                            f.write((('%g ' * len(line)).rstrip() + '\n') % line)
 
                     if save_img or view_img:  # Add bbox to image
                         label = '%s %.2f' % (names[int(cls)], conf)

--- a/test.py
+++ b/test.py
@@ -140,7 +140,7 @@ def test(data,
                     xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
                     line = (cls, *xywh, conf) if save_conf else (cls, *xywh)  # label format
                     with open(str(save_dir / 'labels' / Path(paths[si]).stem) + '.txt', 'a') as f:
-                        f.write(('%g ' * len(line) + '\n') % line)
+                        f.write(('%g ' * len(line)).rstrip() % line + '\n')
 
             # W&B logging
             if len(wandb_images) < log_imgs:


### PR DESCRIPTION
Remove the whitespace at the end of each line of label txt file which generated by using '--save-dir' argument in detect.py, this fix the bug of LabelImg cannot display the bbox of the generated txt file when you are pseudo labeling.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to text file formatting in detection and testing scripts.

### 📊 Key Changes
- Adjusted the string formatting code in both `detect.py` and `test.py`.
- Removed any trailing spaces before the newline character when writing to text files.

### 🎯 Purpose & Impact
- 🎨 Enhances the consistency and cleanliness of text file outputs by ensuring no extra spaces are added at the end of each line.
- 👍 Users will experience more standardized output files, beneficial for downstream processes that might consume these files.