### PR TITLE
Fix torch multi-GPU --device error

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -81,9 +81,8 @@ def profile(x, ops, n=100, device=None):
     #     m1 = lambda x: x * torch.sigmoid(x)
     #     m2 = nn.SiLU()
     #     profile(x, [m1, m2], n=100)  # profile speed over 100 iterations
-    if device is None:
-        device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-        
+    
+    device = device or torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')    
     x = x.to(device)
     x.requires_grad = True
     print(torch.__version__, device.type, torch.cuda.get_device_properties(0) if device.type == 'cuda' else '')

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -75,13 +75,15 @@ def time_synchronized():
     return time.time()
 
 
-def profile(x, ops, n=100, device=torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')):
+def profile(x, ops, n=100, device=None):
     # profile a pytorch module or list of modules. Example usage:
     #     x = torch.randn(16, 3, 640, 640)  # input
     #     m1 = lambda x: x * torch.sigmoid(x)
     #     m2 = nn.SiLU()
     #     profile(x, [m1, m2], n=100)  # profile speed over 100 iterations
-
+    if device is None:
+        device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+        
     x = x.to(device)
     x.requires_grad = True
     print(torch.__version__, device.type, torch.cuda.get_device_properties(0) if device.type == 'cuda' else '')


### PR DESCRIPTION
Should fix https://github.com/ultralytics/yolov5/issues/1695 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved device handling for profiling utility in YOLOv5.

### 📊 Key Changes
- Changed the default parameter of `device` from a static assignment to `None`.
- Dynamically setting the device inside the `profile` function if not provided.

### 🎯 Purpose & Impact
- 🛠️ **Flexibility**: This change allows the `profile` function to be more flexible by not forcing a predefined device, enhancing usability across different hardware.
- 💻 **Convenience**: Automatically selects the appropriate device (CPU or GPU), simplifying the function call for users.
- 🚀 **User-Friendly**: Potentially reduces errors for users who forget to specify a device, making the function more robust and user-friendly.