### PR TITLE
CVPR 2021 Argoverse-HD autodownload curl

### DIFF
--- a/data/scripts/get_argoverse_hd.sh
+++ b/data/scripts/get_argoverse_hd.sh
@@ -12,7 +12,7 @@ d='../argoverse/' # unzip directory
 mkdir $d
 url=https://argoverse-hd.s3.us-east-2.amazonaws.com/
 f=Argoverse-HD-Full.zip
-wget $url$f -O $f && unzip -q $f -d $d && rm $f &# download, unzip, remove in background
+curl -L $url$f -o $f && unzip -q $f -d $d && rm $f &# download, unzip, remove in background
 wait                                              # finish background tasks
 
 cd ../argoverse/Argoverse-1.1/


### PR DESCRIPTION
curl preferred over wget for slightly better cross platform compatibility (i.e. out of the box macos compatible).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Switching from `wget` to `curl` for downloading the Argoverse-HD dataset.

### 📊 Key Changes
- The script now uses `curl` instead of `wget` for file downloads.
- The `wget` command line has been replaced with the corresponding `curl` command to download the `Argoverse-HD-Full.zip` file.

### 🎯 Purpose & Impact
- 🔄 **Purpose:** This change may be for consistency or to address environments where `wget` is not available but `curl` is, thus increasing compatibility.
- 🔗 **Impact:** Users who rely on this script for downloading the dataset will now be using `curl`, which is widely supported and typically pre-installed on many systems. This change could lead to fewer issues during setup, especially for users who might not have had `wget` installed.