### PR TITLE
GitHub API rate limit fallback

### DIFF
--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -16,28 +16,32 @@ def gsutil_getsize(url=''):
     return eval(s.split(' ')[0]) if len(s) else 0  # bytes
 
 
-def attempt_download(file):
+def attempt_download(file, repo='ultralytics/yolov5'):
     # Attempt file download if does not exist
     file = Path(str(file).strip().replace("'", '').lower())
 
     if not file.exists():
-        response = requests.get('https://api.github.com/repos/ultralytics/yolov5/releases/latest').json()  # github api
-        assets = [x['name'] for x in response['assets']]  # release assets, i.e. ['yolov5s.pt', 'yolov5m.pt', ...]
-        name = file.name
+        try:
+            response = requests.get(f'https://api.github.com/repos/{repo}/releases/latest').json()  # github api
+            assets = [x['name'] for x in response['assets']]  # release assets, i.e. ['yolov5s.pt', 'yolov5m.pt', ...]
+            tag = response['tag_name']  # i.e. 'v1.0'
+        except:  # fallback plan
+            assets = ['yolov5.pt', 'yolov5.pt', 'yolov5l.pt', 'yolov5x.pt']
+            tag = subprocess.check_output('git tag', shell=True).decode('utf-8').split('\n')[-2]
 
+        name = file.name
         if name in assets:
-            msg = f'{file} missing, try downloading from https://github.com/ultralytics/yolov5/releases/'
+            msg = f'{file} missing, try downloading from https://github.com/{repo}/releases/'
             redundant = False  # second download option
             try:  # GitHub
-                tag = response['tag_name']  # i.e. 'v1.0'
-                url = f'https://github.com/ultralytics/yolov5/releases/download/{tag}/{name}'
+                url = f'https://github.com/{repo}/releases/download/{tag}/{name}'
                 print(f'Downloading {url} to {file}...')
                 torch.hub.download_url_to_file(url, file)
                 assert file.exists() and file.stat().st_size > 1E6  # check
             except Exception as e:  # GCP
                 print(f'Download error: {e}')
                 assert redundant, 'No secondary mirror'
-                url = f'https://storage.googleapis.com/ultralytics/yolov5/ckpt/{name}'
+                url = f'https://storage.googleapis.com/{repo}/ckpt/{name}'
                 print(f'Downloading {url} to {file}...')
                 os.system(f'curl -L {url} -o {file}')  # torch.hub.download_url_to_file(url, weights)
             finally:


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced flexibility in downloading model files from custom repositories.

### 📊 Key Changes
- 🔄 Updated the `attempt_download` function to allow for specifying a custom GitHub repository.
- 🛠 Added a fallback mechanism that defaults to a predefined asset list and uses the last git tag in case the GitHub API call fails.
- 📡 Included a dynamic repository URL for storage bucket downloads, aligning with the new custom repo feature.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: This change allows users to download model files from different GitHub repositories, not just the default `ultralytics/yolov5`. It also provides a robust fallback for download attempts if the GitHub API request fails.
- ✨ **Impact**: Users and developers can work with models across various repositories, increasing modularity and collaboration opportunities. Moreover, the fallback ensures model downloads are less likely to fail, improving the reliability of model setup processes.