### PR TITLE
Add --label-smoothing eps argument to train.py (default 0.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -221,6 +221,7 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
     hyp['box'] *= 3. / nl  # scale to layers
     hyp['cls'] *= nc / 80. * 3. / nl  # scale to classes and layers
     hyp['obj'] *= (imgsz / 640) ** 2 * 3. / nl  # scale to image size and layers
+    hyp['label_smoothing'] = opt.label_smoothing
     model.nc = nc  # attach number of classes to model
     model.hyp = hyp  # attach hyperparameters to model
     model.gr = 1.0  # iou loss ratio (obj_loss = 1.0 or iou)
@@ -474,6 +475,7 @@ if __name__ == '__main__':
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     parser.add_argument('--quad', action='store_true', help='quad dataloader')
     parser.add_argument('--linear-lr', action='store_true', help='linear LR')
+    parser.add_argument('--label-smoothing', type=int, default=0.0, help='Label smoothing epsilon')
     opt = parser.parse_args()
 
     # Set DDP variables

--- a/train.py
+++ b/train.py
@@ -475,7 +475,8 @@ if __name__ == '__main__':
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     parser.add_argument('--quad', action='store_true', help='quad dataloader')
     parser.add_argument('--linear-lr', action='store_true', help='linear LR')
-    parser.add_argument('--label-smoothing', type=int, default=0.0, help='Label smoothing epsilon')
+    parser.add_argument('--label-smoothing', type=float, default=0.0, help='Label smoothing epsilon')
+
     opt = parser.parse_args()
 
     # Set DDP variables

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -97,9 +97,7 @@ class ComputeLoss:
         BCEobj = nn.BCEWithLogitsLoss(pos_weight=torch.tensor([h['obj_pw']], device=device))
 
         # Class label smoothing https://arxiv.org/pdf/1902.04103.pdf eqn 3
-        self.cp, self.cn = smooth_BCE(eps=h.get('label_smoothing', 0.0))
-
-        print(f'positive BCE target: {self.cp}, negative BCE target {self.cn}')
+        self.cp, self.cn = smooth_BCE(eps=h.get('label_smoothing', 0.0))  # positive, negative BCE targets
 
         # Focal loss
         g = h['fl_gamma']  # focal loss gamma

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -99,8 +99,6 @@ class ComputeLoss:
         # Class label smoothing https://arxiv.org/pdf/1902.04103.pdf eqn 3
         self.cp, self.cn = smooth_BCE(eps=h.get('label_smoothing', 0.0))
 
-        print(h.get('label_smoothing', 0.0), self.cp, self.cn)
-
         # Focal loss
         g = h['fl_gamma']  # focal loss gamma
         if g > 0:

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -99,6 +99,8 @@ class ComputeLoss:
         # Class label smoothing https://arxiv.org/pdf/1902.04103.pdf eqn 3
         self.cp, self.cn = smooth_BCE(eps=h.get('label_smoothing', 0.0))
 
+        print(f'positive BCE target: {self.cp}, negative BCE target {self.cn}')
+
         # Focal loss
         g = h['fl_gamma']  # focal loss gamma
         if g > 0:

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -99,6 +99,8 @@ class ComputeLoss:
         # Class label smoothing https://arxiv.org/pdf/1902.04103.pdf eqn 3
         self.cp, self.cn = smooth_BCE(eps=h.get('label_smoothing', 0.0))
 
+        print(h.get('label_smoothing', 0.0), self.cp, self.cn)
+
         # Focal loss
         g = h['fl_gamma']  # focal loss gamma
         if g > 0:

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -97,7 +97,7 @@ class ComputeLoss:
         BCEobj = nn.BCEWithLogitsLoss(pos_weight=torch.tensor([h['obj_pw']], device=device))
 
         # Class label smoothing https://arxiv.org/pdf/1902.04103.pdf eqn 3
-        self.cp, self.cn = smooth_BCE(eps=0.0)
+        self.cp, self.cn = smooth_BCE(eps=h.get('label_smoothing', 0.0))
 
         # Focal loss
         g = h['fl_gamma']  # focal loss gamma


### PR DESCRIPTION
I added `--label-smoothing` option into the training script as discussed at #2332
It runs OK, I'm doing some experiments on my dataset to compare the performance with and w/o label smoothing.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing label smoothing support in YOLOv5 training.

### 📊 Key Changes
- Added `label_smoothing` hyperparameter in the training configuration.
- Incorporated label smoothing into the loss computation.

### 🎯 Purpose & Impact
- 🎯 **Improved Model Generalization:** Label smoothing can help prevent the model from becoming overconfident about its predictions, potentially leading to better generalization on unseen data.
- 🔍 **Enhanced Training Options:** The update gives users more control over their model's training process, allowing for fine-tuning and experimentation with label smoothing.
- 💪 **Potential for Higher Accuracy:** By using label smoothing, users may achieve higher accuracy in certain scenarios, especially where the dataset may not be perfectly labeled.