### PR TITLE
final_epoch EMA bug fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -383,7 +383,8 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
                 ckpt = {'epoch': epoch,
                         'best_fitness': best_fitness,
                         'training_results': results_file.read_text(),
-                        'model': deepcopy(model.module if is_parallel(model) else model).half(),
+                        'model': ema.ema if final_epoch else deepcopy(
+                            model.module if is_parallel(model) else model).half(),
                         'ema': (deepcopy(ema.ema).half(), ema.updates),
                         'optimizer': optimizer.state_dict(),
                         'wandb_id': wandb_run.id if wandb else None}


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to model checkpointing during training in YOLOv5.

### 📊 Key Changes
- Adjusted the checkpoint creation logic to include the Exponential Moving Average (EMA) model if it's the final epoch of training.
- `deepcopy(model.module ...).half()` is now conditionally used based on whether it's the final epoch.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: This change ensures that the most accurate version of the model (EMA) is saved during the final training epoch.
- 🎯 **Impact**: Users will get a potentially better, smoother version of their trained model upon completion of training, which could improve performance in real-world applications.