### PR TITLE
Update utils/datasets.py to support .webp files

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -25,7 +25,7 @@ from utils.torch_utils import torch_distributed_zero_first
 
 # Parameters
 help_url = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
-img_formats = ['bmp', 'jpg', 'jpeg', 'png', 'tif', 'tiff', 'dng']  # acceptable image suffixes
+img_formats = ['bmp', 'jpg', 'jpeg', 'png', 'tif', 'tiff', 'dng', 'webp']  # acceptable image suffixes
 vid_formats = ['mov', 'avi', 'mp4', 'mpg', 'mpeg', 'm4v', 'wmv', 'mkv']  # acceptable video suffixes
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Simply added 'webp' as an image format to the img_formats array so that webp image files can be used as training data.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Support for WEBP image format added to YOLOv5.

### 📊 Key Changes
- The list of acceptable image formats/suffixes now includes 'webp'.

### 🎯 Purpose & Impact
- **Purpose**: To allow YOLOv5 to utilize WEBP images, which are popular due to their efficient compression.
- **Impact**: Users can now train YOLOv5 models with '.webp' images, potentially reducing disk usage and improving load times. 🚀