### PR TITLE
--verbose on final_epoch

### DIFF
--- a/test.py
+++ b/test.py
@@ -37,7 +37,6 @@ def test(data,
          plots=True,
          log_imgs=0,  # number of logged images
          compute_loss=None):
-
     # Initialize/load model and set device
     training = model is not None
     if training:  # called by train.py
@@ -227,7 +226,7 @@ def test(data,
     print(pf % ('all', seen, nt.sum(), mp, mr, map50, map))
 
     # Print results per class
-    if (verbose or (nc <= 20 and not training)) and nc > 1 and len(stats):
+    if (verbose or (nc < 50 and not training)) and nc > 1 and len(stats):
         for i, c in enumerate(ap_class):
             print(pf % (names[c], seen, nt[c], p[i], r[i], ap50[i], ap[i]))
 

--- a/train.py
+++ b/train.py
@@ -344,6 +344,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                                                  single_cls=opt.single_cls,
                                                  dataloader=testloader,
                                                  save_dir=save_dir,
+                                                 verbose=nc < 50 and final_epoch,
                                                  plots=plots and final_epoch,
                                                  log_imgs=opt.log_imgs if wandb else 0,
                                                  compute_loss=compute_loss)


### PR DESCRIPTION
Automatically reports per-class statistics for datasets with <50 classes. Verbose can also be manually forced with:
```
python test.py --verbose
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced console output readability for YOLOv5 classes during testing and final epoch training.

### 📊 Key Changes
- Altered the condition in the test script to print results for up to 49 classes (increased from 20).
- Modified train script to include verbosity during the final epoch when the number of classes is less than 50.

### 🎯 Purpose & Impact
- The adjustments make it easier for users to review detailed class-specific performance metrics when the number of classes is reasonably small.
- Users working with datasets that have up to 49 classes will now get a more informative output directly in the console, improving their ability to swiftly analyze the performance across different classes.
- This change may be especially appreciated by researchers and practitioners who aim to quickly debug or assess their models on a moderate number of classes without diving deep into logs or additional visualization tools.