### PR TITLE
Remove Cython from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # pip install -r requirements.txt
 
 # base ----------------------------------------
-Cython
 matplotlib>=3.2.2
 numpy>=1.18.5
 opencv-python>=4.1.2


### PR DESCRIPTION
Cython should be a dependency of the remaining packages in requirements.txt, so should be installed anyway even if not a direct requirement.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved simplicity in YOLOv5 dependencies.

### 📊 Key Changes
- Removed Cython from the list of required packages.

### 🎯 Purpose & Impact
- **Purpose:** Streamlining installation by eliminating unnecessary dependencies, potentially due to Cython no longer being a prerequisite for any of the YOLOv5 components.
- **Impact:** Users will experience a more straightforward installation process with fewer steps, reducing potential issues related to the Cython package. This can lead to a smoother setup experience and might lower the barrier to entry for new users interested in using YOLOv5 for object detection tasks.