### PR TITLE
Update COCO train postprocessing

### DIFF
--- a/train.py
+++ b/train.py
@@ -402,15 +402,18 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
 
         # Test best.pt
         if opt.data.endswith('coco.yaml') and nc == 80:  # if COCO
-            results, _, _ = test.test(opt.data,
-                                      batch_size=total_batch_size,
-                                      imgsz=imgsz_test,
-                                      model=attempt_load(best if best.exists() else last, device).half(),
-                                      single_cls=opt.single_cls,
-                                      dataloader=testloader,
-                                      save_dir=save_dir,
-                                      save_json=True,  # use pycocotools
-                                      plots=False)
+            for conf, iou, save_json in ([0.25, 0.45, False], [0.001, 0.65, True]):  # speed, mAP tests
+                results, _, _ = test.test(opt.data,
+                                          batch_size=total_batch_size,
+                                          imgsz=imgsz_test,
+                                          conf_thres=conf,
+                                          iou_thres=iou,
+                                          model=attempt_load(best if best.exists() else last, device).half(),
+                                          single_cls=opt.single_cls,
+                                          dataloader=testloader,
+                                          save_dir=save_dir,
+                                          save_json=save_json,
+                                          plots=False)
 
     else:
         dist.destroy_process_group()


### PR DESCRIPTION
This PR updated COCO training post process steps in order to streamline COCO development going forward. Now final mAP and Speed are printed to workspace, and visible in W&B logs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced evaluation metrics in COCO dataset testing with varying thresholds.

### 📊 Key Changes
- Introduced two different test configurations for confidence (`conf_thres`) and IoU (`iou_thres`) thresholds during the COCO evaluation.
- The first set uses a confidence threshold of 0.25 and an IoU threshold of 0.45, designed for speed testing without saving results as JSON.
- The second set adopts a confidence threshold of 0.001 and an IoU threshold of 0.65, targeting accurate mAP (mean Average Precision) evaluation, and saves the results as JSON.

### 🎯 Purpose & Impact
- The update aims to provide a more comprehensive testing regime on the COCO dataset by assessing model performance under different thresholds for speed and accuracy.
- Users can quickly understand how changes in confidence and IoU thresholds affect detection performance, helping them better tailor models according to their needs.
- Considering thresholds at different levels allows for balancing between speed and precision, which could lead to improved applicability of the YOLOv5 model for various real-world scenarios. 🏃💨🎯