### PR TITLE
Add opencv-contrib-python to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Cython
 matplotlib>=3.2.2
 numpy>=1.18.5
 opencv-python>=4.1.2
+opencv-contrib-python>=4.1.2
 Pillow
 PyYAML>=5.3.1
 scipy>=1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,18 @@
 # pip install -r requirements.txt
 
 # base ----------------------------------------
-Cython
 matplotlib>=3.2.2
 numpy>=1.18.5
 opencv-python>=4.1.2
-opencv-contrib-python>=4.1.2
 Pillow
 PyYAML>=5.3.1
 scipy>=1.4.1
-tensorboard>=2.2
 torch>=1.7.0
 torchvision>=0.8.1
 tqdm>=4.41.0
 
 # logging -------------------------------------
+tensorboard>=2.4.1
 # wandb
 
 # plotting ------------------------------------


### PR DESCRIPTION
### Environment
- Windows 10
- CUDA 11.1
- Miniconda (Python 3.7.4)

### Input (CMD)
`python detect.py --source xxx.mp4 --view-img`


### Result
`cv2.error: OpenCV(4.5.1) C:\~~\opencv\modules\highgui\src\window.cpp:651: error: (-2:Unspecified error) The function is not implemented. Rebuild the library with Windows, GTK+ 2.x or Cocoa support. If you are on Ubuntu or Debian, install libgtk2.0-dev and pkg-config, then re-run cmake or configure script in function 'cvShowImage'`


### Solution
`pip install opencv-contrib-python`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update and streamline package dependencies for YOLOv5.

### 📊 Key Changes
- ✂️ Removed `Cython` from requirements.
- 🆙 Updated `tensorboard` minimum version to `2.4.1`.
- 🧹 Cleaned up requirements sections by moving `tensorboard`.

### 🎯 Purpose & Impact
- 🔍 The removal of `Cython` suggests it's no longer necessary, simplifying installation.
- ⚙️ Updating `tensorboard` ensures compatibility with newer features and fixes.
- 🌐 By relocating `tensorboard`, the requirements file is better organized, which could help users understand and manage their development environment more easily.