### PR TITLE
Update minimum stride to 32

### DIFF
--- a/test.py
+++ b/test.py
@@ -52,7 +52,8 @@ def test(data,
 
         # Load model
         model = attempt_load(weights, map_location=device)  # load FP32 model
-        imgsz = check_img_size(imgsz, s=model.stride.max())  # check img_size
+        gs = max(int(model.stride.max()), 32)  # grid size (max stride)
+        imgsz = check_img_size(imgsz, s=gs)  # check img_size
 
         # Multi-GPU disabled, incompatible with .half() https://github.com/ultralytics/yolov5/issues/99
         # if device.type != 'cpu' and torch.cuda.device_count() > 1:
@@ -85,7 +86,7 @@ def test(data,
         if device.type != 'cpu':
             model(torch.zeros(1, 3, imgsz, imgsz).to(device).type_as(next(model.parameters())))  # run once
         path = data['test'] if opt.task == 'test' else data['val']  # path to val/test images
-        dataloader = create_dataloader(path, imgsz, batch_size, model.stride.max(), opt, pad=0.5, rect=True,
+        dataloader = create_dataloader(path, imgsz, batch_size, gs, opt, pad=0.5, rect=True,
                                        prefix=colorstr('test: ' if opt.task == 'test' else 'val: '))[0]
 
     seen = 0

--- a/train.py
+++ b/train.py
@@ -161,7 +161,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
         del ckpt, state_dict
 
     # Image sizes
-    gs = int(model.stride.max())  # grid size (max stride)
+    gs = max(int(model.stride.max()), 32)  # grid size (max stride)
     nl = model.model[-1].nl  # number of detection layers (used for scaling hyp['obj'])
     imgsz, imgsz_test = [check_img_size(x, gs) for x in opt.img_size]  # verify imgsz are gs-multiples
 


### PR DESCRIPTION
Fix for #2255, where removal of P5 layer cause max stride 16 (from P4 layer) to be insufficient to properly downscale and upscale the image during inference. Minimum stride now set at 32 regardless of model architecture, with larger models (i.e. P6 models) requiring correspondingly larger min stride, 64 in the case of P6 for example).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved grid size handling in YOLOv5 image processing functions.

### 📊 Key Changes
- Updated the `grid size (gs)` calculation to be the maximum of model stride and 32.
- Applied this new `grid size` calculation to both `test.py` and `train.py`.

### 🎯 Purpose & Impact
- Ensures that the grid size is adequately large for models with small strides, improving image handling.
- This change could result in more consistent and reliable input image sizing across different models, potentially leading to enhanced model performance and stability.