### PR TITLE
Add bias to Classify()

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -1,7 +1,6 @@
 # This file contains modules common to various models
 
 import math
-
 import numpy as np
 import torch
 import torch.nn as nn
@@ -244,7 +243,7 @@ class Classify(nn.Module):
     def __init__(self, c1, c2, k=1, s=1, p=None, g=1):  # ch_in, ch_out, kernel, stride, padding, groups
         super(Classify, self).__init__()
         self.aap = nn.AdaptiveAvgPool2d(1)  # to x(b,c1,1,1)
-        self.conv = nn.Conv2d(c1, c2, k, s, autopad(k, p), groups=g, bias=False)  # to x(b,c2,1,1)
+        self.conv = nn.Conv2d(c1, c2, k, s, autopad(k, p), groups=g)  # to x(b,c2,1,1)
         self.flat = Flatten()
 
     def forward(self, x):


### PR DESCRIPTION
This PR adds the default nn.Conv2d() bias to the Classify() head, fixing a minor mistake.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Classify module by tweaking convolutional layer configuration.

### 📊 Key Changes
- Removed an unnecessary blank line for better code formatting.
- Updated the `Conv2d` layer in the `Classify` class by removing the `bias=False` argument.

### 🎯 Purpose & Impact
- Enhances the code cleanliness, making it more readable and maintainable.
- The removal of `bias=False` could potentially allow the `Conv2d` layer to learn an additional bias term, possibly improving the model's flexibility and performance on certain tasks.
- Users may experience subtle improvements in the performance of models using the `Classify` module due to this change.