### PR TITLE
Cat apriori to autolabels

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -137,7 +137,8 @@ def detect(save_img=False):
                     vid_writer.write(im0)
 
     if save_txt or save_img:
-        print('Results saved to %s' % save_dir)
+        s = f"\n{len(list(save_dir.glob('labels/*.txt')))} labels saved to {save_dir / 'labels'}" if save_txt else ''
+        print(f"Results saved to {save_dir}{s}")
 
     print('Done. (%.3fs)' % (time.time() - t0))
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -263,7 +263,7 @@ def wh_iou(wh1, wh2):
     return inter / (wh1.prod(2) + wh2.prod(2) - inter)  # iou = inter / (area1 + area2 - inter)
 
 
-def non_max_suppression(prediction, conf_thres=0.1, iou_thres=0.6, merge=False, classes=None, agnostic=False):
+def non_max_suppression(prediction, conf_thres=0.1, iou_thres=0.6, classes=None, agnostic=False, labels=()):
     """Performs Non-Maximum Suppression (NMS) on inference results
 
     Returns:
@@ -279,6 +279,7 @@ def non_max_suppression(prediction, conf_thres=0.1, iou_thres=0.6, merge=False, 
     time_limit = 10.0  # seconds to quit after
     redundant = True  # require redundant detections
     multi_label = nc > 1  # multiple labels per box (adds 0.5ms/img)
+    merge = False  # use merge-NMS
 
     t = time.time()
     output = [torch.zeros(0, 6)] * prediction.shape[0]
@@ -286,6 +287,15 @@ def non_max_suppression(prediction, conf_thres=0.1, iou_thres=0.6, merge=False, 
         # Apply constraints
         # x[((x[..., 2:4] < min_wh) | (x[..., 2:4] > max_wh)).any(1), 4] = 0  # width-height
         x = x[xc[xi]]  # confidence
+
+        # Cat apriori labels if autolabelling
+        if labels and len(labels[xi]):
+            l = labels[xi]
+            v = torch.zeros((len(l), nc + 5), device=x.device)
+            v[:, :4] = l[:, 1:5]  # box
+            v[:, 4] = 1.0  # conf
+            v[range(len(l)), l[:, 0].long() + 5] = 1.0  # cls
+            x = torch.cat((x, v), 0)
 
         # If none remain process next image
         if not x.shape[0]:


### PR DESCRIPTION
This PR concats apriori labels to any newly generated autolabels in test.py by default. To autolabel existing datasets without concating apriori labels, use detect.py --save-txt or test.py --save-txt pointed to a data.yaml that does not have any /labels/ associated with it's /images/ path.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced detection result storage, label handling during testing, and NMS functionality in YOLOv5.

### 📊 Key Changes
- Detect.py now provides the number of label files saved when saving text results.
- Test.py scales targets directly without a separate weight tensor and supports automatic labelling during NMS.
- Non_max_suppression in utils/general.py includes a new parameter for supporting automatic labelling, and it no longer uses the merge flag (i.e., merge-NMS is disabled).

### 🎯 Purpose & Impact
- The printing enhancements in detect.py and test.py clarify the output to the user, especially regarding where results are saved. 🏷️
- Adjustments to target scaling streamline the code in test.py and may make the testing process more efficient. 📉
- The introduction of labels as an argument in non_max_suppression allows for better integration with autolabeling, which could lead to improved training with custom datasets. 🤖
- Removing merge-NMS can simplify the codebase and reduce complexity, potentially making the NMS process more transparent and maintainable. 🔍