### PR TITLE
Fix detect error when loading weights with SyncBN

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -123,8 +123,10 @@ def attempt_load(weights, map_location=None):
             m.inplace = True  # pytorch 1.7.0 compatibility
         elif type(m) is Conv:
             m._non_persistent_buffers_set = set()  # pytorch 1.6.0 compatibility
-        elif hasattr(m, 'bn') and hasattr(m.bn, 'num_features') and type(m.bn) is nn.SyncBatchNorm:
-            m.bn = nn.BatchNorm2d(m.bn.num_features)  # assign bn
+        elif hasattr(m, 'bn') and type(m.bn) is nn.SyncBatchNorm:  # convert SyncBatchNorm to BatchNorm2d
+            bn2d = nn.BatchNorm2d(num_features=m.bn.num_features)
+            bn2d.load_state_dict(m.bn.state_dict())
+            m.bn = bn2d
 
     if len(model) == 1:
         return model[-1]  # return model

--- a/models/experimental.py
+++ b/models/experimental.py
@@ -123,6 +123,8 @@ def attempt_load(weights, map_location=None):
             m.inplace = True  # pytorch 1.7.0 compatibility
         elif type(m) is Conv:
             m._non_persistent_buffers_set = set()  # pytorch 1.6.0 compatibility
+        elif hasattr(m, 'bn') and hasattr(m.bn, 'num_features') and type(m.bn) is nn.SyncBatchNorm:
+            m.bn = nn.BatchNorm2d(m.bn.num_features)  # assign bn
 
     if len(model) == 1:
         return model[-1]  # return model


### PR DESCRIPTION
I use multi-GPUs for distributed training with syncB, but the saved weights can't be loaded on the CPU. 
This pull requests is a fix.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgraded model compatibility with different PyTorch versions by adapting batch normalization layers.

### 📊 Key Changes
- Compatibility tweaks for PyTorch versions 1.6.0 and 1.7.0 in the `attempt_load` function.
- Conversion of `SyncBatchNorm` to `BatchNorm2d` for models with sync batch norm layers to ensure compatibility.

### 🎯 Purpose & Impact
- 💡 Ensures that the model loading function is compatible with older PyTorch versions, preventing potential loading issues for users on legacy systems.
- 🔄 The transition from `SyncBatchNorm` to `BatchNorm2d` broadens support across different hardware and software configurations, reducing the need for users to match specific batch norm types to their environment.
- ✨ These changes may lead to improved model performance and stability, making the YOLOv5 models more robust and accessible for a wider range of users.