### PR TITLE
Display correct CUDA devices

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -48,20 +48,20 @@ def select_device(device='', batch_size=None):
     cpu_request = device.lower() == 'cpu'
     if device and not cpu_request:  # if device requested other than 'cpu'
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable
-        assert torch.cuda.is_available(), 'CUDA unavailable, invalid device %s requested' % device  # check availablity
+        assert torch.cuda.is_available(), f'CUDA unavailable, invalid device {device} requested'  # check availablity
 
     cuda = False if cpu_request else torch.cuda.is_available()
     if cuda:
         c = 1024 ** 2  # bytes to MB
         ng = torch.cuda.device_count()
         if ng > 1 and batch_size:  # check that batch_size is compatible with device_count
-            assert batch_size % ng == 0, 'batch-size %g not multiple of GPU count %g' % (batch_size, ng)
+            assert batch_size % ng == 0, f'batch-size {batch_size} not multiple of GPU count {ng}'
         x = [torch.cuda.get_device_properties(i) for i in range(ng)]
         s = f'Using torch {torch.__version__} '
-        for i in range(0, ng):
+        for i, d in enumerate(device.split(',')):
             if i == 1:
                 s = ' ' * len(s)
-            logger.info("%sCUDA:%g (%s, %dMB)" % (s, i, x[i].name, x[i].total_memory / c))
+            logger.info(f"{s}CUDA:{d} ({x[i].name}, {x[i].total_memory / c:d}MB)")
     else:
         logger.info(f'Using torch {torch.__version__} CPU')
 

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -58,10 +58,10 @@ def select_device(device='', batch_size=None):
             assert batch_size % ng == 0, f'batch-size {batch_size} not multiple of GPU count {ng}'
         x = [torch.cuda.get_device_properties(i) for i in range(ng)]
         s = f'Using torch {torch.__version__} '
-        for i, d in enumerate(device.split(',')):
+        for i, d in enumerate((device or '0').split(',')):
             if i == 1:
                 s = ' ' * len(s)
-            logger.info(f"{s}CUDA:{d} ({x[i].name}, {x[i].total_memory / c:d}MB)")
+            logger.info(f"{s}CUDA:{d} ({x[i].name}, {x[i].total_memory / c}MB)")
     else:
         logger.info(f'Using torch {torch.__version__} CPU')
 


### PR DESCRIPTION
Resolves https://github.com/ultralytics/yolov5/issues/1760. CUDA device indices should now appear as requested (underlying functionality unchanged, no bugs, simply print to screen more accurately).

```
$ python train.py --devices 2,3

Using torch 1.7.1 CUDA:2 (GeForce RTX 2080 Ti, 11019MB)
                  CUDA:3 (GeForce RTX 2080 Ti, 11019MB)
...
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR refines device selection and logging in Ultralytics YOLOv5's `torch_utils.py`.

### 📊 Key Changes
- Updated error messages to use f-strings for better readability and consistency.
- Modified the batch size compatibility assertion to be clearer and more direct.
- Enhanced the GPU logging format to be more informative, showing GPU IDs and properties.

### 🎯 Purpose & Impact
- The purpose is to improve code quality and maintainability by using f-strings, which are more modern and preferred for string formatting in Python.
- Ensures clearer error messages, providing a better understanding for users when they encounter issues related to device availability or batch size configurations.
- Potential impact includes a smoother user experience when setting up the environment for YOLOv5, as users can more easily identify and troubleshoot hardware compatibility issues.