### PR TITLE
Simplified PyTorch hub custom models

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -106,8 +106,31 @@ def yolov5x(pretrained=False, channels=3, classes=80):
     return create('yolov5x', pretrained, channels, classes)
 
 
+def custom(model='path/to/model.pt'):
+    """YOLOv5-custom model from https://github.com/ultralytics/yolov5
+
+    Arguments (3 format options):
+        model (str): 'path/to/model.pt'
+        model (dict): torch.load('path/to/model.pt')
+        model (nn.Module): 'torch.load('path/to/model.pt')['model']
+
+    Returns:
+        pytorch model
+    """
+    if isinstance(model, str):
+        model = torch.load(model)  # load checkpoint
+    if isinstance(model, dict):
+        model = model['model']  # load model
+
+    hub_model = Model(model.yaml).to(next(model.parameters()).device)  # create
+    hub_model.load_state_dict(model.float().state_dict())  # load state_dict
+    hub_model.names = model.names  # class names
+    return hub_model
+
+
 if __name__ == '__main__':
-    model = create(name='yolov5s', pretrained=True, channels=3, classes=80)  # example
+    model = create(name='yolov5s', pretrained=True, channels=3, classes=80)  # pretrained example
+    # model = custom(model='path/to/model.pt')  # custom example
     model = model.autoshape()  # for PIL/cv2/np inputs and NMS
 
     # Verify inference


### PR DESCRIPTION
This PR simplifies the process of loading a custom YOLOv5-based model (of any architecture) in PyTorch Hub. The new syntax is very simple:

```python
import torch

model = torch.hub.load('ultralytics/yolov5', 'custom', path_or_model='path/to/custom_model.pt')
model = model.autoshape()  # for PIL/cv2/np inputs and NMS

# OR if a custom model is already loaded in the python workspace:
model = torch.hub.load('ultralytics/yolov5', 'custom', path_or_model=custom_model)
model = model.autoshape()  # for PIL/cv2/np inputs and NMS
```



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
New support for loading custom YOLOv5 models directly from user-specified paths.

### 📊 Key Changes
- Added `custom()` function to `hubconf.py` allowing users to load their own trained YOLOv5 models.
- Supports three input formats:
  - A string path to the model `.pt` file.
  - A dictionary object obtained from torch.load().
  - An nn.Module object from the loaded checkpoint.
- Automatically transfers the model to the same device as its parameters.
- Loads the model's `state_dict` and class names (`names`).
- Example usage commented out in the `__main__` block.

### 🎯 Purpose & Impact
- 🚀 Enables users to easily deploy their custom-trained YOLOv5 models for inference.
- 💻 Improves flexibility by supporting different methods for providing the model.
- 🔌 Potentially expands the use cases of YOLOv5 to custom datasets and specialized applications.
- 🌐 Non-expert users benefit from a straightforward way to implement their own models, improving the overall user experience.