### PR TITLE
Check im.format during dataset caching

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -445,7 +445,8 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                 im = Image.open(im_file)
                 im.verify()  # PIL verify
                 shape = exif_size(im)  # image size
-                assert (shape[0] > 9) & (shape[1] > 9), 'image size <10 pixels'
+                assert (shape[0] > 9) & (shape[1] > 9), f'image size {shape} <10 pixels'
+                assert im.format.lower() in img_formats, f'invalid format {im.format}'
 
                 # verify labels
                 if os.path.isfile(lb_file):

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -446,7 +446,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                 im.verify()  # PIL verify
                 shape = exif_size(im)  # image size
                 assert (shape[0] > 9) & (shape[1] > 9), f'image size {shape} <10 pixels'
-                assert im.format.lower() in img_formats, f'invalid format {im.format}'
+                assert im.format.lower() in img_formats, f'invalid image format {im.format}'
 
                 # verify labels
                 if os.path.isfile(lb_file):


### PR DESCRIPTION
Possible fix for #195, whereby images with acceptable suffixes i.e. *.jpg are actually prohibited formats (i.e. *.gif). This introduces a PIL img.format check on label caching for this specific possibility, and prints to screen the affected image (and then ignores it for training/val).

NOTE: this is in addition to a file suffix check that occurs earlier in the dataloader.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to image validation during dataset loading in the YOLOv5 codebase.

### 📊 Key Changes
- Improved error message for images with dimensions less than 10 pixels by including the actual image size in the assertion error.
- Added an assertion check to validate image formats against a list of supported formats (`img_formats`).

### 🎯 Purpose & Impact
- 🛠️ **Enhanced Debugging:** Extended error messages will help users better understand why their images are failing to load during training or inference.
- 📸 **Image Format Validation:** The new image format check ensures that only supported image files are processed, reducing the risk of errors during model training or evaluation due to incompatible files.
  
These improvements could result in a smoother experience for users by preventing unclear errors and ensuring dataset integrity before kicking off possibly lengthy training jobs.