### PR TITLE
Fix batch-size on resume for multi-gpu

### DIFF
--- a/train.py
+++ b/train.py
@@ -477,7 +477,7 @@ if __name__ == '__main__':
         apriori = opt.global_rank, opt.local_rank
         with open(Path(ckpt).parent.parent / 'opt.yaml') as f:
             opt = argparse.Namespace(**yaml.load(f, Loader=yaml.FullLoader))  # replace
-        opt.cfg, opt.weights, opt.resume, opt.global_rank, opt.local_rank = '', ckpt, True, *apriori  # reinstate
+        opt.cfg, opt.weights, opt.resume, opt.batch_size, opt.global_rank, opt.local_rank = '', ckpt, True, opt.total_batch_size, *apriori  # reinstate
         logger.info('Resuming training from %s' % ckpt)
     else:
         # opt.hyp = opt.hyp or ('hyp.finetune.yaml' if opt.weights else 'hyp.scratch.yaml')


### PR DESCRIPTION
Fixes #1936

Tested on my own and with author of the mentioned Issue.

Command:
```bash
python -m torch.distributed.launch --master_port 9963 --nproc_per_node 2 train.py --data coco128.yaml --cfg yolov5s.yaml --weights yolov5s.pt --epochs 3 --batch-size 64 --device 3,4
python -m torch.distributed.launch --master_port 9963 --nproc_per_node 2 train.py --resume
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in resume training functionality for YOLOv5.

### 📊 Key Changes
- Changed the `train.py` script to update `opt.batch_size` properly when resuming training.

### 🎯 Purpose & Impact
- The purpose of this change is to ensure that the batch size used when resuming training from a checkpoint is set correctly to the total batch size (`opt.total_batch_size`).
- This will prevent potential inconsistencies with batch sizes when training is paused and resumed, leading to more reliable and stable training runs for users. 🛠️
  
This update is particularly beneficial for users who conduct long training sessions that may need to be paused and resumed due to various reasons, such as hardware limitations or scheduling constraints. 🔄