### PR TITLE
Confusion matrix native image-space fix

### DIFF
--- a/test.py
+++ b/test.py
@@ -178,7 +178,7 @@ def test(data,
                 tbox = xywh2xyxy(labels[:, 1:5])
                 scale_coords(img[si].shape[1:], tbox, shapes[si][0], shapes[si][1])  # native-space labels
                 if plots:
-                    confusion_matrix.process_batch(pred, torch.cat((labels[:, 0:1], tbox), 1))
+                    confusion_matrix.process_batch(predn, torch.cat((labels[:, 0:1], tbox), 1))
 
                 # Per target class
                 for cls in torch.unique(tcls_tensor):


### PR DESCRIPTION
Make sure the labels and predictions are equally scaled on confusion_matrix.process_batch

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of prediction handling in test suite.

### 📊 Key Changes
- Modified the `confusion_matrix.process_batch` function call to input `predn` instead of `pred`.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: The change ensures that the predictions processed in the confusion matrix are the normalized versions, likely correcting a previous oversight.
- 🌍 **Impact**: Improves the accuracy of the confusion matrix output, which is critical for evaluating model performance. Users will benefit from more reliable metrics for their object detection tasks. 📈