### PR TITLE
DDP Multi-GPU --resume bug fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -472,9 +472,10 @@ if __name__ == '__main__':
     if opt.resume:  # resume an interrupted run
         ckpt = opt.resume if isinstance(opt.resume, str) else get_latest_run()  # specified or most recent path
         assert os.path.isfile(ckpt), 'ERROR: --resume checkpoint does not exist'
+        apriori = opt.global_rank, opt.local_rank
         with open(Path(ckpt).parent.parent / 'opt.yaml') as f:
             opt = argparse.Namespace(**yaml.load(f, Loader=yaml.FullLoader))  # replace
-        opt.cfg, opt.weights, opt.resume = '', ckpt, True
+        opt.cfg, opt.weights, opt.resume, opt.global_rank, opt.local_rank = '', ckpt, True, *apriori  # reinstate
         logger.info('Resuming training from %s' % ckpt)
     else:
         # opt.hyp = opt.hyp or ('hyp.finetune.yaml' if opt.weights else 'hyp.scratch.yaml')


### PR DESCRIPTION
Multi-GPU --resume bug fix for issue #851. This retains the values of `opt.global_rank` and `opt.local_rank` when DDP training is resumed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved resume functionality in YOLOv5 training script.

### 📊 Key Changes
- Introduced code to ensure distributed training settings are correctly retained when resuming training from a checkpoint.

### 🎯 Purpose & Impact
- The change fixes a potential issue where training resumption could disregard the distributed training rank settings.
- Users relying on distributed training will experience a more consistent and reliable resumption of their training process, particularly in environments using multiple GPUs or nodes. 🔄
- Makes the process of resuming training smoother and less error-prone, which can save time and computational resources. 💻🕒