### PR TITLE
ENV HOME=/usr/src/app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM nvcr.io/nvidia/pytorch:21.02-py3
 RUN apt update && apt install -y zip htop screen libgl1-mesa-glx
 
 # Install python dependencies
-RUN python -m pip install --upgrade pip
 COPY requirements.txt .
+RUN python -m pip install --upgrade pip
 RUN pip install --no-cache -r requirements.txt gsutil notebook
 
 # Create working directory
@@ -16,11 +16,8 @@ WORKDIR /usr/src/app
 # Copy contents
 COPY . /usr/src/app
 
-# Copy weights
-#RUN python3 -c "from models import *; \
-#attempt_download('weights/yolov5s.pt'); \
-#attempt_download('weights/yolov5m.pt'); \
-#attempt_download('weights/yolov5l.pt')"
+# Set environment variables
+ENV HOME=/usr/src/app
 
 
 # ---------------------------------------------------  Extras Below  ---------------------------------------------------


### PR DESCRIPTION
Set HOME environment variable per Binder requirements. 
https://github.com/binder-examples/minimal-dockerfile

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refined Docker build process for improved container setup.

### 📊 Key Changes
- Changed the order of operations for pip installation, moving the pip upgrade command to after copying the requirements.txt file.
- Removed the commented-out section that used to download YOLOv5 weights during the Docker build.
- Added an environment variable to set the HOME directory inside the Docker image.

### 🎯 Purpose & Impact
- 🔄 Rearranging pip upgrade command helps in utilizing the build cache more efficiently. If requirements.txt changes, only the pip install step, and not the pip upgrade step, will need to be rerun.
- 🚀 Removing weight download script reduces the Docker image build time and size, as these weights are not necessary for the build itself and can be downloaded later when needed.
- 🏠 Setting the HOME environment variable provides a default directory for operations within the container, potentially simplifying file management for users.