### PR TITLE
--no-cache notebook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update && apt install -y zip htop screen libgl1-mesa-glx
 # Install python dependencies
 RUN python -m pip install --upgrade pip
 COPY requirements.txt .
-RUN pip install -r requirements.txt gsutil
+RUN pip install --no-cache -r requirements.txt gsutil notebook
 
 # Create working directory
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
Update Dockerfile towards Binder launch requirements:
https://github.com/binder-examples/minimal-dockerfile

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving YOLOv5 Docker build with enhanced dependency management.

### 📊 Key Changes
- Updated the Dockerfile to install Python dependencies without caching.
- Added Jupyter Notebook to the list of installed packages.

### 🎯 Purpose & Impact
- **Faster Builds and Reduced Image Size:** Using `--no-cache` option with `pip install` minimizes the Docker image size by not storing unnecessary cache data, leading to reduced disk usage and potentially quicker build times. 🚀
- **Ready for Interactive Work:** Including `notebook` in the installation list allows users to run Jupyter Notebooks within the Docker container, opening up more interactive and educational possibilities with YOLOv5. 📘