### PR TITLE
Improved model+EMA checkpointing

### DIFF
--- a/test.py
+++ b/test.py
@@ -272,7 +272,6 @@ def test(data,
     if not training:
         s = f"\n{len(list(save_dir.glob('labels/*.txt')))} labels saved to {save_dir / 'labels'}" if save_txt else ''
         print(f"Results saved to {save_dir}{s}")
-    model.float()  # for training
     maps = np.zeros(nc) + map
     for i, c in enumerate(ap_class):
         maps[c] = ap[i]

--- a/test.py
+++ b/test.py
@@ -272,6 +272,7 @@ def test(data,
     if not training:
         s = f"\n{len(list(save_dir.glob('labels/*.txt')))} labels saved to {save_dir / 'labels'}" if save_txt else ''
         print(f"Results saved to {save_dir}{s}")
+    model.float()  # for training
     maps = np.zeros(nc) + map
     for i, c in enumerate(ap_class):
         maps[c] = ap[i]

--- a/train.py
+++ b/train.py
@@ -148,8 +148,9 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
             best_fitness = ckpt['best_fitness']
 
         # EMA
-        if ckpt.get('ema'):
-            pass
+        if ema and ckpt.get('ema'):
+            ema.ema.load_statedict(ckpt['ema'][0].float().to(device).statedict())
+            ema.updates = ckpt['ema'][1]
 
         # Results
         if ckpt.get('training_results') is not None:

--- a/train.py
+++ b/train.py
@@ -385,7 +385,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                         'training_results': results_file.read_text(),
                         'model': model,
                         'ema': (ema.ema, ema.updates),
-                        'optimizer': None if final_epoch else optimizer.state_dict(),
+                        'optimizer': optimizer.state_dict(),
                         'wandb_id': wandb_run.id if wandb else None}
 
                 # Save last, best and delete

--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@ import math
 import os
 import random
 import time
+from copy import deepcopy
 from pathlib import Path
 from threading import Thread
 
@@ -383,7 +384,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                 ckpt = {'epoch': epoch,
                         'best_fitness': best_fitness,
                         'training_results': results_file.read_text(),
-                        'model': model,
+                        'model': deepcopy(model).half(),
                         'ema': (ema.ema, ema.updates),
                         'optimizer': optimizer.state_dict(),
                         'wandb_id': wandb_run.id if wandb else None}

--- a/train.py
+++ b/train.py
@@ -31,7 +31,7 @@ from utils.general import labels_to_class_weights, increment_path, labels_to_ima
 from utils.google_utils import attempt_download
 from utils.loss import ComputeLoss
 from utils.plots import plot_images, plot_labels, plot_results, plot_evolution
-from utils.torch_utils import ModelEMA, select_device, intersect_dicts, torch_distributed_zero_first
+from utils.torch_utils import ModelEMA, select_device, intersect_dicts, torch_distributed_zero_first, is_parallel
 
 logger = logging.getLogger(__name__)
 
@@ -381,7 +381,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                 ckpt = {'epoch': epoch,
                         'best_fitness': best_fitness,
                         'training_results': results_file.read_text(),
-                        'model': model.half(),
+                        'model': (model.module if is_parallel(model) else model).half(),
                         'ema': (ema.ema.half(), ema.updates),
                         'optimizer': optimizer.state_dict(),
                         'wandb_id': wandb_run.id if wandb else None}

--- a/train.py
+++ b/train.py
@@ -196,7 +196,6 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
 
     # Process 0
     if rank in [-1, 0]:
-        ema.updates = start_epoch * nb // accumulate  # set EMA updates
         testloader = create_dataloader(test_path, imgsz_test, batch_size * 2, gs, opt,  # testloader
                                        hyp=hyp, cache=opt.cache_images and not opt.notest, rect=True, rank=-1,
                                        world_size=opt.world_size, workers=opt.workers,
@@ -340,8 +339,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
         # DDP process 0 or single-GPU
         if rank in [-1, 0]:
             # mAP
-            if ema:
-                ema.update_attr(model, include=['yaml', 'nc', 'hyp', 'gr', 'names', 'stride', 'class_weights'])
+            ema.update_attr(model, include=['yaml', 'nc', 'hyp', 'gr', 'names', 'stride', 'class_weights'])
             final_epoch = epoch + 1 == epochs
             if not opt.notest or final_epoch:  # Calculate mAP
                 results, maps, times = test.test(opt.data,
@@ -450,7 +448,7 @@ if __name__ == '__main__':
     parser.add_argument('--hyp', type=str, default='data/hyp.scratch.yaml', help='hyperparameters path')
     parser.add_argument('--epochs', type=int, default=300)
     parser.add_argument('--batch-size', type=int, default=16, help='total batch size for all GPUs')
-    parser.add_argument('--img-size', nargs='+', type=int, default=[128, 128], help='[train, test] image sizes')
+    parser.add_argument('--img-size', nargs='+', type=int, default=[640, 640], help='[train, test] image sizes')
     parser.add_argument('--rect', action='store_true', help='rectangular training')
     parser.add_argument('--resume', nargs='?', const=True, default=False, help='resume most recent training')
     parser.add_argument('--nosave', action='store_true', help='only save final checkpoint')

--- a/train.py
+++ b/train.py
@@ -4,7 +4,6 @@ import math
 import os
 import random
 import time
-from copy import deepcopy
 from pathlib import Path
 from threading import Thread
 
@@ -384,8 +383,8 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                 ckpt = {'epoch': epoch,
                         'best_fitness': best_fitness,
                         'training_results': results_file.read_text(),
-                        'model': deepcopy(model).half(),
-                        'ema': (ema.ema, ema.updates),
+                        'model': model.half(),
+                        'ema': (ema.ema.half(), ema.updates),
                         'optimizer': optimizer.state_dict(),
                         'wandb_id': wandb_run.id if wandb else None}
 
@@ -394,6 +393,8 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                 if best_fitness == fi:
                     torch.save(ckpt, best)
                 del ckpt
+                model.float(), ema.ema.float()
+
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training
 

--- a/train.py
+++ b/train.py
@@ -149,7 +149,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
 
         # EMA
         if ema and ckpt.get('ema'):
-            ema.ema.load_state_dict(ckpt['ema'][0].float().statedict())
+            ema.ema.load_state_dict(ckpt['ema'][0].float().state_dict())
             ema.updates = ckpt['ema'][1]
 
         # Results

--- a/train.py
+++ b/train.py
@@ -393,7 +393,8 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                 if best_fitness == fi:
                     torch.save(ckpt, best)
                 del ckpt
-                model.float(), ema.ema.float()
+
+            model.float(), ema.ema.float()
 
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training

--- a/train.py
+++ b/train.py
@@ -149,7 +149,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
 
         # EMA
         if ema and ckpt.get('ema'):
-            ema.ema.load_statedict(ckpt['ema'][0].float().to(device).statedict())
+            ema.ema.load_state_dict(ckpt['ema'][0].float().statedict())
             ema.updates = ckpt['ema'][1]
 
         # Results

--- a/utils/general.py
+++ b/utils/general.py
@@ -484,8 +484,8 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
 def strip_optimizer(f='weights/best.pt', s=''):  # from utils.general import *; strip_optimizer()
     # Strip optimizer from 'f' to finalize training, optionally save as 's'
     x = torch.load(f, map_location=torch.device('cpu'))
-    for key in 'optimizer', 'training_results', 'wandb_id':
-        x[key] = None
+    for k in 'optimizer', 'training_results', 'wandb_id', 'ema':  # keys
+        x[k] = None
     x['epoch'] = -1
     x['model'].half()  # to FP16
     for p in x['model'].parameters():

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -270,8 +270,8 @@ class ModelEMA:
     def __init__(self, model, decay=0.9999, updates=0):
         # Create EMA
         self.ema = deepcopy(model.module if is_parallel(model) else model).eval()  # FP32 EMA
-        if next(model.parameters()).device.type != 'cpu':
-            self.ema.half()  # FP16 EMA
+        # if next(model.parameters()).device.type != 'cpu':
+        #     self.ema.half()  # FP16 EMA
         self.updates = updates  # number of EMA updates
         self.decay = lambda x: decay * (1 - math.exp(-x / 2000))  # decay exponential ramp (to help early epochs)
         for p in self.ema.parameters():

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -270,8 +270,8 @@ class ModelEMA:
     def __init__(self, model, decay=0.9999, updates=0):
         # Create EMA
         self.ema = deepcopy(model.module if is_parallel(model) else model).eval()  # FP32 EMA
-        # if next(model.parameters()).device.type != 'cpu':
-        #     self.ema.half()  # FP16 EMA
+        if next(model.parameters()).device.type != 'cpu':
+            self.ema.half()  # FP16 EMA
         self.updates = updates  # number of EMA updates
         self.decay = lambda x: decay * (1 - math.exp(-x / 2000))  # decay exponential ramp (to help early epochs)
         for p in self.ema.parameters():


### PR DESCRIPTION
This PR integrates **model** checkpointing along with the current **EMA** checkpointing. This should produce more perfect `--resume` results.

Before: EMA FP32 + optimizer state dict FP32 checkpoints.
After: EMA FP16 + Model FP16 + optimizer state dict FP32 checkpoints.

Tested in Docker: on CPU, GPU, Multi-GPU DP, Multi-GPU DDP, Multi-GPU DDP + Sync

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
PR improves code organization, EMA handling, and checkpoint saving within the Ultralytics YOLOv5 training pipeline.

### 📊 Key Changes
- Removed redundant code that cast a model to floating-point after testing.
- Integrated the Exponential Moving Average (EMA) model update directly into the training loop.
- Ensured EMA state and update count are properly loaded from checkpoints during resume.
- Moved the EMA instantiation to earlier in the training process to avoid potential issues.
- Adjusted checkpoint saving to include the EMA state and update count explicitly.
- Generalized the optimizer state stripping method to also remove keys related to EMA and other training artifacts when finalizing training weights.

### 🎯 Purpose & Impact
- Streamlines the training process and improves the management of the EMA model, which is crucial for stabilizing model weights during training. 🏋️‍♂️
- Facilitates better resumption of training by accurately restoring the EMA state, allowing for a seamless continuation of the training process. 🔄
- Reduces the risk of errors by ensuring that the EMA updates are correctly accounted for from the start of training. 🔍
- Simplifies the final model artifact by stripping unnecessary information, making it easier for users to deploy the model in production environments. 🚀
- Overall, these changes could lead to improved model performance and a more user-friendly training experience for developers using Ultralytics YOLOv5. 📈