### PR TITLE
Implement default class names

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -1,15 +1,15 @@
 import argparse
 import logging
-import math
 import sys
 from copy import deepcopy
 from pathlib import Path
 
-sys.path.append('./')  # to run '$ python *.py' files in subdirectories
-logger = logging.getLogger(__name__)
-
+import math
 import torch
 import torch.nn as nn
+
+sys.path.append('./')  # to run '$ python *.py' files in subdirectories
+logger = logging.getLogger(__name__)
 
 from models.common import Conv, Bottleneck, SPP, DWConv, Focus, BottleneckCSP, Concat, NMS, autoShape
 from models.experimental import MixConv2d, CrossConv, C3
@@ -82,6 +82,7 @@ class Model(nn.Module):
             logger.info('Overriding model.yaml nc=%g with nc=%g' % (self.yaml['nc'], nc))
             self.yaml['nc'] = nc  # override yaml value
         self.model, self.save = parse_model(deepcopy(self.yaml), ch=[ch])  # model, savelist, ch_out
+        self.names = [str(i) for i in range(self.yaml['nc'])]  # default names
         # print([x.shape for x in self.forward(torch.zeros(1, ch, 64, 64))])
 
         # Build strides, anchors


### PR DESCRIPTION
This PR implements default class names on model construction, partly addressing issue #1605.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced YOLO initialization and logging improvements.

### 📊 Key Changes
- Reordered import statements to group similar items together for better readability (`math` import moved up).
- Added default `self.names` initialization within the YOLO `__init__` method.

### 🎯 Purpose & Impact
- The reordering of imports and slight code rearrangement serves to make the code more maintainable and readable, aligning with Python best practices.
- By setting `self.names`, the initialization ensures that even if `nc` (number of classes) is modified, the model has a default naming scheme for classes. This change is geared towards improving the user experience by providing a more robust class handling mechanism, potentially leading to fewer errors when custom classes are not explicitly named. 🛠💡