### PR TITLE
Be able to create dataset from annotated images only

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -1032,33 +1032,24 @@ def extract_boxes(path='../coco128/'):  # from utils.datasets import *; extract_
                     b[[1, 3]] = np.clip(b[[1, 3]], 0, h)
                     assert cv2.imwrite(str(f), im[b[1]:b[3], b[0]:b[2]]), f'box failure in {f}'
 
-
-def autosplit(path='../coco128', weights=(0.9, 0.1, 0.0), annotated_only=False): # from utils.datasets import *; autosplit('../coco128')
-
+def autosplit(path='../coco128', weights=(0.9, 0.1, 0.0), annotated_only=False):
     """ Autosplit a dataset into train/val/test splits and save path/autosplit_*.txt files
-    # Arguments
+    Usage: from utils.datasets import *; autosplit('../coco128')
+    Arguments
         path:           Path to images directory
         weights:        Train, val, test weights (list)
         annotated_only: Only use images with an annotated txt file
     """
-
     path = Path(path)  # images dir
-
-    # make sure we only work with images files
-    files = sum([list(path.rglob(f"*.{img_ext}")) for img_ext in img_formats], [])
+    files = sum([list(path.rglob(f"*.{img_ext}")) for img_ext in img_formats], [])  # image files only
     n = len(files)  # number of files
-
     indices = random.choices([0, 1, 2], weights=weights, k=n)  # assign each image to a split
 
     txt = ['autosplit_train.txt', 'autosplit_val.txt', 'autosplit_test.txt']  # 3 txt files
     [(path / x).unlink() for x in txt if (path / x).exists()]  # remove existing
 
-    if annotated_only:
-        print("Only annotated images with a .txt file associated will be used to create the dataset")
-
+    print(f'Autosplitting images from {path}' + ', using *.txt labeled images only' * annotated_only)
     for i, img in tqdm(zip(indices, files), total=n):
-        # in case we want to use only annotated files
-        if not annotated_only or (annotated_only and Path(img2label_paths([str(img)])[0]).exists()):
+        if not annotated_only or Path(img2label_paths([str(img)])[0]).exists():  # check label
             with open(path / txt[i], 'a') as f:
                 f.write(str(img) + '\n')  # add image to txt file
-


### PR DESCRIPTION
> I closed my [previous PR](https://github.com/ultralytics/yolov5/pull/2331) as it was featuring a background images functionality that still needs work. It is removed from now.

Add the ability to create a dataset/splits only with images that have an annotation file, i.e a .txt file, associated to it. As we talked about this, the absence of a txt file could mean two things:

* either the image wasn't yet labelled by someone,
* either there is no object to detect.

When it's easy to create small datasets, when you have to create datasets with thousands of images (and more coming), it's hard to track where you at and you don't want to wait to have all of them annotated before starting to train. Which means some images would lack txt files and annotations, resulting in label inconsistency as you say in #2313. By adding the `annotated_only` argument to the function, people could create, if they want to, datasets/splits only with images that were labelled, for sure.

The function uses `img2label_paths` also available in `utils/datasets.py` to check if an annotated file exists. Therefore, it works with the default structure Yolo recommends to create a custom dataset (`images` and `labels` folders).


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced dataset autosplit function with annotation filter option.

### 📊 Key Changes
- Added an `annotated_only` parameter to the autosplit function.
- Modified file selection to only include image files based on `img_formats`.
- Implemented a check to ensure only images with corresponding annotation files are used when `annotated_only` is True.

### 🎯 Purpose & Impact
- **Purpose**: These updates provide more flexibility in dataset creation, allowing users to create splits based only on images with annotations, which is essential for training accurate machine learning models.
- **Impact**: Users will benefit from cleaner data splits, particularly when dealing with datasets that contain a mix of annotated and unannotated images. This can lead to better training performance and more robust model validation. 🚀