### PR TITLE
Resume fix for yaml constructor posixpath error

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,7 +143,6 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
         start_epoch = ckpt['epoch'] + 1
         if opt.resume:
             assert start_epoch > 0, '%s training to %g epochs is finished, nothing to resume.' % (weights, epochs)
-            shutil.copytree(wdir, wdir.parent / f'weights_backup_epoch{start_epoch - 1}')  # save previous weights
         if epochs < start_epoch:
             logger.info('%s has been trained for %g epochs. Fine-tuning for %g additional epochs.' %
                         (weights, ckpt['epoch'], epochs))

--- a/train.py
+++ b/train.py
@@ -50,6 +50,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
     with open(save_dir / 'hyp.yaml', 'w') as f:
         yaml.dump(hyp, f, sort_keys=False)
     with open(save_dir / 'opt.yaml', 'w') as f:
+        opt.save_dir = str(save_dir)  # yaml constructor can not read PosixPath
         yaml.dump(vars(opt), f, sort_keys=False)
 
     # Configure

--- a/train.py
+++ b/train.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 def train(hyp, opt, device, tb_writer=None, wandb=None):
     logger.info(f'Hyperparameters {hyp}')
     save_dir, epochs, batch_size, total_batch_size, weights, rank = \
-        opt.save_dir, opt.epochs, opt.batch_size, opt.total_batch_size, opt.weights, opt.global_rank
+        Path(opt.save_dir), opt.epochs, opt.batch_size, opt.total_batch_size, opt.weights, opt.global_rank
 
     # Directories
     wdir = save_dir / 'weights'
@@ -50,7 +50,6 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
     with open(save_dir / 'hyp.yaml', 'w') as f:
         yaml.dump(hyp, f, sort_keys=False)
     with open(save_dir / 'opt.yaml', 'w') as f:
-        opt.save_dir = str(save_dir)  # yaml constructor can not read PosixPath
         yaml.dump(vars(opt), f, sort_keys=False)
 
     # Configure
@@ -432,9 +431,8 @@ if __name__ == '__main__':
     # Resume
     if opt.resume:  # resume an interrupted run
         ckpt = opt.resume if isinstance(opt.resume, str) else get_latest_run()  # specified or most recent path
-        opt.save_dir = Path(ckpt).parent.parent  # runs/train/exp
         assert os.path.isfile(ckpt), 'ERROR: --resume checkpoint does not exist'
-        with open(opt.save_dir / 'opt.yaml') as f:
+        with open(Path(ckpt).parent.parent / 'opt.yaml') as f:
             opt = argparse.Namespace(**yaml.load(f, Loader=yaml.FullLoader))  # replace
         opt.cfg, opt.weights, opt.resume = '', ckpt, True
         logger.info('Resuming training from %s' % ckpt)
@@ -444,7 +442,7 @@ if __name__ == '__main__':
         assert len(opt.cfg) or len(opt.weights), 'either --cfg or --weights must be specified'
         opt.img_size.extend([opt.img_size[-1]] * (2 - len(opt.img_size)))  # extend to 2 sizes (train, test)
         opt.name = 'evolve' if opt.evolve else opt.name
-        opt.save_dir = Path(increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok))  # increment run
+        opt.save_dir = increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok)  # increment run
 
     # DDP mode
     device = select_device(opt.device, batch_size=opt.batch_size)
@@ -518,7 +516,7 @@ if __name__ == '__main__':
         assert opt.local_rank == -1, 'DDP mode not implemented for --evolve'
         opt.notest, opt.nosave = True, True  # only test/save final epoch
         # ei = [isinstance(x, (int, float)) for x in hyp.values()]  # evolvable indices
-        yaml_file = opt.save_dir / 'hyp_evolved.yaml'  # save best result here
+        yaml_file = Path(opt.save_dir) / 'hyp_evolved.yaml'  # save best result here
         if opt.bucket:
             os.system('gsutil cp gs://%s/evolve.txt .' % opt.bucket)  # download evolve.txt if exists
 


### PR DESCRIPTION
This PR attempts to fix a --resume bug following PR https://github.com/ultralytics/yolov5/pull/1377.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlined file and directory handling in YOLOv5 training script.

### 📊 Key Changes
- 🛠 Changed `opt.save_dir` to always be a `Path` object for consistent directory handling.
- 🗑️ Removed automatic backup of weights during training to avoid unnecessary file duplication.
- 🚀 Adjusted checkpoint loading logic to directly use checkpoint directory path when resuming training.
- 📁 Standardized the use of `Path` objects when constructing file paths for improved clarity and maintainability.

### 🎯 Purpose & Impact
- 💾 These changes aim to simplify the codebase, reducing the potential for errors related to file paths.
- 🧹 By avoiding unnecessary weight backups, the training process is decluttered, saving disk space.
- 🛤️ Provides a clearer and more robust framework for file path operations, which should help users and developers avoid path-related bugs.
- 🚀 Enhancing maintainability and readability of the code can facilitate further development and user engagement with the YOLOv5 project.