### PR TITLE
Support Turbojpeg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ pandas
 # extras --------------------------------------
 thop  # FLOPS computation
 pycocotools>=2.0  # COCO mAP
-git+git://github.com/lilohuang/PyTurboJPEG.git
+# git+git://github.com/lilohuang/PyTurboJPEG.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ pandas
 # extras --------------------------------------
 thop  # FLOPS computation
 pycocotools>=2.0  # COCO mAP
+git+git://github.com/lilohuang/PyTurboJPEG.git

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -27,7 +27,7 @@ help_url = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
 img_formats = ['bmp', 'jpg', 'jpeg', 'png', 'tif', 'tiff', 'dng']  # acceptable image suffixes
 vid_formats = ['mov', 'avi', 'mp4', 'mpg', 'mpeg', 'm4v', 'wmv', 'mkv']  # acceptable video suffixes
 logger = logging.getLogger(__name__)
-turbojpeg_flag = False
+turbojpeg_flag = True
 
 try:
     from turbojpeg import TurboJPEG

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -33,7 +33,7 @@ try:
     from turbojpeg import TurboJPEG
 except ImportError:
     turbojpeg_flag = False
-    raise ImportError("turbojpeg is not installed, now disable this feature.")
+    print(ImportError("turbojpeg is not installed, now disable this feature."))
 
 
 # Get orientation exif tag

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -27,7 +27,7 @@ help_url = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
 img_formats = ['bmp', 'jpg', 'jpeg', 'png', 'tif', 'tiff', 'dng']  # acceptable image suffixes
 vid_formats = ['mov', 'avi', 'mp4', 'mpg', 'mpeg', 'm4v', 'wmv', 'mkv']  # acceptable video suffixes
 logger = logging.getLogger(__name__)
-turbojpeg_flag = True
+turbojpeg_flag = False
 
 try:
     from turbojpeg import TurboJPEG

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -211,7 +211,7 @@ class LoadImage:
 
 
 
-class LoadImages_v1:  # for inference
+class LoadImages:  # for inference
     def __init__(self, path, img_size=640):
         p = str(Path(path))  # os-agnostic
         p = os.path.abspath(p)  # absolute path


### PR DESCRIPTION
Dear Ultralytics:
    I noticed that Yolov5 suffer from performance drop when dealing with jpeg images. I currently update the dataset.py to support TurboJpeg packages to allow perf increase. Feel free to contact me if you have any questions. The code is tested under Ubuntu20 with pytorch1.6 on single card.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR includes an enhancement that integrates TurboJPEG for faster image loading.

### 📊 Key Changes
- Added TurboJPEG to `requirements.txt` as an optional dependency.
- Implemented TurboJPEG-based loading in `datasets.py` for JPEG images.
- Included a check to only enable TurboJPEG loading if the package is successfully installed; otherwise, default to previous method.

### 🎯 Purpose & Impact
- **Purpose**: To optimize the speed of image loading, particularly JPEG files, which benefit from TurboJPEG's accelerated decoding.
- **Impact**: Users with TurboJPEG installed can expect faster image processing when using YOLOv5, leading to improved performance, especially when dealing with large datasets. If TurboJPEG is not installed, the system will continue as normal without enhanced speed.