### PR TITLE
FROM nvcr.io/nvidia/pytorch:20.10-py3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Start FROM latest PyTorch image https://hub.docker.com/r/pytorch/pytorch
-FROM pytorch/pytorch:latest
+# Start FROM Nvidia PyTorch image https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
+FROM nvcr.io/nvidia/pytorch:20.10-py3
 
 # Install dependencies
 RUN pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Start FROM Nvidia PyTorch image https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
-FROM nvcr.io/nvidia/pytorch:20.11-py3
+# Start FROM latest PyTorch image https://hub.docker.com/r/pytorch/pytorch
+FROM pytorch/pytorch:latest
 
 # Install dependencies
 RUN pip install --upgrade pip
@@ -28,7 +28,7 @@ COPY . /usr/src/app
 # for v in {300..303}; do t=ultralytics/coco:v$v && sudo docker build -t $t . && sudo docker push $t; done
 
 # Pull and Run
-# t=ultralytics/yolov5:latest && sudo docker pull $t && sudo docker run -it --ipc=host $t
+# t=ultralytics/yolov5:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all $t
 
 # Pull and Run with local directory access
 # t=ultralytics/yolov5:latest && sudo docker pull $t && sudo docker run -it --ipc=host --gpus all -v "$(pwd)"/coco:/usr/src/coco $t


### PR DESCRIPTION
Fixes bug #1552.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update YOLOv5 Docker base image and improve GPU support in containers.

### 📊 Key Changes
- Downgrade base Docker image from `nvcr.io/nvidia/pytorch:20.11-py3` to `nvcr.io/nvidia/pytorch:20.10-py3`.
- Enrich Docker run command with `--gpus all` flag for better GPU utilization.

### 🎯 Purpose & Impact
- **Compatibility**: Changing the base image might resolve compatibility issues with specific CUDA or cuDNN versions.
- **GPU Utilization**: With the `--gpus all` flag, users can now directly allocate all available GPUs to the YOLOv5 Docker container, improving training and inference performance.
- Users should experience smoother Docker setup and potentially faster model operations due to enhanced GPU support. 💨🚀