### PR TITLE
auto-verbose if nc <= 20

### DIFF
--- a/test.py
+++ b/test.py
@@ -226,7 +226,7 @@ def test(data,
     print(pf % ('all', seen, nt.sum(), mp, mr, map50, map))
 
     # Print results per class
-    if verbose and nc > 1 and len(stats):
+    if (verbose or (nc <= 20 and not training)) and nc > 1 and len(stats):
         for i, c in enumerate(ap_class):
             print(pf % (names[c], seen, nt[c], p[i], r[i], ap50[i], ap[i]))
 


### PR DESCRIPTION
This PR automatically sets test.py to --verbose for datasets with <= 20 classes when called directly (not training).

This may help most users see per-class metrics by default since typically custom datasets are < 20 classes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced information displayed for per-class results during testing.

### 📊 Key Changes
- Modified the condition that determines when to print per-class results in `test.py`.
- Per-class results will now print either when `verbose` is true, or when the number of classes (`nc`) is less than or equal to 20 and the model is not in training mode.

### 🎯 Purpose & Impact
- 💡 **Purpose**: To improve the usability by providing more detailed feedback on model performance when the number of classes is small, without overwhelming the user with information during training sessions.
- 🚀 **Potential Impact**: Users can now get a quick overview of model accuracy per class for small datasets even when not in verbose mode, which is great for quick evaluations and debugging. This could be particularly useful when working with a limited number of classes and when users want an immediate, detailed assessment without sifting through extensive logs.