### PR TITLE
Torch CUDA synchronize update

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -49,7 +49,7 @@ def select_device(device='', batch_size=None):
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable
-        assert torch.cuda.is_available(), f'CUDA unavailable, invalid device {device} requested'  # check availablity
+        assert torch.cuda.is_available(), f'CUDA unavailable, invalid device {device} requested'  # check availability
 
     cuda = torch.cuda.is_available() and not cpu
     if cuda:

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -36,42 +36,41 @@ def init_torch_seeds(seed=0):
     # Speed-reproducibility tradeoff https://pytorch.org/docs/stable/notes/randomness.html
     torch.manual_seed(seed)
     if seed == 0:  # slower, more reproducible
-        cudnn.deterministic = True
-        cudnn.benchmark = False
+        cudnn.benchmark, cudnn.deterministic = False, True
     else:  # faster, less reproducible
-        cudnn.deterministic = False
-        cudnn.benchmark = True
+        cudnn.benchmark, cudnn.deterministic = True, False
 
 
 def select_device(device='', batch_size=None):
     # device = 'cpu' or '0' or '0,1,2,3'
-    cpu_request = device.lower() == 'cpu'
-    if device and not cpu_request:  # if device requested other than 'cpu'
+    s = f'Using torch {torch.__version__} '  # string
+    cpu = device.lower() == 'cpu'
+    if cpu:
+        os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
+    elif device:  # non-cpu device requested
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable
         assert torch.cuda.is_available(), f'CUDA unavailable, invalid device {device} requested'  # check availablity
 
-    cuda = False if cpu_request else torch.cuda.is_available()
+    cuda = torch.cuda.is_available() and not cpu
     if cuda:
-        c = 1024 ** 2  # bytes to MB
-        ng = torch.cuda.device_count()
-        if ng > 1 and batch_size:  # check that batch_size is compatible with device_count
-            assert batch_size % ng == 0, f'batch-size {batch_size} not multiple of GPU count {ng}'
-        x = [torch.cuda.get_device_properties(i) for i in range(ng)]
-        s = f'Using torch {torch.__version__} '
-        for i, d in enumerate((device or '0').split(',')):
-            if i == 1:
-                s = ' ' * len(s)
-            logger.info(f"{s}CUDA:{d} ({x[i].name}, {x[i].total_memory / c}MB)")
+        n = torch.cuda.device_count()
+        if n > 1 and batch_size:  # check that batch_size is compatible with device_count
+            assert batch_size % n == 0, f'batch-size {batch_size} not multiple of GPU count {n}'
+        space = ' ' * len(s)
+        for i, d in enumerate(device.split(',') if device else range(n)):
+            p = torch.cuda.get_device_properties(i)
+            s += f"{'' if i == 0 else space}CUDA:{d} {p.name} {p.total_memory / 1024 ** 2}MB"  # bytes to MB
     else:
-        logger.info(f'Using torch {torch.__version__} CPU')
+        s += 'CPU'
 
-    logger.info('')  # skip a line
+    logger.info(f'{s}\n')  # skip a line
     return torch.device('cuda:0' if cuda else 'cpu')
 
 
 def time_synchronized():
     # pytorch-accurate time
-    torch.cuda.synchronize() if torch.cuda.is_available() else None
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
     return time.time()
 
 

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -59,7 +59,7 @@ def select_device(device='', batch_size=None):
         space = ' ' * len(s)
         for i, d in enumerate(device.split(',') if device else range(n)):
             p = torch.cuda.get_device_properties(i)
-            s += f"{'' if i == 0 else space}CUDA:{d} {p.name} {p.total_memory / 1024 ** 2}MB"  # bytes to MB
+            s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / 1024 ** 2}MB)"  # bytes to MB
     else:
         s += 'CPU'
 

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -59,7 +59,7 @@ def select_device(device='', batch_size=None):
         space = ' ' * len(s)
         for i, d in enumerate(device.split(',') if device else range(n)):
             p = torch.cuda.get_device_properties(i)
-            s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / 1024 ** 2}MB)"  # bytes to MB
+            s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / 1024 ** 2}MB)\n"  # bytes to MB
     else:
         s += 'CPU'
 


### PR DESCRIPTION
Fix for #1816. Torch CUDA synchronization is not attempted now on CUDA-enabled machines when `--device cpu` is requested.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved CUDA device handling and reproducibility configuration in PyTorch utilities.

### 📊 Key Changes
- Unified assignment of `cudnn.deterministic` and `cudnn.benchmark` values for clarity.
- Simplified CPU request handling in `select_device` by setting environment variable `CUDA_VISIBLE_DEVICES` to '-1'.
- Enhanced device selection string output to be more informative and user-friendly.
- Ensured `batch_size` is a multiple of GPU count, raising an error for incompatibility.
- Optimized GPU device properties fetching and logging.
- Made the `time_synchronized` function more concise.

### 🎯 Purpose & Impact
- Streamlining CUDA configurations improves code clarity and reproducibility when seeding for randomness 🔁.
- Clarifications in device selection facilitate better handling of CPU-only requests and ensure better error messaging 🖥️.
- More informative logging assists users in understanding their device utilization and system capabilities 📈.
- Batch size check against GPU count helps prevent runtime errors due to configuration mismatches 🛠️.
- Cleaner codebase with compact and improved readability, aiding maintenance and development 🧹.

These changes help provide a smoother experience for users working with different devices and configurations, aiming to improve the overall reliability and performance of machine learning workflows running on the Ultralytics YOLOv5 project.