### PR TITLE
optimization-for-streams-detection

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -61,12 +61,13 @@ def detect(save_img=False):
         model(torch.zeros(1, 3, imgsz, imgsz).to(device).type_as(next(model.parameters())))  # run once
     t0 = time.time()
 
-    prev_img = [None] * dataset.count
+    prev_img = [None] * dataset.count if webcam else [None]
     for path, img, im0s, vid_cap in dataset:
-        # Optimize repeated img
-        if (prev_img == img).all():
-            continue
-        prev_img = img
+        # Optimize repeated img for steams
+        if webcam:
+            if (prev_img == img).all():
+                continue
+            prev_img = img
 
         img = torch.from_numpy(img).to(device)
         img = img.half() if half else img.float()  # uint8 to fp16/32

--- a/detect.py
+++ b/detect.py
@@ -16,7 +16,7 @@ from utils.torch_utils import select_device, load_classifier, time_synchronized
 
 
 def detect(save_img=False):
-    source, weights, view_img, save_txt, imgsz = opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size
+    source, weights, view_img, save_txt, imgsz, skip_step = opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size, opt.skip_step
     webcam = source.isnumeric() or source.endswith('.txt') or source.lower().startswith(
         ('rtsp://', 'rtmp://', 'http://'))
 
@@ -47,7 +47,7 @@ def detect(save_img=False):
     if webcam:
         view_img = check_imshow()
         cudnn.benchmark = True  # set True to speed up constant image size inference
-        dataset = LoadStreams(source, img_size=imgsz, stride=stride)
+        dataset = LoadStreams(source, img_size=imgsz, stride=stride, skip_step=skip_step)
     else:
         save_img = True
         dataset = LoadImages(source, img_size=imgsz, stride=stride)
@@ -60,7 +60,14 @@ def detect(save_img=False):
     if device.type != 'cpu':
         model(torch.zeros(1, 3, imgsz, imgsz).to(device).type_as(next(model.parameters())))  # run once
     t0 = time.time()
+
+    prev_img = [None] * dataset.count
     for path, img, im0s, vid_cap in dataset:
+        # Optimize repeated img
+        if (prev_img == img).all():
+            continue
+        prev_img = img
+
         img = torch.from_numpy(img).to(device)
         img = img.half() if half else img.float()  # uint8 to fp16/32
         img /= 255.0  # 0 - 255 to 0.0 - 1.0
@@ -149,6 +156,7 @@ if __name__ == '__main__':
     parser.add_argument('--weights', nargs='+', type=str, default='yolov5s.pt', help='model.pt path(s)')
     parser.add_argument('--source', type=str, default='data/images', help='source')  # file/folder, 0 for webcam
     parser.add_argument('--img-size', type=int, default=640, help='inference size (pixels)')
+    parser.add_argument('--skip-step', type=int, default=4, help='default read every 4th frame for streams')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='object confidence threshold')
     parser.add_argument('--iou-thres', type=float, default=0.45, help='IOU threshold for NMS')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')


### PR DESCRIPTION
1. Optimize repeated images detection when loads streams.
2. Add option arg **skip_step** for stream detection instead of reading every 4th frame. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced `detect.py` to allow skipping frames in webcam streams for improved performance.

### 📊 Key Changes
- Added a new command-line argument `--skip-step` to specify the number of frames to skip during webcam stream processing.
- Modified `LoadStreams` class to accept the `skip_step` parameter and use it for skipping frames.
- Implemented frame skipping logic within the `update` method of the `LoadStreams` class to improve real-time webcam stream processing.
- Introduced an optimization to bypass processing if consecutive webcam frames are identical.

### 🎯 Purpose & Impact
- **Purpose**: To provide an option to reduce computational load and increase processing speed by skipping over a configurable number of frames in video streams from webcams.
- **Impact**: Users can experience reduced latency and improved real-time detection performance when using video streams, especially beneficial for systems with limited processing power. 🚀