### PR TITLE
plot_images() scale bug fix

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -141,9 +141,12 @@ def plot_images(images, targets, paths=None, fname='images.jpg', names=None, max
             labels = image_targets.shape[1] == 6  # labels if no conf column
             conf = None if labels else image_targets[:, 6]  # check for confidence presence (label vs pred)
 
-            if boxes.shape[1] and boxes.max() <= 1:  # if normalized
-                boxes[[0, 2]] *= w  # scale to pixels
-                boxes[[1, 3]] *= h
+            if boxes.shape[1]:
+                if boxes.max() <= 1:  # if normalized
+                    boxes[[0, 2]] *= w  # scale to pixels
+                    boxes[[1, 3]] *= h
+                elif scale_factor < 1: # absolute coords need scale if image scales
+                    boxes *= scale_factor
             boxes[[0, 2]] += block_x
             boxes[[1, 3]] += block_y
             for j, box in enumerate(boxes.T):


### PR DESCRIPTION
fix bugs in plot_images, if img_size > 640, the boxes are not correct

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced bounding box scaling in image plotting for diverse coordinate systems.

### 📊 Key Changes
- Improved bounding box scaling logic within the image plotting function.
- Added support for absolute coordinate scaling based on an image's scale factor.

### 🎯 Purpose & Impact
- Ensures that bounding boxes are accurately overlaid on images, regardless of whether the box coordinates are normalized or absolute.
- Provides better visual debugging and analysis for users by correctly scaling boxes, improving the utility of the visual outputs. 📈
- Users working with images at different scales can now expect consistent and correct annotations, enhancing the reliability of the visualization tools in YOLOv5. 🎨