### PR TITLE
RuntimeError: cuDNN error: CUDNN_STATUS_INTERNAL_ERROR fix

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -78,7 +78,6 @@ def create_dataloader(path, imgsz, batch_size, stride, opt, hyp=None, augment=Fa
                         batch_size=batch_size,
                         num_workers=nw,
                         sampler=sampler,
-                        pin_memory=True,
                         collate_fn=LoadImagesAndLabels.collate_fn)
     return dataloader, dataset
 


### PR DESCRIPTION
The issue is not general and can only be reproduced by certain environment.

A possible reason of the bug could be the none fixed size of the label yield from the dataloader as the `collect_fn` does.

reference: [Pinned Host Memory](https://developer.nvidia.com/blog/how-optimize-data-transfers-cuda-cc/)

https://github.com/ultralytics/yolov5/issues/1546
https://github.com/ultralytics/yolov5/issues/1547
https://github.com/ultralytics/yolov5/issues/1573

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved DataLoader flexibility in YOLOv5.

### 📊 Key Changes
- Removed the `pin_memory=True` argument from DataLoader instantiation.

### 🎯 Purpose & Impact
- This change is aimed at making the data loading process more adaptable, as `pin_memory` may not always be necessary or beneficial depending on the user's hardware setup.
- Users might experience different memory usage characteristics, potentially reducing memory overhead on systems where pinning memory doesn't provide performance benefits.