### PR TITLE
autoShape() speed profiling update

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -168,7 +168,6 @@ class NMS(nn.Module):
 
 class autoShape(nn.Module):
     # input-robust model wrapper for passing cv2/np/PIL/torch inputs. Includes preprocessing, inference and NMS
-    img_size = 640  # inference size (pixels)
     conf = 0.25  # NMS confidence threshold
     iou = 0.45  # NMS IoU threshold
     classes = None  # (optional list) filter by class
@@ -278,7 +277,8 @@ class Detections:
 
     def print(self):
         self.display(pprint=True)  # print results
-        print(f'Speed: %.1f/%.1f/%.1f ms pre-process/inference/NMS per image at shape {tuple(self.s)}' % tuple(self.t))
+        print(f'Speed: %.1fms pre-process, %.1fms inference, %.1fms NMS per image at shape {tuple(self.s)}' %
+              tuple(self.t))                      
 
     def show(self):
         self.display(show=True)  # show results


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlining of the autoShape wrapper in YOLOv5 for better input handling.

### 📊 Key Changes
- Removed a hardcoded `img_size` from the `autoShape` class, implying a shift towards dynamic image sizing.
- Refined the printing format of the preprocessing, inference, and NMS speeds for improved clarity.

### 🎯 Purpose & Impact
- Removing hardcoded values like `img_size` can make the code more flexible and less prone to errors related to fixed input dimensions. This change will allow users to work with images of various sizes more efficiently.
- The updated print statement will enhance readability, making it easier for users to understand the time taken for different stages (pre-processing, inference, NMS) of the model's predictions, which is crucial for performance tuning and debugging. 🚀