### PR TITLE
check_requirements() exclude pycocotools, thop

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -164,7 +164,7 @@ if __name__ == '__main__':
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     opt = parser.parse_args()
     print(opt)
-    check_requirements()
+    check_requirements(exclude=('pycocotools', 'thop'))
 
     with torch.no_grad():
         if opt.update:  # update all models (to fix SourceChangeWarning)


### PR DESCRIPTION
Exclude non-critical packages from dependency checks in detect.py. `pycocotools` and `thop` in particular are not required for inference.

Issue first raised in https://github.com/ultralytics/yolov5/issues/1944 and also raised in https://github.com/ultralytics/yolov5/discussions/2556

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement on dependencies check in the YOLOv5 detection script.

### 📊 Key Changes
- Modified the `check_requirements()` function call to exclude `pycocotools` and `thop` during dependency checks.

### 🎯 Purpose & Impact
- 🔍 **Purpose**: Reduces unnecessary warnings when `pycocotools` and `thop` are not installed, as they are not always required.
- 📈 **Impact**: Users who do not use these packages can run detections without being prompted to install additional, potentially unnecessary, requirements. This leads to a more streamlined experience and less confusion for users focused on basic functionality.