### PR TITLE
Prevent PR plotting

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -64,7 +64,7 @@ def ap_per_class(tp, conf, pred_cls, target_cls, plot=False, save_dir='precision
             # AP from recall-precision curve
             for j in range(tp.shape[1]):
                 ap[ci, j], mpre, mrec = compute_ap(recall[:, j], precision[:, j])
-                if j == 0:
+                if plot and (j == 0):
                     py.append(np.interp(px, mrec, mpre))  # precision at mAP@0.5
 
     # Compute F1 score (harmonic mean of precision and recall)


### PR DESCRIPTION
Minor PR to prevent PR curve computation when not in plotting mode.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved plotting logic in metrics for object detection models.

### 📊 Key Changes
- Modified the condition for precision plotting to only execute when `plot` is set to `True`.

### 🎯 Purpose & Impact
- Ensures that precision plotting occurs only during active plot requests, leading to optimized performance and clarity.
- Users not seeking to plot precision metrics will experience more streamlined evaluations, while those using plotting features will continue to have their precision metrics visualized as expected. 📈