### PR TITLE
Robust objectness loss balancing

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -105,8 +105,8 @@ class ComputeLoss:
             BCEcls, BCEobj = FocalLoss(BCEcls, g), FocalLoss(BCEobj, g)
 
         det = model.module.model[-1] if is_parallel(model) else model.model[-1]  # Detect() module
-        self.balance = {3: [4.0, 1.0, 0.4], 4: [4.0, 1.0, 0.25, 0.06], 5: [4.0, 1.0, 0.25, 0.06, .02]}[det.nl]
-        self.ssi = (det.stride == 16).nonzero(as_tuple=False).item()  # stride 16 index
+        self.balance = {3: [4.0, 1.0, 0.4]}.get(det.nl, [4.0, 1.0, 0.25, 0.06, .02])  # P3-P7
+        self.ssi = list(det.stride).index(16) if autobalance else 0  # stride 16 index
         self.BCEcls, self.BCEobj, self.gr, self.hyp, self.autobalance = BCEcls, BCEobj, model.gr, h, autobalance
         for k in 'na', 'nc', 'nl', 'anchors':
             setattr(self, k, getattr(det, k))


### PR DESCRIPTION
Fix for #2255, where training breaks when P5 layer is removed because the loss function balancing dictionary only supplied keys for 3, 4 and 5 layers.

Objectness loss balancing terms are now robust to all layer counts from 1 to 5. The values correspond to P3-P7 (in order).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimizing loss function in YOLOv5 for improved model balance and flexibility.

### 📊 Key Changes
- Updated balance dictionary handling for different numbers of layers (nl) to be more flexible.
- Modified stride index (ssi) to support dynamic assignment based on the presence of `autobalance`.

### 🎯 Purpose & Impact
- 🎛 **Improved model flexibility:** Allows more robust handling of different configurations, which may lead to better performance on diverse datasets.
- ⚙️ **Enhanced autobalance feature:** With the conditional stride index assignment, the loss function adapts more intelligently to the autobalance state, potentially improving the model's loss calculation and ultimately its training efficacy.
- 🔍 **Potential for better results:** Users might experience improved detection results due to the nuanced allocation of loss weights and stride handling during training.