### PR TITLE
YOLOv5 PyTorch Hub models >> check_requirements()

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -1,4 +1,4 @@
-"""File for accessing YOLOv5 models via PyTorch Hub https://pytorch.org/hub/
+"""File for accessing YOLOv5 models via PyTorch Hub https://pytorch.org/hub/ultralytics_yolov5/
 
 Usage:
     import torch

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,8 +1,8 @@
-"""File for accessing YOLOv5 via PyTorch Hub https://pytorch.org/hub/
+"""File for accessing YOLOv5 models via PyTorch Hub https://pytorch.org/hub/
 
 Usage:
     import torch
-    model = torch.hub.load('ultralytics/yolov5', 'yolov5s', pretrained=True, channels=3, classes=80)
+    model = torch.hub.load('ultralytics/yolov5', 'yolov5s')
 """
 
 from pathlib import Path
@@ -10,11 +10,12 @@ from pathlib import Path
 import torch
 
 from models.yolo import Model
-from utils.general import set_logging
+from utils.general import check_requirements, set_logging
 from utils.google_utils import attempt_download
 from utils.torch_utils import select_device
 
 dependencies = ['torch', 'yaml']
+check_requirements(exclude=('pycocotools', 'thop'))
 set_logging()
 
 


### PR DESCRIPTION
Dependency checks have been missing from YOLOv5 PyTorch Hub model loading, causing errors in some cases when users are attempting to import hub models in unsupported environments. This should examine the YOLOv5 requirements.txt file and `pip install` any missing or version-conflict packages encountered. 

This is highly experimental (!), please let us know if this creates problems in your custom workflows.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced PyTorch Hub support for YOLOv5 models.

### 📊 Key Changes
- Clarified comment documentation for accessing YOLOv5 models through PyTorch Hub.
- Simplified the `torch.hub.load` example usage by removing default parameters.
- Added a check for required dependencies while excluding optional ones (`pycocotools`, `thop`).

### 🎯 Purpose & Impact
- 📝 **Clarification:** Helps users better understand how to access YOLOv5 models via PyTorch Hub, improving usability.
- 🧼 **Simplification:** The removal of additional parameters from the example encourages a cleaner and more straightforward user experience when loading models.
- ✅ **Dependency Check:** Ensures that users have necessary dependencies installed, which minimizes errors and improves the overall reliability when using the models. Potential reduction in initial setup issues for new users.