### PR TITLE
W&B artifacts feature addition

### DIFF
--- a/train.py
+++ b/train.py
@@ -386,10 +386,10 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
 
     if rank in [-1, 0]:
         # Strip optimizers
-        for f in [last, best]:
-            if f.exists():  # is *.pt
-                strip_optimizer(f)  # strip optimizer
-                os.system('gsutil cp %s gs://%s/weights' % (f, opt.bucket)) if opt.bucket else None  # upload
+        final = best if best.exists() else last  # final model
+        (strip_optimizer(f) for f in [last, best] if f.exists())  # strip optimizers
+        if opt.bucket:
+            os.system(f'gsutil cp {final} gs://{opt.bucket}/weights')  # upload
 
         # Plots
         if plots:
@@ -398,9 +398,11 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                 files = ['results.png', 'precision_recall_curve.png', 'confusion_matrix.png']
                 wandb.log({"Results": [wandb.Image(str(save_dir / f), caption=f) for f in files
                                        if (save_dir / f).exists()]})
-        logger.info('%g epochs completed in %.3f hours.\n' % (epoch - start_epoch + 1, (time.time() - t0) / 3600))
+                if opt.log_artifacts:
+                    wandb.log_artifact(wandb.Artifact('model', type=model).add_file(final))
 
         # Test best.pt
+        logger.info('%g epochs completed in %.3f hours.\n' % (epoch - start_epoch + 1, (time.time() - t0) / 3600))
         if opt.data.endswith('coco.yaml') and nc == 80:  # if COCO
             for conf, iou, save_json in ([0.25, 0.45, False], [0.001, 0.65, True]):  # speed, mAP tests
                 results, _, _ = test.test(opt.data,
@@ -408,7 +410,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                                           imgsz=imgsz_test,
                                           conf_thres=conf,
                                           iou_thres=iou,
-                                          model=attempt_load(best if best.exists() else last, device).half(),
+                                          model=attempt_load(final, device).half(),
                                           single_cls=opt.single_cls,
                                           dataloader=testloader,
                                           save_dir=save_dir,
@@ -448,6 +450,7 @@ if __name__ == '__main__':
     parser.add_argument('--sync-bn', action='store_true', help='use SyncBatchNorm, only available in DDP mode')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
     parser.add_argument('--log-imgs', type=int, default=16, help='number of images for W&B logging, max 100')
+    parser.add_argument('--log-artifacts', action='store_true', help='log artifacts, i.e. final trained model')
     parser.add_argument('--workers', type=int, default=8, help='maximum number of dataloader workers')
     parser.add_argument('--project', default='runs/train', help='save to project/name')
     parser.add_argument('--name', default='exp', help='save to project/name')

--- a/train.py
+++ b/train.py
@@ -387,7 +387,9 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
     if rank in [-1, 0]:
         # Strip optimizers
         final = best if best.exists() else last  # final model
-        (strip_optimizer(f) for f in [last, best] if f.exists())  # strip optimizers
+        for f in [last, best]:
+            if f.exists():
+                strip_optimizer(f)  # strip optimizers
         if opt.bucket:
             os.system(f'gsutil cp {final} gs://{opt.bucket}/weights')  # upload
 
@@ -399,7 +401,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                 wandb.log({"Results": [wandb.Image(str(save_dir / f), caption=f) for f in files
                                        if (save_dir / f).exists()]})
                 if opt.log_artifacts:
-                    wandb.log_artifact(wandb.Artifact('model', type=model).add_file(final))
+                    wandb.log_artifact(artifact_or_path=str(final), type='model', name=save_dir.stem)
 
         # Test best.pt
         logger.info('%g epochs completed in %.3f hours.\n' % (epoch - start_epoch + 1, (time.time() - t0) / 3600))


### PR DESCRIPTION
This PR adds W&B artifact upload ability with the `--log-artifacts` flag in train.py. When this flag is used final trained model (`best.pt` if available, else `last.pt` if `--nosave` is used) will be uploaded to the W&B cloud console.

```bash
$ python train.py --log-artifacts
```
<img width="1053" alt="Screen Shot 2020-12-16 at 2 16 01 PM" src="https://user-images.githubusercontent.com/26833433/102413202-6e733900-3fa9-11eb-8f08-3728d13eed9d.png">

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model saving and logging for YOLOv5 training.

### 📊 Key Changes
- Simplified decision logic for choosing between 'best' or 'last' saved models.
- Centralized uploading of the final model to a storage bucket (e.g., Google Cloud Storage).
- Added conditional logging of model artifacts on Weights & Biases (W&B).
- Ensured the final model is used for post-training evaluation.

### 🎯 Purpose & Impact
- **Code Clarity**: Condensed and cleaned up the code dealing with model saving.
- **Efficiency**: Avoids redundant uploads by choosing only the final model for cloud storage.
- **Integration**: Provides better integration with W&B by offering artifact logging.
- **Consistency**: Guarantees the usage of the same final model for subsequent evaluation, ensuring consistent results.

The update streamlines the training end process, making it clearer, more efficient, and better integrated with external tools like W&B, enhancing the user experience for developers leveraging the YOLOv5 training pipeline. 🚀