### PR TITLE
Fix: Log Plots in each step.

### DIFF
--- a/test.py
+++ b/test.py
@@ -81,6 +81,7 @@ def test(data,
         import wandb  # Weights & Biases
     except ImportError:
         log_imgs = 0
+
     # Dataloader
     if not training:
         img = torch.zeros((1, 3, imgsz, imgsz), device=device)  # init img

--- a/test.py
+++ b/test.py
@@ -81,7 +81,6 @@ def test(data,
         import wandb  # Weights & Biases
     except ImportError:
         log_imgs = 0
-
     # Dataloader
     if not training:
         img = torch.zeros((1, 3, imgsz, imgsz), device=device)  # init img
@@ -240,7 +239,7 @@ def test(data,
     if plots:
         confusion_matrix.plot(save_dir=save_dir, names=list(names.values()))
         if wandb and wandb.run:
-            wandb.log({"Images": wandb_images})
+            wandb.log({"Debug Bounding Boxes/Images": wandb_images})
             wandb.log({"Validation": [wandb.Image(str(f), caption=f.name) for f in sorted(save_dir.glob('test*.jpg'))]})
 
     # Save JSON

--- a/train.py
+++ b/train.py
@@ -339,7 +339,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                                                  single_cls=opt.single_cls,
                                                  dataloader=testloader,
                                                  save_dir=save_dir,
-                                                 plots=plots and final_epoch,
+                                                 plots=plots or final_epoch,
                                                  log_imgs=opt.log_imgs if wandb else 0)
 
             # Write


### PR DESCRIPTION
I noticed that the logic to set `plot` argument when calling `test.test()` was set to -> `plots=plots and final_epoch`, which doesn't make sense as this logic will only evaluate to true on the last epoch. So, the bounding box debugging and validation plots become useless.

## This PR Adds:
* Fixed plots logic (`plots=plots or final_epoch`)
* Assign a new section to bounding box debugging images so that they don't get lost in the static media section

@glenn-jocher Should I also make the same PR for yolov3 repo as well?

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced WandB logging and fixed conditional plotting logic in test and training scripts.

### 📊 Key Changes
- In `test.py`, updated the WandB logging label from "Images" to "Debug Bounding Boxes/Images".
- Altered the condition for plotting in `train.py` from `and` to `or`, ensuring plots are generated in more scenarios.

### 🎯 Purpose & Impact
- 🤖 The new label for WandB logging intends to provide clearer context to users reviewing the logged images, indicating that they include debug information in the form of bounding boxes.
- 📈 The change to the conditional logic for generating plots means users will receive visual feedback (i.e., plots) either when `plots` is set to `True` or when it is the `final_epoch` during training, improving the usability and diagnostic capabilities of the training process.
- 🧑‍🔬 This update can lead to better monitoring and evaluation of model performance throughout the training lifecycle, particularly beneficial for developers and researchers focused on model accuracy and diagnostics.