### PR TITLE
Fix labels being missed when image extension appears twice in filename

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -335,7 +335,7 @@ class LoadStreams:  # multiple IP or RTSP cameras
 def img2label_paths(img_paths):
     # Define label paths as a function of image paths
     sa, sb = os.sep + 'images' + os.sep, os.sep + 'labels' + os.sep  # /images/, /labels/ substrings
-    return [x.replace(sa, sb, 1).replace('.' + x.split('.')[-1], '.txt') for x in img_paths]
+    return ['txt'.join(x.replace(sa, sb, 1).rsplit(x.split('.')[-1], 1)) for x in img_paths]
 
 
 class LoadImagesAndLabels(Dataset):  # for training/testing


### PR DESCRIPTION
I noticed a bug that would result in labels being marked as missing when the image's extension appears twice in the filename. For example, an image with the filename "a.jpg.jpg" would result in the label filename "a.txt.txt". 

This code makes it so only the last occurrence of the extension is replaced with "txt", so the label filename is "a.jpg.txt". This fixed a bug for me where a lot of my images had the extension appear twice after scraping from google images and so the labels would not be found.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to label path conversion in the YOLOv5 dataset utility.

### 📊 Key Changes
- Optimized the `img2label_paths` function used for converting image file paths to their corresponding label file paths.

### 🎯 Purpose & Impact
- The purpose of the change is to increase the robustness of the label path conversion, ensuring that it handles edge cases where filenames contain multiple periods.
- This improvement may impact all users who rely on accurate label loading for training and evaluating their YOLOv5 models. It is a subtle but important fix that enhances the stability of the dataset management in YOLOv5. 🛠️📈