### PR TITLE
Add isdocker()

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -47,6 +47,11 @@ def get_latest_run(search_dir='.'):
     return max(last_list, key=os.path.getctime) if last_list else ''
 
 
+def isdocker():
+    # Is environment a Docker container
+    return Path('/workspace').exists()
+
+
 def check_online():
     # Check internet connectivity
     import socket
@@ -62,7 +67,7 @@ def check_git_status():
     print(colorstr('github: '), end='')
     try:
         assert Path('.git').exists(), 'skipping check (not a git repository)'
-        assert not Path('/workspace').exists(), 'skipping check (Docker image)'  # not Path('/.dockerenv').exists()
+        assert not isdocker(), 'skipping check (Docker image)'  # not Path('/.dockerenv').exists()
         assert check_online(), 'skipping check (offline)'
 
         cmd = 'git fetch && git config --get remote.origin.url'
@@ -98,13 +103,14 @@ def check_img_size(img_size, s=32):
 def check_imshow():
     # Check if environment supports image displays
     try:
+        assert not isdocker()
         cv2.imshow('test', np.zeros((1, 1, 3)))
         cv2.waitKey(1)
         cv2.destroyAllWindows()
         cv2.waitKey(1)
         return True
     except Exception as e:
-        print(f'WARNING: Environment does not support cv2.imshow() or PIL Image.show() image previews\n{e}')
+        print(f'WARNING: Environment does not support cv2.imshow() or PIL Image.show() image displays\n{e}')
         return False
 
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -49,7 +49,7 @@ def get_latest_run(search_dir='.'):
 
 def isdocker():
     # Is environment a Docker container
-    return Path('/workspace').exists()
+    return Path('/workspace').exists()  # or Path('/.dockerenv').exists()
 
 
 def check_online():
@@ -67,7 +67,7 @@ def check_git_status():
     print(colorstr('github: '), end='')
     try:
         assert Path('.git').exists(), 'skipping check (not a git repository)'
-        assert not isdocker(), 'skipping check (Docker image)'  # not Path('/.dockerenv').exists()
+        assert not isdocker(), 'skipping check (Docker image)'
         assert check_online(), 'skipping check (offline)'
 
         cmd = 'git fetch && git config --get remote.origin.url'

--- a/utils/general.py
+++ b/utils/general.py
@@ -103,7 +103,7 @@ def check_img_size(img_size, s=32):
 def check_imshow():
     # Check if environment supports image displays
     try:
-        assert not isdocker()
+        assert not isdocker(), 'cv2.imshow() is disabled in Docker environments'
         cv2.imshow('test', np.zeros((1, 1, 3)))
         cv2.waitKey(1)
         cv2.destroyAllWindows()


### PR DESCRIPTION
Second attempt at fix for #2226, command line environment streaming with automatic `--view-img` enabled bug.

First PR is #2231.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Docker detection and environment compatibility checks in Ultralytics YOLOv5 utilities.

### 📊 Key Changes
- Added a new `isdocker()` function to check if the current environment is a Docker container.
- Updated `check_git_status()` to use the new `isdocker()` function for Docker environment detection.
- Enhanced `check_imshow()` function, adding a Docker check to disable image display in Docker environments.

### 🎯 Purpose & Impact
- 🚀 **Increase Clarity**: This PR simplifies Docker environment checks, making the codebase cleaner and more readable.
- 🧱 **Enhanced Compatibility**: It ensures that certain functions behave correctly when YOLOv5 is run inside Docker containers, preventing unnecessary errors.
- 🖥️ **Improved User Experience**: For users working in Docker, it provides clearer warnings about disabled image display capabilities.

This PR helps ensure that the YOLOv5 utilities function appropriately across different environments, especially for developers deploying YOLOv5 in Docker containers.