### PR TITLE
W&B ID reset on training completion 

### DIFF
--- a/train.py
+++ b/train.py
@@ -134,7 +134,13 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
     # Logging
     if rank in [-1, 0] and wandb and wandb.run is None:
         opt.hyp = hyp  # add hyperparameters
-        wandb_ID = wandb.util.generate_id()
+        
+        # check whether wandb_ID is unique
+        temp_ID = ckpt.get('wandb_id') if 'ckpt' in locals() else None
+        if temp_ID == '3hdht16b':
+                wandb_ID = wandb.util.generate_id()
+        else:
+                wandb_ID = temp_ID
         wandb_run = wandb.init(config=opt, resume="allow",
                                project='YOLOv5' if opt.project == 'runs/train' else Path(opt.project).stem,
                                name=save_dir.stem,

--- a/train.py
+++ b/train.py
@@ -134,10 +134,11 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
     # Logging
     if rank in [-1, 0] and wandb and wandb.run is None:
         opt.hyp = hyp  # add hyperparameters
+        wandb_ID = wandb.util.generate_id()
         wandb_run = wandb.init(config=opt, resume="allow",
                                project='YOLOv5' if opt.project == 'runs/train' else Path(opt.project).stem,
                                name=save_dir.stem,
-                               id=ckpt.get('wandb_id') if 'ckpt' in locals() else None)
+                               id=wandb_ID)
     loggers = {'wandb': wandb}  # loggers dict
 
     # Resume

--- a/train.py
+++ b/train.py
@@ -134,17 +134,10 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
     # Logging
     if rank in [-1, 0] and wandb and wandb.run is None:
         opt.hyp = hyp  # add hyperparameters
-        
-        # check whether wandb_ID is unique
-        temp_ID = ckpt.get('wandb_id') if 'ckpt' in locals() else None
-        if temp_ID == '3hdht16b':
-                wandb_ID = wandb.util.generate_id()
-        else:
-                wandb_ID = temp_ID
         wandb_run = wandb.init(config=opt, resume="allow",
                                project='YOLOv5' if opt.project == 'runs/train' else Path(opt.project).stem,
                                name=save_dir.stem,
-                               id=wandb_ID)
+                               id=ckpt.get('wandb_id') if 'ckpt' in locals() else None)
     loggers = {'wandb': wandb}  # loggers dict
 
     # Resume

--- a/utils/general.py
+++ b/utils/general.py
@@ -361,8 +361,8 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
 def strip_optimizer(f='weights/best.pt', s=''):  # from utils.general import *; strip_optimizer()
     # Strip optimizer from 'f' to finalize training, optionally save as 's'
     x = torch.load(f, map_location=torch.device('cpu'))
-    x['optimizer'] = None
-    x['training_results'] = None
+    for key in 'optimizer', 'training_results', 'wandb_id':
+        x[key] = None
     x['epoch'] = -1
     x['model'].half()  # to FP16
     for p in x['model'].parameters():


### PR DESCRIPTION
Fix the bug of always the same W&B ID  and continue  overwrite with the old logging.
BUG report
https://github.com/ultralytics/yolov5/issues/1851


New code have been tested on my server.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved optimizer stripping function for finalizing model training.

### 📊 Key Changes
- Enhanced the `strip_optimizer()` function to remove additional data from the model file.
- Now also strips 'wandb_id' along with 'optimizer' and 'training_results'.

### 🎯 Purpose & Impact
- The purpose of this change is to reduce the file size and remove unnecessary information from model weights files after training, making the files cleaner for deployment.
- Potential impact includes faster model loading and simpler model files, which can be beneficial for users deploying models in production environments. 🚀