### PR TITLE
LoadStreams() frame loss bug fix

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -300,7 +300,8 @@ class LoadStreams:  # multiple IP or RTSP cameras
             # _, self.imgs[index] = cap.read()
             cap.grab()
             if n == 4:  # read every 4th frame
-                _, self.imgs[index] = cap.retrieve()
+                success, im = cap.retrieve()
+                self.imgs[index] = im if success else self.imgs[index] * 0
                 n = 0
             time.sleep(0.01)  # wait time
 


### PR DESCRIPTION
Fix for #2196, streamloader returning None on a dropped frame / network connection problems. Default behavior now is to return a black frame if cv2 cap retrieval fails.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved error handling in video frame buffering for YOLOv5 datasets.

### 📊 Key Changes
- Adjusted video frame capture logic in the dataset utility script.
- Added a check to ensure that a frame is only updated if it's successfully retrieved.

### 🎯 Purpose & Impact
- **Purpose:** The change ensures more robust video frame handling by guaranteeing that only valid frames are used. If a frame fails to be retrieved, it's replaced with a blank frame instead of potentially using a corrupt or invalid image.
- **Impact:** This can improve the model training and inference process by eliminating potential glitches due to faulty frames. Users should experience a more stable dataset reading process, especially when working with video data.