### PR TITLE
Get predictions as base64

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -11,7 +11,7 @@ from PIL import Image, ImageDraw
 
 from utils.datasets import letterbox
 from utils.general import non_max_suppression, make_divisible, scale_coords, xyxy2xywh
-from utils.plots import color_list
+from utils.plots import color_list, plot_one_box
 
 
 def autopad(k, p=None):  # kernel, padding
@@ -253,10 +253,10 @@ class Detections:
                     n = (pred[:, -1] == c).sum()  # detections per class
                     str += f"{n} {self.names[int(c)]}{'s' * (n > 1)}, "  # add to string
                 if show or save or render:
-                    img = Image.fromarray(img.astype(np.uint8)) if isinstance(img, np.ndarray) else img  # from np
                     for *box, conf, cls in pred:  # xyxy, confidence, class
-                        # str += '%s %.2f, ' % (names[int(cls)], conf)  # label
-                        ImageDraw.Draw(img).rectangle(box, width=4, outline=colors[int(cls) % 10])  # plot
+                        label = f'{self.names[int(cls)]} {conf:.2f}'
+                        plot_one_box(box, img, label=label, color=colors[int(cls) % 10])
+            img = Image.fromarray(img.astype(np.uint8)) if isinstance(img, np.ndarray) else img  # from np
             if pprint:
                 print(str.rstrip(', '))
             if show:

--- a/models/common.py
+++ b/models/common.py
@@ -274,7 +274,7 @@ class Detections:
                 buffered = BytesIO()
                 img.save(buffered, format="JPEG")
                 img_base64 = base64.b64encode(buffered.getvalue()).decode('utf-8')
-                print(img_base64)
+                return img_base64
 
 
     def print(self):
@@ -292,7 +292,7 @@ class Detections:
         return self.imgs
 
     def tobase64(self):
-        self.display(base_64=True)
+        return self.display(base_64=True)
 
     def __len__(self):
         return self.n

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -1033,19 +1033,52 @@ def extract_boxes(path='../coco128/'):  # from utils.datasets import *; extract_
                     assert cv2.imwrite(str(f), im[b[1]:b[3], b[0]:b[2]]), f'box failure in {f}'
 
 
-def autosplit(path='../coco128', weights=(0.9, 0.1, 0.0)):  # from utils.datasets import *; autosplit('../coco128')
+def autosplit(path='../coco128', weights=(0.9, 0.1, 0.0), annotated_only=False, bg_imgs_path=None, bg_imgs_ratio=0.05): # from utils.datasets import *; autosplit('../coco128')
+
     """ Autosplit a dataset into train/val/test splits and save path/autosplit_*.txt files
     # Arguments
-        path:       Path to images directory
-        weights:    Train, val, test weights (list)
+        path:           Path to images directory
+        weights:        Train, val, test weights (list)
+        annotated_only: Only use images with an annotated txt file associated to create the dataset
+        bg_imgs_path:   Path to background images to introduce inside the dataset (to reduce FPs)
+        bg_imgs_ratio:  Ratio of background images to add according to the number of images in each split
     """
+
     path = Path(path)  # images dir
-    files = list(path.rglob('*.*'))
+
+    # make sure we only work with images files
+    files = sum([list(path.rglob(f"*.{img_ext}")) for img_ext in img_formats], [])
     n = len(files)  # number of files
+
     indices = random.choices([0, 1, 2], weights=weights, k=n)  # assign each image to a split
+
     txt = ['autosplit_train.txt', 'autosplit_val.txt', 'autosplit_test.txt']  # 3 txt files
     [(path / x).unlink() for x in txt if (path / x).exists()]  # remove existing
+
+    if annotated_only:
+        print("Only annotated images with a .txt file associated will be used to create the dataset")
+
+    bg_dataset_sizes = [0, 0, 0] # calculate num of bg images needed for each split
     for i, img in tqdm(zip(indices, files), total=n):
-        if img.suffix[1:] in img_formats:
+        # in case we want to use only annotated files
+        if not annotated_only or (annotated_only and (img.parent / (img.stem + ".txt")).exists()):
             with open(path / txt[i], 'a') as f:
                 f.write(str(img) + '\n')  # add image to txt file
+            bg_dataset_sizes[i] += bg_imgs_ratio
+
+    # automatically fill our dataset with background images
+    if bg_imgs_path:
+        assert 0 < bg_imgs_ratio <= 0.1, "We recommend a background images ratio between 0% (0) and 10% (0.1)"
+        bg_path = Path(bg_imgs_path)
+        bg_files = sum([list(bg_path.rglob(f"*.{img_ext}")) for img_ext in img_formats], [])
+
+        print("Filling the dataset with some background images...")
+
+        # keep only the number of bg images needed
+        bg_files = random.sample(bg_files, round(sum(bg_dataset_sizes)))
+        bg_indices = random.choices([0, 1, 2], weights=weights, k=len(bg_files))
+
+        for i, img in tqdm(zip(bg_indices, bg_files), total=len(bg_files)):
+            with open(path / txt[i], 'a') as f:
+                f.write(str(img) + '\n')  # add image to txt file
+


### PR DESCRIPTION
Since we integrated the bounding boxes and the class names on inference images in the Pytorch Hub version with #2243, it would be nice to integrate another functionality to export this image as base64 as well.

We can see that some people are starting to integrate yolov5 as an API service, and they face some issues to generate the bounding boxes and the class names:

https://github.com/WelkinU/yolov5-fastapi-demo/blob/910f09d731d13c71a68ae2e5c09b7699b47f097d/server.py#L55-L91

Now that we fixed it, adding this little `tobase64` could help people to return a predicted image to their client if needed. 

There is one question though with the `display` function, it seems it can be used for batches and I don't know if this `tobase64` function will handle this properly.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introduced base64 image encoding and dataset improvement features

### 📊 Key Changes
- Added `base64` image encoding support in `models/common.py` for exporting detection results.
- Introduced new `autosplit` parameters to filter datasets based on annotations and add background images in `utils/datasets.py`.

### 🎯 Purpose & Impact
- **base64 Encoding**: Allows for easier integration with web applications by encoding detection results in base64, enabling inline display without the need for separate image files.
- **Annotated-Only Splitting**: With `annotated_only` parameter, datasets can be built using only images with corresponding annotation files, which can help with training accuracy.
- **Background Image Addition**: The addition of background images to the dataset using `bg_imgs_path` and `bg_imgs_ratio` aims to reduce false positives by providing more diverse non-object examples.

The changes make YOLOv5 more versatile for different user scenarios, potentially leading to more robust models and easier deployment in web environments. 🚀