### PR TITLE
(feat):add ARLoss and regloss schedule

### DIFF
--- a/data/hyp.scratch.yaml
+++ b/data/hyp.scratch.yaml
@@ -31,3 +31,8 @@ flipud: 0.0  # image flip up-down (probability)
 fliplr: 0.5  # image flip left-right (probability)
 mosaic: 1.0  # image mosaic (probability)
 mixup: 0.0  # image mixup (probability)
+arloss: ["linear", 0.5] # parameters of area ratio loss [type:linear/nonlinear, alph: range 0-1] such as ["nonlinear",0.3]
+
+## loss schedule: ["name_loss",nepoch,"name_loss"],such as one stage(niter:[0-50)) use CIOU,two stage(niter:50-end) use ARLoss
+## name_loss: "IoU","DIoU","GIoU","CIoU","ARLoss_DIoU","ARLoss_GIoU","ARLoss_CIoU"
+# regloss_schedule: ["CIoU",100,"ARLoss_CIoU"]     # <----- use regloss_schedule by uncomment

--- a/test.py
+++ b/test.py
@@ -21,6 +21,7 @@ from utils.torch_utils import select_device, time_synchronized
 
 def test(data,
          weights=None,
+         ni=None,
          batch_size=32,
          imgsz=640,
          conf_thres=0.001,
@@ -111,7 +112,7 @@ def test(data,
 
             # Compute loss
             if training:
-                loss += compute_loss([x.float() for x in train_out], targets, model)[1][:3]  # box, obj, cls
+                loss += compute_loss([x.float() for x in train_out], targets, model, ni=ni)[1][:3]  # box, obj, cls
 
             # Run NMS
             targets[:, 2:] *= torch.Tensor([width, height, width, height]).to(device)  # to pixels


### PR DESCRIPTION
Decide whether this feature is used by modifying the HYP file.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Implementing a dynamic loss schedule and area ratio loss to enhance model performance.

### 📊 Key Changes
- Added **area ratio loss (ARLoss)** parameters in `hyp.scratch.yaml` to adjust the contribution of different areas in loss calculation.
- Introduced `regloss_schedule` for switching between different loss calculations at a specified epoch during training.
- `test.py` and `train.py` now consider the current iteration `ni` to compute the loss according to the dynamic schedule.
- In `train.py`, `--weights` argument default value updated to an empty string.
- Enhanced `bbox_iou` function in `utils/general.py` to support area ratio loss calculations.
- Updated `compute_loss` function in `utils/loss.py` to include the area ratio loss and dynamic loss schedule during training.

### 🎯 Purpose & Impact
- This change aims to improve the model's performance by fine-tuning how loss is computed based on the area of the predicted and ground truth boxes.
- The addition of a loss schedule allows the model to adaptively change its loss computation method as it progresses through epochs, which can potentially make the training process more effective.
- Users can expect enhanced detection precision, as these changes could help the model in better differentiating between objects of various sizes and aspect ratios.
- It may also lead to better generalization in different scenarios, making the model more robust.