### PR TITLE
Changed socket port and added timeout

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -51,7 +51,7 @@ def check_online():
     # Check internet connectivity
     import socket
     try:
-        socket.create_connection(("1.1.1.1", 53))  # check host accesability
+        socket.create_connection(("1.1.1.1", 443), 5)  # check host accesability
         return True
     except OSError:
         return False


### PR DESCRIPTION
I noticed that `train` hangs at the start for quite a bit(>30s) when I ran it on a server. It turns out that port `53` is blocked. I changed it to port `443` for https(less chance of being blocked) and added a timeout of 5 seconds.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved internet connectivity check in YOLOv5 utility function. 🌐✅

### 📊 Key Changes
- The port for checking internet connectivity has been changed from 53 to 443.
- A timeout of 5 seconds has been added to the connection attempt.

### 🎯 Purpose & Impact
- 💡 The change from port 53 (DNS) to port 443 (HTTPS) could lead to more reliable connectivity checks, as port 443 is commonly used for secured web traffic and less likely to be blocked.
- ⏱ Introducing a timeout ensures the check completes quickly, preventing long delays in the event that "1.1.1.1" is unreachable, which leads to better user experience.
- 🛠 Users can expect a more robust and efficient check for internet access when running YOLOv5 functions, impacting any features that require internet connectivity.