### PR TITLE
image weights compatible faster random index generator v2 for mosaic …

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -666,7 +666,7 @@ def load_mosaic(self, index):
     labels4, segments4 = [], []
     s = self.img_size
     yc, xc = [int(random.uniform(-x, 2 * s + x)) for x in self.mosaic_border]  # mosaic center x, y
-    indices = [index] + [self.indices[random.randint(0, self.n - 1)] for _ in range(3)]  # 3 additional image indices
+    indices = [index] + random.choices(self.indices, k=3)  # 3 additional image indices
     for i, index in enumerate(indices):
         # Load image
         img, _, (h, w) = load_image(self, index)
@@ -721,7 +721,7 @@ def load_mosaic9(self, index):
 
     labels9, segments9 = [], []
     s = self.img_size
-    indices = [index] + [self.indices[random.randint(0, self.n - 1)] for _ in range(8)]  # 8 additional image indices
+    indices = [index] + random.choices(self.indices, k=8)  # 8 additional image indices
     for i, index in enumerate(indices):
         # Load image
         img, _, (h, w) = load_image(self, index)


### PR DESCRIPTION
@glenn-jocher 

It's related to #2345.

image weights compatible faster random index generator v2 for mosaic augmentation

It's much faster than baseline, and compatible with image weights option!

It's my test code. It's 2x faster than baseline.

```python
import random
import numpy as np
import time

indices = np.arange(100000)
n = len(indices)

def anchor(indices, k=4):
  randomly_picked_indices = [0] + [indices[random.randint(0, n - 1)] for _ in range(k-1)]
  

def proposed(indices, k=4):
  randomly_picked_indices = [0] + random.choices(indices, k=k-1)

t1 = time.time()
for _ in range(100000):
  anchor(indices)
t2 = time.time()

print("anchor t2-t1: ", t2-t1)

t1 = time.time()
for _ in range(100000):
  proposed(indices)
t2 = time.time()
print("proposed t2-t1: ", t2-t1)
```

Refer to [experiment results on google Colab](https://colab.research.google.com/drive/1Lh83JVdUYHIHzKt3-sEHp1OBOhlpkIKW?usp=sharing) for more details

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved random selection for mosaic image augmentation.

### 📊 Key Changes
- Replaced the use of `random.randint` with `random.choices` for selecting additional image indices in both `load_mosaic` and `load_mosaic9` methods.

### 🎯 Purpose & Impact
- **Enhanced Efficiency**: The new method streamlines the selection process, potentially improving the runtime performance by reducing code complexity.
- **User Experience**: This update can lead to more diversity in the selection of images for augmentation, which may improve learning for models trained with the YOLOv5 framework.
- **Maintainability**: Using `random.choices` is a cleaner and more Pythonic way of achieving the same end, which can make the codebase easier to understand and maintain.