### PR TITLE
Update matplotlib svg backend

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -21,7 +21,7 @@ from utils.metrics import fitness
 
 # Settings
 matplotlib.rc('font', **{'size': 11})
-matplotlib.use('Agg')  # for writing to files only
+matplotlib.use('svg')  # for writing to files only
 
 
 def color_list():


### PR DESCRIPTION
This PR updates the default matplotlib backend from 'Agg' to 'svg'. This backend demonstrated the fastest canvas drawing speeds of all noninteractive backends tested. Tested plotting speeds on VOC labels.png: 'Agg' 5.4 seconds, 'svg' 2.4 seconds.

> def use(backend, *, force=True):
>     """
>     Select the backend used for rendering and GUI integration.
> 
>     Parameters
>     ----------
>     backend : str
>         The backend to switch to.  This can either be one of the standard
>         backend names, which are case-insensitive:
> 
>         - interactive backends:
>           GTK3Agg, GTK3Cairo, MacOSX, nbAgg,
>           Qt4Agg, Qt4Cairo, Qt5Agg, Qt5Cairo,
>           TkAgg, TkCairo, WebAgg, WX, WXAgg, WXCairo
> 
>         - non-interactive backends:
>           agg, cairo, pdf, pgf, ps, svg, template

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement in image output format for YOLOv5 visualizations.

### 📊 Key Changes
- Altered the default matplotlib backend setting from 'Agg' to 'svg'.

### 🎯 Purpose & Impact
- 🎨 **Purpose**: To improve the quality and scalability of plot outputs by switching to the SVG (Scalable Vector Graphics) format.
- 🔍 **Impact**: Users will experience enhanced visual quality in saved plots, as SVG maintains clarity at any zoom level, contributing to better presentations and analysis. Additionally, SVG files can be more easily edited post-generation if needed.