### PR TITLE
Docker CUDA warning fix

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -61,7 +61,7 @@ def select_device(device='', batch_size=None):
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable
         assert torch.cuda.is_available(), f'CUDA unavailable, invalid device {device} requested'  # check availability
 
-    cuda = torch.cuda.is_available() and not cpu
+    cuda = not cpu and torch.cuda.is_available()
     if cuda:
         n = torch.cuda.device_count()
         if n > 1 and batch_size:  # check that batch_size is compatible with device_count


### PR DESCRIPTION
This PR fixes the warning displayed in Docker with CPU first noticed in issue #1891. Solution is a rearrangement of logic to avoid calls to torch.cuda.is_available(). Problem is likely within torch but this change has no negative side effects so it's probably worth it to implement.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved device selection logic for CUDA in YOLOv5.

### 📊 Key Changes
- Reordered the conditions in the device selection to prioritize CPU check before verifying CUDA availability.

### 🎯 Purpose & Impact
- 🚀 **Purpose:** The change ensures that the CPU preference is considered before the system checks for CUDA compatibility. This could prevent unnecessary checks for CUDA when CPU mode is explicitly requested.
- ✅ **Impact:** This tweak might result in minor performance improvements and cleaner logic during the initialization of the YOLOv5 model, especially for environments where CUDA is not intended to be used. It primarily benefits users who wish to run models on the CPU or manage GPU visibility more efficiently.