### PR TITLE
Single class train update

### DIFF
--- a/train.py
+++ b/train.py
@@ -71,7 +71,8 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
         check_dataset(data_dict)  # check
     train_path = data_dict['train']
     test_path = data_dict['val']
-    nc, names = (1, ['item']) if opt.single_cls else (int(data_dict['nc']), data_dict['names'])  # number classes, names
+    nc = 1 if opt.single_cls else int(data_dict['nc'])  # number of classes
+    names = ['item'] if opt.single_cls and len(data_dict['names']) != 1 else data_dict['names']  # class names
     assert len(names) == nc, '%g names found for nc=%g dataset in %s' % (len(names), nc, opt.data)  # check
 
     # Model
@@ -447,7 +448,7 @@ if __name__ == '__main__':
     parser.add_argument('--image-weights', action='store_true', help='use weighted image selection for training')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--multi-scale', action='store_true', help='vary img-size +/- 50%%')
-    parser.add_argument('--single-cls', action='store_true', help='train as single-class dataset')
+    parser.add_argument('--single-cls', action='store_true', help='train multi-class data as single-class')
     parser.add_argument('--adam', action='store_true', help='use torch.optim.Adam() optimizer')
     parser.add_argument('--sync-bn', action='store_true', help='use SyncBatchNorm, only available in DDP mode')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')


### PR DESCRIPTION
Fix for 'item' class appearing on forced `--single-cls` training of existing single class datasets. See  https://github.com/ultralytics/yolov5/issues/12#issuecomment-747246875

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of single-class mode training in YOLOv5.

### 📊 Key Changes
- Tweaked the logic setting up the number of classes (`nc`) and the names of the classes (`names`) for single-class datasets in `train.py`.
- Amended the help description for the `--single-cls` argument to clarify its purpose.

### 🎯 Purpose & Impact
- 🎯 The adjustment ensures that single-class training mode correctly handles the class names within the dataset, whether there is only one name or multiple names present.
- 🚀 This update improves usability by providing clear guidance when training YOLOv5 on single-class datasets, potentially preventing errors and confusion for users.
- 📈 Users opting to train models with a single class can expect more robust behavior, especially when the dataset might inaccurately have multiple names listed.