### PR TITLE
Hybrid auto-labelling support

### DIFF
--- a/test.py
+++ b/test.py
@@ -33,7 +33,8 @@ def test(data,
          dataloader=None,
          save_dir=Path(''),  # for saving images
          save_txt=False,  # for auto-labelling
-         save_conf=False,
+         save_hybrid=False,  # for hybrid auto-labelling
+         save_conf=False,  # save auto-label confidences
          plots=True,
          log_imgs=0):  # number of logged images
 
@@ -45,7 +46,6 @@ def test(data,
     else:  # called directly
         set_logging()
         device = select_device(opt.device, batch_size=batch_size)
-        save_txt = opt.save_txt  # save *.txt labels
 
         # Directories
         save_dir = Path(increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok))  # increment run
@@ -115,7 +115,7 @@ def test(data,
 
             # Run NMS
             targets[:, 2:] *= torch.Tensor([width, height, width, height]).to(device)  # to pixels
-            lb = [targets[targets[:, 0] == i, 1:] for i in range(nb)] if save_txt else []  # for autolabelling
+            lb = [targets[targets[:, 0] == i, 1:] for i in range(nb)] if save_hybrid else []  # for autolabelling
             t = time_synchronized()
             output = non_max_suppression(inf_out, conf_thres=conf_thres, iou_thres=iou_thres, labels=lb)
             t1 += time_synchronized() - t
@@ -292,6 +292,7 @@ if __name__ == '__main__':
     parser.add_argument('--augment', action='store_true', help='augmented inference')
     parser.add_argument('--verbose', action='store_true', help='report mAP by class')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
+    parser.add_argument('--save-hybrid', action='store_true', help='save label+prediction hybrid results to *.txt')
     parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
     parser.add_argument('--save-json', action='store_true', help='save a cocoapi-compatible JSON results file')
     parser.add_argument('--project', default='runs/test', help='save to project/name')
@@ -313,7 +314,8 @@ if __name__ == '__main__':
              opt.single_cls,
              opt.augment,
              opt.verbose,
-             save_txt=opt.save_txt,
+             save_txt=opt.save_txt | opt.save_hybrid,
+             save_hybrid=opt.save_hybrid,
              save_conf=opt.save_conf,
              )
 


### PR DESCRIPTION
This PR introduces hybrid autolabelling support in test.py. The auto-labelling options are now:

- `python test.py --save-txt`: traditional auto-labelling
- `python test.py --save-hybrid`: save hybrid autolabels, combining existing labels with new predictions before NMS (existing predictions given confidence=1.0 before NMS.
- `python test.py --save-conf`: add confidences to any of the above commands

Regardless of any of the above settings, be aware that auto-labelling works best at very high confidence thresholds, i.e. 0.90 confidence, whereas mAP computation relies on very low confidence threshold, i.e. 0.001, to properly evaluate the area under the PR curve. **The two activities are thus essentially mutually exclusive, there is no reason I know of to combine the two into a single test run.**

<img width="1299" alt="Screen Shot 2020-12-08 at 6 14 27 PM" src="https://user-images.githubusercontent.com/26833433/101565170-597f2000-3981-11eb-96b1-134705f2d70f.png">


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancing auto-labelling capabilities in YOLOv5 test script with hybrid label saving.

### 📊 Key Changes
- Added a `save_hybrid` argument that allows for hybrid auto-labelling during testing.
- Modified how labels for auto-labelling are created based on the new `save_hybrid` flag.
- `save_txt` usage modified to be dependent on both `save_txt` and `save_hybrid` options.

### 🎯 Purpose & Impact
- 🎨 The `save_hybrid` option introduces a new way to auto-label by combining both labels and predictions, which may improve label accuracy and assist in retraining models.
- 💾 By adjusting the use of `save_txt`, users now have more flexibility in how they choose to save auto-labelled data.
- 🔧 Users will experience enhanced testing capabilities, allowing for more efficient model analysis and dataset improvement.