### PR TITLE
Add check_imshow()

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -9,8 +9,8 @@ from numpy import random
 
 from models.experimental import attempt_load
 from utils.datasets import LoadStreams, LoadImages
-from utils.general import check_img_size, check_requirements, non_max_suppression, apply_classifier, scale_coords, \
-    xyxy2xywh, strip_optimizer, set_logging, increment_path
+from utils.general import check_img_size, check_requirements, check_imshow, non_max_suppression, apply_classifier, \
+    scale_coords, xyxy2xywh, strip_optimizer, set_logging, increment_path
 from utils.plots import plot_one_box
 from utils.torch_utils import select_device, load_classifier, time_synchronized
 
@@ -45,7 +45,7 @@ def detect(save_img=False):
     # Set Dataloader
     vid_path, vid_writer = None, None
     if webcam:
-        view_img = True
+        view_img = check_imshow()
         cudnn.benchmark = True  # set True to speed up constant image size inference
         dataset = LoadStreams(source, img_size=imgsz, stride=stride)
     else:
@@ -118,7 +118,7 @@ def detect(save_img=False):
             # Stream results
             if view_img:
                 cv2.imshow(str(p), im0)
-                cv2.waitKey(1) # 1 millisecond
+                cv2.waitKey(1)  # 1 millisecond
 
             # Save results (image with detections)
             if save_img:

--- a/utils/general.py
+++ b/utils/general.py
@@ -95,6 +95,19 @@ def check_img_size(img_size, s=32):
     return new_size
 
 
+def check_imshow():
+    # Check if environment supports image displays
+    try:
+        cv2.imshow('test', np.zeros((1, 1, 3)))
+        cv2.waitKey(1)
+        cv2.destroyAllWindows()
+        cv2.waitKey(1)
+        return True
+    except:
+        print('WARNING: Environment does not support cv2.imshow() or PIL.Image.show() image displays')
+        return False
+
+
 def check_file(file):
     # Search for file if not found
     if os.path.isfile(file) or file == '':

--- a/utils/general.py
+++ b/utils/general.py
@@ -103,8 +103,8 @@ def check_imshow():
         cv2.destroyAllWindows()
         cv2.waitKey(1)
         return True
-    except:
-        print('WARNING: Environment does not support cv2.imshow() or PIL.Image.show() image displays')
+    except Exception as e:
+        print(f'WARNING: Environment does not support cv2.imshow() or PIL Image.show() image previews.\n{e}')
         return False
 
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -104,7 +104,7 @@ def check_imshow():
         cv2.waitKey(1)
         return True
     except Exception as e:
-        print(f'WARNING: Environment does not support cv2.imshow() or PIL Image.show() image previews.\n{e}')
+        print(f'WARNING: Environment does not support cv2.imshow() or PIL Image.show() image previews\n{e}')
         return False
 
 


### PR DESCRIPTION
Fix for #2226, command line environment streaming with automatic `--view-img` enabled bug.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved environment compatibility for image display in YOLOv5 detection.

### 📊 Key Changes
- Added function `check_imshow()` to validate if the environment supports image display using opencv.
- Updated `detect.py` to use `check_imshow()` when setting `view_img` for webcam sources.

### 🎯 Purpose & Impact
- The new `check_imshow()` function ensures that users do not encounter errors when their environment lacks the ability to display images using `cv2.imshow()` or `PIL Image.show()`.
- This update enhances user experience by automatically detecting and handling display capability issues, leading to smoother operation across various systems.
- Users with non-compatible display environments can now run YOLOv5 detection without manual code adjustments, broadening the accessible user base. 🚀