### PR TITLE
Unified hub and detect.py box and labels plotting

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -11,7 +11,7 @@ from PIL import Image, ImageDraw
 
 from utils.datasets import letterbox
 from utils.general import non_max_suppression, make_divisible, scale_coords, xyxy2xywh
-from utils.plots import color_list
+from utils.plots import color_list, plot_one_box
 
 
 def autopad(k, p=None):  # kernel, padding
@@ -253,10 +253,10 @@ class Detections:
                     n = (pred[:, -1] == c).sum()  # detections per class
                     str += f"{n} {self.names[int(c)]}{'s' * (n > 1)}, "  # add to string
                 if show or save or render:
-                    img = Image.fromarray(img.astype(np.uint8)) if isinstance(img, np.ndarray) else img  # from np
                     for *box, conf, cls in pred:  # xyxy, confidence, class
-                        # str += '%s %.2f, ' % (names[int(cls)], conf)  # label
-                        ImageDraw.Draw(img).rectangle(box, width=4, outline=colors[int(cls) % 10])  # plot
+                        label = f'{self.names[int(cls)]} {conf:.2f}'
+                        plot_one_box(box, img, label=label, color=colors[int(cls) % 10])
+            img = Image.fromarray(img.astype(np.uint8)) if isinstance(img, np.ndarray) else img  # from np
             if pprint:
                 print(str.rstrip(', '))
             if show:


### PR DESCRIPTION
Following our discussion regarding the model from Pytorch Hub (#36), I added the missing class names and confidences next to bounding boxes.

**Before:**

![96368758-114c3a00-1156-11eb-9ede-a03f9aff42e4](https://user-images.githubusercontent.com/623763/108425688-17087800-723b-11eb-91ec-9971603d2d84.jpg)

**After:**

![zidane](https://user-images.githubusercontent.com/623763/108425730-28ea1b00-723b-11eb-9f98-709a8e9ed534.jpg)

It reuses `plot_one_box` used in `detect.py`, therefore the rendering is now the same when using the model through Pytorch Hub or the Python Script.
 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced object detection visualization in YOLOv5.

### 📊 Key Changes
- Replaced manual rectangle drawing with `plot_one_box` function for bounding box visualization on detected objects.
- Moved the conversion of `np.ndarray` to `Image` outside the loop for better code efficiency.

### 🎯 Purpose & Impact
- **Purpose:** To improve the way bounding boxes and labels are drawn on images, making them clearer and more informative.
- **Impact:** Users will benefit from more readable and professional visual output when displaying or saving detection results. The update may also improve the speed and efficiency of visualization in the codebase.🚀

🎨 The change also promotes code reuse by utilizing an existing utility function (`plot_one_box`), which streamlines further maintenance and upgrades.