### PR TITLE
W&B resume ddp from run link fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -33,7 +33,7 @@ from utils.google_utils import attempt_download
 from utils.loss import ComputeLoss
 from utils.plots import plot_images, plot_labels, plot_results, plot_evolution
 from utils.torch_utils import ModelEMA, select_device, intersect_dicts, torch_distributed_zero_first, is_parallel
-from utils.wandb_logging.wandb_utils import WandbLogger, resume_and_get_id
+from utils.wandb_logging.wandb_utils import WandbLogger, check_wandb_resume
 
 logger = logging.getLogger(__name__)
 
@@ -496,7 +496,7 @@ if __name__ == '__main__':
         check_requirements()
 
     # Resume
-    wandb_run = resume_and_get_id(opt)
+    wandb_run = check_wandb_resume(opt)
     if opt.resume and not wandb_run:  # resume an interrupted run
         ckpt = opt.resume if isinstance(opt.resume, str) else get_latest_run()  # specified or most recent path
         assert os.path.isfile(ckpt), 'ERROR: --resume checkpoint does not exist'


### PR DESCRIPTION
More improvement over #2574 
@glenn-jocher I wasn't gonna do this until next week but I got the idea for the fix and I couldn't resist. Now both offline and wandb link resume works perfectly with DDP

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Weights & Biases (wandb) resume functionality in YOLOv5's training script.

### 📊 Key Changes
- Renamed `resume_and_get_id` to `check_wandb_resume` to better reflect its functionality.
- Updated `remove_prefix` function to have a default `prefix` parameter.
- Introduced `get_run_info` function to obtain run information from a wandb path.
- Implemented `process_wandb_config_ddp_mode` to handle Distributed Data Parallel (DDP) mode with wandb.
- Changed wandb artifact downloading logic for improved handling in DDP mode.
- Streamlined wandb initialization logic within `WandbLogger` to accommodate run resumption from wandb artifacts.

### 🎯 Purpose & Impact
- 🛠️ The changes improve the flexibility and reliability of resuming training runs from wandb, particularly when using distributed training setups.
- 🤝 They make it easier for users to resume interrupted training sessions, potentially saving time and resources.
- 🚀 This can lead to enhanced experiment tracking and model management within the YOLOv5 community, especially for those who rely on wandb for experiment logging and artifacts storage.