### PR TITLE
W&B DDP fix

### DIFF
--- a/utils/wandb_logging/wandb_utils.py
+++ b/utils/wandb_logging/wandb_utils.py
@@ -16,9 +16,9 @@ from utils.general import colorstr, xywh2xyxy, check_dataset
 
 try:
     import wandb
+    from wandb import init, finish
 except ImportError:
     wandb = None
-    print(f"{colorstr('wandb: ')}Install Weights & Biases for YOLOv5 logging with 'pip install wandb' (recommended)")
 
 WANDB_ARTIFACT_PREFIX = 'wandb-artifact://'
 
@@ -71,6 +71,9 @@ class WandbLogger():
                 self.data_dict = self.setup_training(opt, data_dict)
             if self.job_type == 'Dataset Creation':
                 self.data_dict = self.check_and_upload_dataset(opt)
+        else:
+            print(f"{colorstr('wandb: ')}Install Weights & Biases for YOLOv5 logging with 'pip install wandb' (recommended)")
+
 
     def check_and_upload_dataset(self, opt):
         assert wandb, 'Install wandb to upload dataset'


### PR DESCRIPTION
Fix for #2562 
Also includes a fix for #1958

Example DDP wandb enabled run -> [Here](https://wandb.ai/cayush/ddp_test/runs/3fprcsgl?workspace=user-cayush)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to Weights & Biases (W&B) logging in YOLOv5 training script.

### 📊 Key Changes
- Initialized a loggers dictionary with WandbLogger as `None` before dataset checks in `train.py`.
- Moved the `wandb_logger.end_epoch` call under the condition that checks if the fitness score improved, ensuring logging occurs at the correct time.
- Altered the call to `wandb_logger.finish_run` to occur immediately after model artifact logging in the case where distributed processing is not used.
- In `wandb_utils.py`, the warning to install W&B if it's not found is now shown only when the W&B logger instance is actually created and wandb is `None`.

### 🎯 Purpose & Impact
- These changes make W&B logging more robust and ensure it only prompts the user to install W&B when necessary, thus improving the user experience.
- Logging optimizations may lead to slight improvements in how training metrics are recorded and displayed on the W&B platform, which is beneficial for tracking model performance.
- The refactored code increases maintainability and could prevent potential bugs related to improper logging states.