### PR TITLE
Daemon thread mosaic plots fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -318,8 +318,9 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                     # if tb_writer:
                     #     tb_writer.add_image(f, result, dataformats='HWC', global_step=epoch)
                     #     tb_writer.add_graph(model, imgs)  # add model to tensorboard
-                elif plots and ni == 3 and wandb:
-                    wandb.log({"Mosaics": [wandb.Image(str(x), caption=x.name) for x in save_dir.glob('train*.jpg')]})
+                elif plots and ni > 3 and wandb:
+                    wandb.log({"Mosaics": [wandb.Image(str(x), caption=x.name) for x in save_dir.glob('train*.jpg')
+                                           if x.exists()]})
 
             # end batch ------------------------------------------------------------------------------------------------
         # end epoch ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Partial fix for #1937. 

```bash
  File "train.py", line 518, in <module>
    train(hyp, opt, device, tb_writer, wandb)
  File "train.py", line 322, in train
    wandb.log({"Mosaics": [wandb.Image(str(x), caption=x.name) for x in save_dir.glob('train*.jpg')]})
  File "train.py", line 322, in <listcomp>
    wandb.log({"Mosaics": [wandb.Image(str(x), caption=x.name) for x in save_dir.glob('train*.jpg')]})
  File "/usr/local/lib/python3.6/dist-packages/wandb/data_types.py", line 1555, in __init__
    self._initialize_from_path(data_or_path)
  File "/usr/local/lib/python3.6/dist-packages/wandb/data_types.py", line 1625, in _initialize_from_path
    self._image = pil_image.open(path)
  File "/usr/local/lib/python3.6/dist-packages/PIL/Image.py", line 2862, in open
    "cannot identify image file %r" % (filename if filename else fp)
PIL.UnidentifiedImageError: cannot identify image file 'runs/train/bat_16/train_batch2.jpg'
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved WandB logging for training mosaic images in YOLOv5.

### 📊 Key Changes
- Adjusted condition for logging mosaics from `ni == 3` to `ni > 3`.
- Added a file existence check before logging images to WandB.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: Ensure reliable logging of mosaic images to WandB, preventing errors when image files do not exist.
- 💪 **Impact**: Enhances the robustness of training logs in WandB and prevents potential disruptions due to missing files. Users of YOLOv5 will experience more consistent tracking of their model training progress.