### PR TITLE
Setup Mypy in project

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,48 @@
+[mypy]
+warn_unused_configs = True
+warn_redundant_casts = True
+show_error_codes = True
+check_untyped_defs = True
+
+files =
+    models,
+    utils,
+    tests
+
+python_version = 3.6
+
+[mypy-torchvision.*]
+ignore_missing_imports = True
+
+[mypy-thop.*]
+ignore_missing_imports = True
+
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-seaborn.*]
+ignore_missing_imports = True
+
+[mypy-cv2.*]
+ignore_missing_imports = True
+
+[mypy-pandas.*]
+ignore_missing_imports = True
+
+[mypy-PIL.*]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True
+
+[mypy-tqdm.*]
+ignore_missing_imports = True
+
+[mypy-onnx.*]
+ignore_missing_imports = True
+
+[mypy-coremltools.*]
+ignore_missing_imports = True


### PR DESCRIPTION
This sets up initial mypy type checking which upstream Torch and other dependencies are working on.

https://github.com/pytorch/pytorch/issues/16574

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introduction of `mypy` configuration for static type checking in the Ultralytics YOLOv5 codebase.

### 📊 Key Changes
- Added a new `mypy.ini` file to configure `mypy`, a static type checker for Python.
- Configured `mypy` to check unused configurations, redundant casts, error codes, and untyped definitions.
- Specified directories to include in the type checks: `models`, `utils`, and `tests`.
- Set the Python version for type checking to 3.6.
- Added rules to ignore missing imports for several third-party libraries like `torchvision`, `numpy`, `cv2`, etc., acknowledging that these libraries may not have type hints available.

### 🎯 Purpose & Impact
- Enhances code quality by ensuring that type annotations are correct and used appropriately, minimizing runtime errors due to type mismatches.
- The configuration notably focuses on the key components of the YOLOv5 codebase that could benefit most from static type checking.
- Makes YOLOv5 more robust for developers by catching potential bugs early in the development lifecycle.
- Helps maintain clear type documentation, which can make the codebase more accessible and understandable to contributors and users alike.