### PR TITLE
 YOLOv5 Hub URL inference bug fix

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -200,8 +200,8 @@ class autoShape(nn.Module):
         for i, im in enumerate(imgs):
             if isinstance(im, str):  # filename or uri
                 im, f = Image.open(requests.get(im, stream=True).raw if im.startswith('http') else im), im  # open
-            files.append(Path(f).with_suffix('.jpg').name if isinstance(im, Image.Image) else f'image{i}.jpg')
-            im = np.array(im)  # to numpy
+                im.filename = f  # for uri
+            files.append(Path(im.filename).with_suffix('.jpg').name if isinstance(im, Image.Image) else f'image{i}.jpg')
             if im.shape[0] < 5:  # image in CHW
                 im = im.transpose((1, 2, 0))  # reverse dataloader .transpose(2, 0, 1)
             im = im[:, :, :3] if im.ndim == 3 else np.tile(im[:, :, None], 3)  # enforce 3ch input

--- a/models/common.py
+++ b/models/common.py
@@ -199,8 +199,8 @@ class autoShape(nn.Module):
         shape0, shape1, files = [], [], []  # image and inference shapes, filenames
         for i, im in enumerate(imgs):
             if isinstance(im, str):  # filename or uri
-                im = Image.open(requests.get(im, stream=True).raw if im.startswith('http') else im)  # open
-            files.append(Path(im.filename).with_suffix('.jpg').name if isinstance(im, Image.Image) else f'image{i}.jpg')
+                im, f = Image.open(requests.get(im, stream=True).raw if im.startswith('http') else im), im  # open
+            files.append(Path(f).with_suffix('.jpg').name if isinstance(im, Image.Image) else f'image{i}.jpg')
             im = np.array(im)  # to numpy
             if im.shape[0] < 5:  # image in CHW
                 im = im.transpose((1, 2, 0))  # reverse dataloader .transpose(2, 0, 1)

--- a/models/common.py
+++ b/models/common.py
@@ -202,6 +202,7 @@ class autoShape(nn.Module):
                 im, f = Image.open(requests.get(im, stream=True).raw if im.startswith('http') else im), im  # open
                 im.filename = f  # for uri
             files.append(Path(im.filename).with_suffix('.jpg').name if isinstance(im, Image.Image) else f'image{i}.jpg')
+            im = np.array(im)  # to numpy
             if im.shape[0] < 5:  # image in CHW
                 im = im.transpose((1, 2, 0))  # reverse dataloader .transpose(2, 0, 1)
             im = im[:, :, :3] if im.ndim == 3 else np.tile(im[:, :, None], 3)  # enforce 3ch input
@@ -253,7 +254,7 @@ class Detections:
                     n = (pred[:, -1] == c).sum()  # detections per class
                     str += f"{n} {self.names[int(c)]}{'s' * (n > 1)}, "  # add to string
                 if show or save or render:
-                    img = Image.fromarray(img.astype(np.uint8)) if isinstance(img, np.ndarray) else img  # from np
+                    img = Image.fromarray(img) if isinstance(img, np.ndarray) else img  # from np
                     for *box, conf, cls in pred:  # xyxy, confidence, class
                         # str += '%s %.2f, ' % (names[int(cls)], conf)  # label
                         ImageDraw.Draw(img).rectangle(box, width=4, outline=colors[int(cls) % 10])  # plot


### PR DESCRIPTION
Fix for #2246 PyTorch Hub URL inference bug.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image handling in YOLOv5 model's forward and display methods.

### 📊 Key Changes
- 🖼️ Assigned the original filename to images opened from a URI, ensuring consistency in how images are referenced.
- ✂️ Modified the handling of non-array images to maintain the original image type during the image display process.

### 🎯 Purpose & Impact
- 🗂️ The assignment of filenames to images loaded from URIs makes debugging and tracking easier, as each image maintains its original reference name.
- 🎨 Ensures that the displayed images remain true to their input format, improving compatibility and visualization quality without altering the underlying image data type.

These changes are aimed at enhancing the usability and reliability of the model inference and visualization process, which can lead to a more user-friendly experience for developers and users alike.