### PR TITLE
FLOPS min stride 32

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -205,7 +205,7 @@ def model_info(model, verbose=False, img_size=640):
 
     try:  # FLOPS
         from thop import profile
-        stride = int(model.stride.max()) if hasattr(model, 'stride') else 32
+        stride = max(int(model.stride.max()), 32) if hasattr(model, 'stride') else 32
         img = torch.zeros((1, model.yaml.get('ch', 3), stride, stride), device=next(model.parameters()).device)  # input
         flops = profile(deepcopy(model), inputs=(img,), verbose=False)[0] / 1E9 * 2  # stride GFLOPS
         img_size = img_size if isinstance(img_size, list) else [img_size, img_size]  # expand if int/float


### PR DESCRIPTION
when i finished the trainning, I want to test my trained model which i use P3-P4.  but i find the FLOPS parameter missing which is important to  measure the performance of a model.
![missing](https://user-images.githubusercontent.com/24860639/108839338-eb590980-760f-11eb-8c92-11b3182388b1.jpg)
I guess the same reason that the stride is to small ,so after update minmum stride to 32,the issue is solved.
![solved](https://user-images.githubusercontent.com/24860639/108840291-1abc4600-7611-11eb-9639-cccfb930e76b.png)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced accuracy in calculating model FLOPS for various strides in YOLOv5.

### 📊 Key Changes
- Modified the way stride is calculated to ensure it is at least 32, even if the model's stride attribute is higher.

### 🎯 Purpose & Impact
- Ensures more precise computation of FLOPS (FLoating-point OPerations Per Second), particularly when the model's stride is greater than 32. 
- This change can provide developers and users a better understanding of the model's computational complexity and efficiency.
- 🏃 Users can expect more accurate performance estimations when selecting models for devices with different computational capacities.