### PR TITLE
GPU export options

### DIFF
--- a/models/export.py
+++ b/models/export.py
@@ -8,7 +8,6 @@ import argparse
 import sys
 import time
 
-from utils.torch_utils import select_device
 
 sys.path.append('./')  # to run '$ python *.py' files in subdirectories
 
@@ -19,6 +18,7 @@ import models
 from models.experimental import attempt_load
 from utils.activations import Hardswish, SiLU
 from utils.general import set_logging, check_img_size
+from utils.torch_utils import select_device
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/models/export.py
+++ b/models/export.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     parser.add_argument('--batch-size', type=int, default=1, help='batch size')
     parser.add_argument('--dynamic', action='store_true', help='dynamic ONNX axes')
     parser.add_argument('--grid', action='store_true', help='export Detect() layer grid')
-    parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
+    parser.add_argument('--device', default='cpu', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     opt = parser.parse_args()
     opt.img_size *= 2 if len(opt.img_size) == 1 else 1  # expand
     print(opt)

--- a/models/export.py
+++ b/models/export.py
@@ -8,7 +8,6 @@ import argparse
 import sys
 import time
 
-
 sys.path.append('./')  # to run '$ python *.py' files in subdirectories
 
 import torch
@@ -24,9 +23,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--weights', type=str, default='./yolov5s.pt', help='weights path')  # from yolov5/models/
     parser.add_argument('--img-size', nargs='+', type=int, default=[640, 640], help='image size')  # height, width
-    parser.add_argument('--dynamic', action='store_true', help='dynamic ONNX axes')
     parser.add_argument('--batch-size', type=int, default=1, help='batch size')
-    parser.add_argument('--skip-last-layer', action='store_true', help='skip export of last (detect) layer')
+    parser.add_argument('--dynamic', action='store_true', help='dynamic ONNX axes')
+    parser.add_argument('--skip-grid', action='store_true', help='skip Detect() layer grid computation')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     opt = parser.parse_args()
     opt.img_size *= 2 if len(opt.img_size) == 1 else 1  # expand
@@ -56,10 +55,7 @@ if __name__ == '__main__':
                 m.act = SiLU()
         # elif isinstance(m, models.yolo.Detect):
         #     m.forward = m.forward_export  # assign forward (optional)
-    if opt.skip_last_layer:
-        model.model[-1].export = False  # set Detect() layer export=False
-    else:
-        model.model[-1].export = True  # set Detect() layer export=True
+    model.model[-1].export = not opt.skip_grid  # set Detect() layer export Boolean
     y = model(img)  # dry run
 
     # TorchScript export

--- a/models/export.py
+++ b/models/export.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     parser.add_argument('--img-size', nargs='+', type=int, default=[640, 640], help='image size')  # height, width
     parser.add_argument('--batch-size', type=int, default=1, help='batch size')
     parser.add_argument('--dynamic', action='store_true', help='dynamic ONNX axes')
-    parser.add_argument('--skip-grid', action='store_true', help='skip Detect() layer grid computation')
+    parser.add_argument('--no-grid', action='store_true', help='no Detect() layer grid computation')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     opt = parser.parse_args()
     opt.img_size *= 2 if len(opt.img_size) == 1 else 1  # expand
@@ -55,7 +55,7 @@ if __name__ == '__main__':
                 m.act = SiLU()
         # elif isinstance(m, models.yolo.Detect):
         #     m.forward = m.forward_export  # assign forward (optional)
-    model.model[-1].export = not opt.skip_grid  # set Detect() layer export Boolean
+    model.model[-1].export = not opt.no_grid  # set Detect() layer grid export
     y = model(img)  # dry run
 
     # TorchScript export

--- a/models/export.py
+++ b/models/export.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     parser.add_argument('--img-size', nargs='+', type=int, default=[640, 640], help='image size')  # height, width
     parser.add_argument('--batch-size', type=int, default=1, help='batch size')
     parser.add_argument('--dynamic', action='store_true', help='dynamic ONNX axes')
-    parser.add_argument('--no-grid', action='store_true', help='no Detect() layer grid computation')
+    parser.add_argument('--grid', action='store_true', help='export Detect() layer grid')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     opt = parser.parse_args()
     opt.img_size *= 2 if len(opt.img_size) == 1 else 1  # expand
@@ -55,7 +55,7 @@ if __name__ == '__main__':
                 m.act = SiLU()
         # elif isinstance(m, models.yolo.Detect):
         #     m.forward = m.forward_export  # assign forward (optional)
-    model.model[-1].export = not opt.no_grid  # set Detect() layer grid export
+    model.model[-1].export = not opt.grid  # set Detect() layer grid export
     y = model(img)  # dry run
 
     # TorchScript export

--- a/models/export.py
+++ b/models/export.py
@@ -8,6 +8,8 @@ import argparse
 import sys
 import time
 
+from utils.torch_utils import select_device
+
 sys.path.append('./')  # to run '$ python *.py' files in subdirectories
 
 import torch
@@ -25,6 +27,7 @@ if __name__ == '__main__':
     parser.add_argument('--dynamic', action='store_true', help='dynamic ONNX axes')
     parser.add_argument('--batch-size', type=int, default=1, help='batch size')
     parser.add_argument('--skip-last-layer', action='store_true', help='skip export of last (detect) layer')
+    parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     opt = parser.parse_args()
     opt.img_size *= 2 if len(opt.img_size) == 1 else 1  # expand
     print(opt)
@@ -32,7 +35,7 @@ if __name__ == '__main__':
     t = time.time()
 
     # Load PyTorch model
-    device = torch.device("cuda:0") if torch.cuda.is_available() else "cpu"
+    device = select_device(opt.device)
     model = attempt_load(opt.weights, map_location=device)  # load FP32 model
     labels = model.names
 


### PR DESCRIPTION
- added suport for GPU export
- added option to skip last (Detection) layer

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgraded YOLOv5 export script for more versatility in ONNX and TorchScript model exporting.

### 📊 Key Changes
- 🔄 Reordered the `--dynamic` argument for consistency.
- 🆕 Added `--grid` argument to control the export of the Detect() layer grid.
- 🆕 Introduced `--device` argument to specify the target device (CPU/GPU) for model loading.
- 🛠 Modified device selection to use `select_device` utility function for flexibility in model device placement.
- 🧰 Refactored model and dummy input tensor to accommodate the specified device.

### 🎯 Purpose & Impact
- 🎛 These updates provide users with improved control over the export process, especially in choosing where the model gets loaded (CPU or GPU) and managing dynamic axes in ONNX models.
- 💻 By including the option to export the Detect() layer grid, users have more flexibility depending on their deployment needs, which could enhance performance for specific use-cases.
- 👥 The changes can potentially benefit both experts looking for fine-grained control over model exporting and novices who need simpler device management.

These updates aim to streamline the exporting process for YOLOv5 users and make the models more adaptable for various deployment environments and scenarios.