### PR TITLE
Update img2label_paths()

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -337,7 +337,15 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         def img2label_paths(img_paths):
             # Define label paths as a function of image paths
             sa, sb = os.sep + 'images' + os.sep, os.sep + 'labels' + os.sep  # /images/, /labels/ substrings
-            return [x.replace(sa, sb, 1).replace(x.split('.')[-1], 'txt') for x in img_paths]
+            label_paths = []
+            for x in img_paths:
+              y = list(x.replace(sa, sb, 1).rpartition('.'))
+              y[-1] = y[-1].replace(x.split('.')[-1], 'txt')
+              y = ''.join(y)
+              label_paths.append(y)
+
+            return label_paths
+
 
         try:
             f = []  # image files

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -337,15 +337,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         def img2label_paths(img_paths):
             # Define label paths as a function of image paths
             sa, sb = os.sep + 'images' + os.sep, os.sep + 'labels' + os.sep  # /images/, /labels/ substrings
-            label_paths = []
-            for x in img_paths:
-              y = list(x.replace(sa, sb, 1).rpartition('.'))
-              y[-1] = y[-1].replace(x.split('.')[-1], 'txt')
-              y = ''.join(y)
-              label_paths.append(y)
-
-            return label_paths
-
+            return [x.replace(sa, sb, 1).replace('.' + x.split('.')[-1], '.txt') for x in img_paths]
 
         try:
             f = []  # image files


### PR DESCRIPTION
If 'jpg' is in the label path name, the label pathing breaks because it is replaced in img2label_paths. 

For example, the data loader is looking for `16-11-2020-11-39-50_txt.rf.0623d8e59ab0a70dc69de2088a0bb17e.txt`, but should be looking for `16-11-2020-11-39-50_jpg.rf.0623d8e59ab0a70dc69de2088a0bb17e.txt`. 

We commonly export files with _jpg in the image file path body (maybe a legacy thing), and those training flows are breaking. 

This PR only replaces the label file extension in img2label_paths. And should still work with the dynamic file pathing. 



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image to label path conversion in dataset handling.

### 📊 Key Changes
- Modified the `img2label_paths` function to properly replace the file extension with `.txt` for associated label files.

### 🎯 Purpose & Impact
- 🎨 **Purpose**: This change ensures that when transforming an image path into its corresponding label path, the function accurately changes the extension to `.txt`. Previously, the extension replacement might have not worked correctly if the filename contained multiple periods.
- ✅ **Impact**: Users will experience more reliable dataset preparation, especially if their image filenames include multiple dots. This will lead to fewer errors and smoother training of models using the YOLOv5 framework.