### PR TITLE
TTA augument boxes one pixel shifted in de-flip ud and lr

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -110,9 +110,9 @@ class Model(nn.Module):
                 # cv2.imwrite(f'img_{si}.jpg', 255 * xi[0].cpu().numpy().transpose((1, 2, 0))[:, :, ::-1])  # save
                 yi[..., :4] /= si  # de-scale
                 if fi == 2:
-                    yi[..., 1] = img_size[0]-1 - yi[..., 1]  # de-flip ud
+                    yi[..., 1] = img_size[0] - 1 - yi[..., 1]  # de-flip ud
                 elif fi == 3:
-                    yi[..., 0] = img_size[1]-1 - yi[..., 0]  # de-flip lr
+                    yi[..., 0] = img_size[1] - 1 - yi[..., 0]  # de-flip lr
                 y.append(yi)
             return torch.cat(y, 1), None  # augmented inference, train
         else:

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -110,9 +110,9 @@ class Model(nn.Module):
                 # cv2.imwrite(f'img_{si}.jpg', 255 * xi[0].cpu().numpy().transpose((1, 2, 0))[:, :, ::-1])  # save
                 yi[..., :4] /= si  # de-scale
                 if fi == 2:
-                    yi[..., 1] = img_size[0] - yi[..., 1]  # de-flip ud
+                    yi[..., 1] = img_size[0]-1 - yi[..., 1]  # de-flip ud
                 elif fi == 3:
-                    yi[..., 0] = img_size[1] - yi[..., 0]  # de-flip lr
+                    yi[..., 0] = img_size[1]-1 - yi[..., 0]  # de-flip lr
                 y.append(yi)
             return torch.cat(y, 1), None  # augmented inference, train
         else:


### PR DESCRIPTION
Thx for sharing your code.
Shouldn’t the lines 113 and 115 in Model.forward be:
yi[..., 1] = img_size[0]-1 - yi[..., 1] # de-flip ud
yi[..., 0] = img_size[1]-1 - yi[..., 0] # de-flip lr

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fix for bounding box coordinates in augmented YOLO model predictions.

### 📊 Key Changes
- Adjusted the de-flipping logic for both up-down and left-right image flips during augmentation.
- Coordinates for the modified axes now subtract 1 after the flip to ensure correct positioning.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: Ensures bounding box coordinates are accurately transformed back after image augmentation, fixing a potential off-by-one error.
- 💥 **Impact**: Provides more accurate object detection for users employing data augmentation during model training or inference, leading to potentially higher precision in the trained models.