### PR TITLE
Improved hubconf.py CI tests

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -133,9 +133,14 @@ if __name__ == '__main__':
     # model = custom(path_or_model='path/to/model.pt')  # custom example
 
     # Verify inference
+    import numpy as np
     from PIL import Image
 
-    imgs = [Image.open(x) for x in Path('data/images').glob('*.jpg')]
-    results = model(imgs)
+    imgs = [Image.open('data/images/bus.jpg'),  # PIL
+            'data/images/zidane.jpg',  # filename
+            'https://github.com/ultralytics/yolov5/raw/master/data/images/bus.jpg',  # URI
+            np.zeros((640, 480, 3))]  # numpy
+
+    results = model(imgs)  # batched inference
     results.print()
     results.save()

--- a/models/common.py
+++ b/models/common.py
@@ -254,7 +254,7 @@ class Detections:
                     n = (pred[:, -1] == c).sum()  # detections per class
                     str += f"{n} {self.names[int(c)]}{'s' * (n > 1)}, "  # add to string
                 if show or save or render:
-                    img = Image.fromarray(img) if isinstance(img, np.ndarray) else img  # from np
+                    img = Image.fromarray(img.astype(np.uint8)) if isinstance(img, np.ndarray) else img  # from np
                     for *box, conf, cls in pred:  # xyxy, confidence, class
                         # str += '%s %.2f, ' % (names[int(cls)], conf)  # label
                         ImageDraw.Draw(img).rectangle(box, width=4, outline=colors[int(cls) % 10])  # plot


### PR DESCRIPTION
Followon to #2250. This PR inreases the hubconf.py tests run in main(), which is called during each CI test. This will allow us to catch errors in the various YOLOv5 Hub inference formats earlier. Tests are updated to below:

```python
    # Verify inference
    import numpy as np
    from PIL import Image

    imgs = [Image.open('data/images/bus.jpg'),  # PIL
            'data/images/zidane.jpg',  # filename
            'https://github.com/ultralytics/yolov5/raw/master/data/images/bus.jpg',  # URI
            np.zeros((640, 480, 3))]  # numpy

    results = model(imgs)  # batched inference
    results.print()
    results.save()
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image input handling for custom model inference in YOLOv5.

### 📊 Key Changes
- Added support for various types of image inputs, including PIL images, file paths, URLs, and NumPy arrays.
- Ensured proper type conversion of NumPy images to PIL images within the `display` function.

### 🎯 Purpose & Impact
- **Flexibility:** Allows users to pass different image formats directly to the model, enhancing ease of use.
- **Consistency:** Conversion to `uint8` for NumPy images prevents type issues, ensuring consistent rendering and visualization.
- **User Experience:** With these changes, the model becomes more accessible for batched inference, benefiting users who work with multiple image sources. 📈🖼️