### PR TITLE
Input channel yaml['ch'] addition

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
+import math
 import sys
 from copy import deepcopy
 from pathlib import Path
 
-import math
 import torch
 import torch.nn as nn
 
@@ -78,10 +78,11 @@ class Model(nn.Module):
                 self.yaml = yaml.load(f, Loader=yaml.FullLoader)  # model dict
 
         # Define model
+        ch = self.yaml['ch'] = self.yaml.get('ch', ch)  # input channels
         if nc and nc != self.yaml['nc']:
             logger.info('Overriding model.yaml nc=%g with nc=%g' % (self.yaml['nc'], nc))
             self.yaml['nc'] = nc  # override yaml value
-        self.model, self.save = parse_model(deepcopy(self.yaml), ch=[ch])  # model, savelist, ch_out
+        self.model, self.save = parse_model(deepcopy(self.yaml), ch=[ch])  # model, savelist
         self.names = [str(i) for i in range(self.yaml['nc'])]  # default names
         # print([x.shape for x in self.forward(torch.zeros(1, ch, 64, 64))])
 

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -196,7 +196,7 @@ def model_info(model, verbose=False, img_size=640):
     try:  # FLOPS
         from thop import profile
         stride = int(model.stride.max()) if hasattr(model, 'stride') else 32
-        img = torch.zeros((1, 3, stride, stride), device=next(model.parameters()).device)  # input
+        img = torch.zeros((1, model.yaml.get('ch', 3), stride, stride), device=next(model.parameters()).device)  # input
         flops = profile(deepcopy(model), inputs=(img,), verbose=False)[0] / 1E9 * 2  # stride FLOPS
         img_size = img_size if isinstance(img_size, list) else [img_size, img_size]  # expand if int/float
         fs = ', %.1f GFLOPS' % (flops * img_size[0] / stride * img_size[1] / stride)  # 640x640 FLOPS


### PR DESCRIPTION
This PR adds support for optional input channel definition in model yaml files, i.e.

```yaml
# parameters
nc: 80  # number of classes
ch: 10  # input channels  <------------------------
depth_multiple: 0.33  # model depth multiple
width_multiple: 0.50  # layer channel multiple
```

Tested with 1, 3 and 10 channel models.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinements in YOLOv5 model initialization and FLOPS calculation.

### 📊 Key Changes
- `math` module import has been moved for better code organization.
- The `self.yaml['ch']` now explicitly initializes with input channels parameter `ch`.
- Removed the redundant `ch_out` comment in model parsing as it was confusing.
- Model's FLOPS calculation now dynamically uses the `ch` value from `model.yaml`.

### 🎯 Purpose & Impact
- 💡 Better code structure provides clarity for future maintenance and development.
- 🚀 Enhances flexibility by ensuring model initialization aligns with configuration files, potentially improving model adaptability to different input channels.
- 🔍 Improves technical documentation within the code for better understanding.
- ✅ More accurate FLOPS calculation leads to better performance insights, impacting developers' ability to optimize models.