### PR TITLE
NMS --classes 0 bug fix

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -311,7 +311,7 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
             x = torch.cat((box, conf, j.float()), 1)[conf.view(-1) > conf_thres]
 
         # Filter by class
-        if classes:
+        if classes is not None:
             x = x[(x[:, 5:6] == torch.tensor(classes, device=x.device)).any(1)]
 
         # Apply finite constraint


### PR DESCRIPTION
I found that if I use only 0 to filter the classes in the non_max_suppression then it won't go through the if statement for the classes. Therefore I added a quick fix.

```python
if classes is not None:
    x = x[(x[:, 5:6] == torch.tensor(classes, device=x.device)).any(1)]

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of class filtering in non-maximum suppression function.

### 📊 Key Changes
- Updated the condition for class filtering from `if classes:` to `if classes is not None:`

### 🎯 Purpose & Impact
- **Purpose:** Ensure that class filtering is correctly applied only when `classes` variable is explicitly set, not just when it's truthy.
- **Impact:** Prevents potential bugs and makes behavior more predictable for end-users when specifying classes for object detection models. This should improve the model's accuracy in scenarios where selective class detection is needed. 🎯🐞

This change will not be immediately noticeable to end-users but ensures more reliable and precise object detection in development.