### PR TITLE
FReLU bias=False bug fix

### DIFF
--- a/utils/activations.py
+++ b/utils/activations.py
@@ -65,7 +65,7 @@ class MemoryEfficientMish(nn.Module):
 class FReLU(nn.Module):
     def __init__(self, c1, k=3):  # ch_in, kernel
         super().__init__()
-        self.conv = nn.Conv2d(c1, c1, k, 1, 1, groups=c1)
+        self.conv = nn.Conv2d(c1, c1, k, 1, 1, groups=c1, bias=False)
         self.bn = nn.BatchNorm2d(c1)
 
     def forward(self, x):


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved the FReLU activation implementation in YOLOv5.

### 📊 Key Changes
- Removed the bias term from the convolution operation within the FReLU activation class.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: To ensure the convolution layer within the FReLU only learns the shape of the activation function without a bias term, potentially streamlining the feature learning process. 
- ⚡ **Impact**: This could lead to more efficient training as the model has fewer parameters to learn, possibly improving the performance and generalization of the neural network on various tasks. Users may experience a slight boost in inference speed and model accuracy.