### PR TITLE
add option to disable half precision when testing

### DIFF
--- a/test.py
+++ b/test.py
@@ -36,7 +36,8 @@ def test(data,
          save_conf=False,  # save auto-label confidences
          plots=True,
          log_imgs=0,  # number of logged images
-         compute_loss=None):
+         compute_loss=None,
+         half_precision=True):
     # Initialize/load model and set device
     training = model is not None
     if training:  # called by train.py
@@ -60,7 +61,7 @@ def test(data,
         #     model = nn.DataParallel(model)
 
     # Half
-    half = device.type != 'cpu'  # half precision only supported on CUDA
+    half = device.type != 'cpu' and half_precision  # half precision only supported on CUDA
     if half:
         model.half()
 


### PR DESCRIPTION
Hello, for the use case I am working on (quantization aware training), half precision is not supported by PyTorch despite using a CUDA enabled GPU.  This causes an error when running the test loop since half precision is automatically enabled if the model is not on CPU.

This PR adds an argument to enable turning half precision off in the test function.  If acceptable, this would be very helpful for simplifying QAT integrations. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of precision control in model testing.

### 📊 Key Changes
- Added a new `half_precision` parameter to the `test` function.

### 🎯 Purpose & Impact
- **Purpose:** Allows users to specify whether or not to use half precision during model testing, rather than automatically setting it based on the device type.
- **Impact:** Users gain more flexibility in testing models with the choice of precision, which can lead to faster computations on compatible hardware (such as CUDA-enabled GPUs) while trading off some numerical accuracy. 🏃💨 This can be particularly useful for users who are testing models and need to balance accuracy with performance.