### PR TITLE
Remove unused code

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -117,8 +117,6 @@ def detect(save_img=False):
             # Stream results
             if view_img:
                 cv2.imshow(str(p), im0)
-                # if cv2.waitKey(1) == ord('q'):  # q to quit
-                #     raise StopIteration
 
             # Save results (image with detections)
             if save_img:

--- a/detect.py
+++ b/detect.py
@@ -117,8 +117,8 @@ def detect(save_img=False):
             # Stream results
             if view_img:
                 cv2.imshow(str(p), im0)
-                if cv2.waitKey(1) == ord('q'):  # q to quit
-                    raise StopIteration
+                # if cv2.waitKey(1) == ord('q'):  # q to quit
+                #     raise StopIteration
 
             # Save results (image with detections)
             if save_img:


### PR DESCRIPTION
## Code Removed :
In `detect.py`,
 line number 120-121 is removed ,
```bash 
                if cv2.waitKey(1) == ord('q'):  # q to quit
                    raise StopIteration
```
## Reason of removal :
Similar code is written is `utils.datasets` class : `LoadStream`
Simialr code (line 310-312 in `utils.datasets`):
```bash
        if cv2.waitKey(1) == ord('q'):  # q to quit
            cv2.destroyAllWindows()
            raise StopIteration
```
Tested it on :
- Simple webcam 
- single http link
- stream.txt (flie containing mutliple http links along with webcam)



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved user experience in real-time object detection streams by removing the quit keystroke.

### 📊 Key Changes
- Removal of the `q` keystroke feature which allowed users to quit the detection stream.

### 🎯 Purpose & Impact
- **Purpose**: To streamline real-time detection without the interruption of a keystroke that would require the stream to stop.
  
- **Impact**: Users will no longer be able to quit the detection feed by pressing `q`. This could either enhance the user experience by preventing accidental exits or slightly inconvenience users who liked the quick exit option. Overall, it might require users to adapt to a new way to terminate the detection loop.