### PR TITLE
Make normalized confusion matrix more interpretable 

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -147,12 +147,12 @@ class ConfusionMatrix:
             if n and sum(j) == 1:
                 self.matrix[gc, detection_classes[m1[j]]] += 1  # correct
             else:
-                self.matrix[gc, self.nc] += 1  # background FP
+                self.matrix[self.nc, gc] += 1  # background FP
 
         if n:
             for i, dc in enumerate(detection_classes):
                 if not any(m1 == i):
-                    self.matrix[self.nc, dc] += 1  # background FN
+                    self.matrix[dc, self.nc] += 1  # background FN
 
     def matrix(self):
         return self.matrix
@@ -168,8 +168,8 @@ class ConfusionMatrix:
             sn.set(font_scale=1.0 if self.nc < 50 else 0.8)  # for label size
             labels = (0 < len(names) < 99) and len(names) == self.nc  # apply names to ticklabels
             sn.heatmap(array, annot=self.nc < 30, annot_kws={"size": 8}, cmap='Blues', fmt='.2f', square=True,
-                       xticklabels=names + ['background FN'] if labels else "auto",
-                       yticklabels=names + ['background FP'] if labels else "auto").set_facecolor((1, 1, 1))
+                       xticklabels=names + ['background FP'] if labels else "auto",
+                       yticklabels=names + ['background FN'] if labels else "auto").set_facecolor((1, 1, 1))
             fig.axes[0].set_xlabel('True')
             fig.axes[0].set_ylabel('Predicted')
             fig.savefig(Path(save_dir) / 'confusion_matrix.png', dpi=250)


### PR DESCRIPTION
This solves https://github.com/ultralytics/yolov5/issues/2071, see it for an explanation of why the current implementation produces a confusion matrix with a misplaced background FP and background FN vectors. Switching their position before normalization means that columns are correctly normalized by the amount of groundtruth for each column.

It's worth noting that this implementation is based on 

https://github.com/kaanakan/object_detection_confusion_matrix/blob/master/confusion_matrix.py

which is based on 

https://github.com/svpino/tf_object_detection_cm

Both of which also implement the confusion matrix for object detection with the background FP and background FN misplaced. I'll link to this PR in each repo.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved label consistency in confusion matrix of YOLOv5.

### 📊 Key Changes
- Fixed an issue in the confusion matrix where false positives (FP) and false negatives (FN) were incorrectly labeled.
- Updated the confusion matrix plotting code to align the labels for FP and FN with standard practice.

### 🎯 Purpose & Impact
- 🎯 This change ensures that the confusion matrix correctly represents and labels the FP and FN, improving the interpretability of model performance for developers and users.
- 💡 The corrected labels will help users more accurately evaluate and tune their object detection models, potentially leading to better performance and fewer classification errors.