### PR TITLE
Ignore W&B logging dir wandb/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,6 +49,7 @@ sdist/
 var/
 wheels/
 *.egg-info/
+wandb/
 .installed.cfg
 *.egg
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Docker build efficiency by updating ignore rules.

### 📊 Key Changes
- Added `wandb/` directory to the `.dockerignore` file.

### 🎯 Purpose & Impact
- **Purpose:** To prevent the `wandb/` (Weights & Biases) directory from being included in the Docker build context, reducing unnecessary data transfer.
- **Impact:** Speeds up Docker builds and keeps images smaller for users, especially beneficial for those using Weights & Biases for experiment tracking. 🚀