### PR TITLE
--image_weights bug fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -181,8 +181,9 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
 
     # Trainloader
     dataloader, dataset = create_dataloader(train_path, imgsz, batch_size, gs, opt,
-                                            hyp=hyp, augment=True, cache=opt.cache_images, rect=opt.rect,
-                                            rank=rank, world_size=opt.world_size, workers=opt.workers)
+                                            hyp=hyp, augment=True, cache=opt.cache_images, rect=opt.rect, rank=rank,
+                                            world_size=opt.world_size, workers=opt.workers,
+                                            image_weights=opt.image_weights)
     mlc = np.concatenate(dataset.labels, 0)[:, 0].max()  # max label class
     nb = len(dataloader)  # number of batches
     assert mlc < nc, 'Label class %g exceeds nc=%g in %s. Possible class labels are 0-%g' % (mlc, nc, opt.data, nc - 1)


### PR DESCRIPTION
Bug fixes for --image_weights.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved data loading with 'image_weights' parameter for batch sampling.

### 📊 Key Changes
- Added `image_weights` option to `create_dataloader` and dataset initialization to influence image sampling during training.
- Ensured even when `image_weights` are used, the indices remain in valid range and prevent potential out-of-range errors.
- Made `image_weights` influence the selection of additional images in mosaic augmentation.

### 🎯 Purpose & Impact
- The `image_weights` parameter aims to provide more control over the probability of an image being included in a training batch, potentially improving training on imbalanced datasets.
- This feature could lead to better model performance by emphasizing harder-to-learn or under-represented samples.
- Users will benefit from more versatile data loading and potentially improved model accuracy.