### PR TITLE
W&B entity support

### DIFF
--- a/train.py
+++ b/train.py
@@ -133,7 +133,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
         wandb_run = wandb.init(config=opt, resume="allow",
                                project='YOLOv5' if opt.project == 'runs/train' else Path(opt.project).stem,
                                name=save_dir.stem,
-                               entity=opt.wandb_entity,
+                               entity=opt.entity,
                                id=ckpt.get('wandb_id') if 'ckpt' in locals() else None)
     loggers = {'wandb': wandb}  # loggers dict
 
@@ -465,7 +465,7 @@ if __name__ == '__main__':
     parser.add_argument('--log-artifacts', action='store_true', help='log artifacts, i.e. final trained model')
     parser.add_argument('--workers', type=int, default=8, help='maximum number of dataloader workers')
     parser.add_argument('--project', default='runs/train', help='save to project/name')
-    parser.add_argument('--wandb_entity', default=None, help='W&B entity')
+    parser.add_argument('--entity', default=None, help='W&B entity')
     parser.add_argument('--name', default='exp', help='save to project/name')
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     parser.add_argument('--quad', action='store_true', help='quad dataloader')

--- a/train.py
+++ b/train.py
@@ -133,6 +133,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
         wandb_run = wandb.init(config=opt, resume="allow",
                                project='YOLOv5' if opt.project == 'runs/train' else Path(opt.project).stem,
                                name=save_dir.stem,
+                               entity=opt.wandb_entity,
                                id=ckpt.get('wandb_id') if 'ckpt' in locals() else None)
     loggers = {'wandb': wandb}  # loggers dict
 
@@ -464,6 +465,7 @@ if __name__ == '__main__':
     parser.add_argument('--log-artifacts', action='store_true', help='log artifacts, i.e. final trained model')
     parser.add_argument('--workers', type=int, default=8, help='maximum number of dataloader workers')
     parser.add_argument('--project', default='runs/train', help='save to project/name')
+    parser.add_argument('--wandb_entity', default=None, help='W&B entity')
     parser.add_argument('--name', default='exp', help='save to project/name')
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     parser.add_argument('--quad', action='store_true', help='quad dataloader')


### PR DESCRIPTION
# W&B entity
- added option for W&B entity specification.


```python
import wandb
from wandb.fastai import WandbCallback
wandb.init(project="fastai-food-101", entity="wandb-examples")

...
```
https://github.com/wandb/examples/blob/6934ec6e5efd481d36e0978f3b273f0defc992af/examples/fastai/fastai-food101/train.py#L6

## Usage

```bash
python train.py --wandb_entity wandb-examples ...
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced integration with Weights & Biases (W&B) by adding support for specifying an entity during training.

### 📊 Key Changes
- Introduced a new command-line argument `--entity` to specify the W&B entity in `train.py`.
- Added code to pass the specified entity to the W&B initialization call.

### 🎯 Purpose & Impact
- **Purpose:** This change allows users to define the W&B entity directly from the command line when starting a training session, making it easier to manage and organize their experiments under different W&B accounts or teams.
- **Impact:** Users who leverage W&B for tracking experiments will enjoy a more streamlined setup process, and teams can now conveniently separate and control access to their respective machine learning experiments and models.