### PR TITLE
Fix Indentation in test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -156,7 +156,7 @@ def test(data,
                                  "domain": "pixel"} for *xyxy, conf, cls in pred.tolist()]
                     boxes = {"predictions": {"box_data": box_data, "class_labels": names}}  # inference-space
                     wandb_images.append(wandb_logger.wandb.Image(img[si], boxes=boxes, caption=path.name))
-                wandb_logger.log_training_progress(predn, path, names)  # logs dsviz tables
+            wandb_logger.log_training_progress(predn, path, names) if wandb_logger else None # logs dsviz tables
 
             # Append to pycocotools JSON dictionary
             if save_json:

--- a/test.py
+++ b/test.py
@@ -156,7 +156,7 @@ def test(data,
                                  "domain": "pixel"} for *xyxy, conf, cls in pred.tolist()]
                     boxes = {"predictions": {"box_data": box_data, "class_labels": names}}  # inference-space
                     wandb_images.append(wandb_logger.wandb.Image(img[si], boxes=boxes, caption=path.name))
-            wandb_logger.log_training_progress(predn, path, names) if wandb_logger else None # logs dsviz tables
+            wandb_logger.log_training_progress(predn, path, names) if wandb_logger and wandb_logger.wandb_run else None # logs dsviz tables
 
             # Append to pycocotools JSON dictionary
             if save_json:

--- a/test.py
+++ b/test.py
@@ -156,7 +156,7 @@ def test(data,
                                  "domain": "pixel"} for *xyxy, conf, cls in pred.tolist()]
                     boxes = {"predictions": {"box_data": box_data, "class_labels": names}}  # inference-space
                     wandb_images.append(wandb_logger.wandb.Image(img[si], boxes=boxes, caption=path.name))
-            wandb_logger.log_training_progress(predn, path, names) if wandb_logger and wandb_logger.wandb_run else None # logs dsviz tables
+            wandb_logger.log_training_progress(predn, path, names) if wandb_logger and wandb_logger.wandb_run else None
 
             # Append to pycocotools JSON dictionary
             if save_json:


### PR DESCRIPTION
This fixes a indentation bug introduced while removing dsviz section from test.py.
@glenn-jocher This is sort of urgent fix.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved conditional logging for WandB integration in YOLOv5's test script.

### 📊 Key Changes
- Adjusted the indentation of the WandB logging call to ensure it only attempts to log if a WandB run is active.

### 🎯 Purpose & Impact
- 🛠️ **Purpose:** To avoid errors when WandB is not being used. The fix prevents the test script from attempting to log to WandB if WandB is not initialized, which could previously lead to exceptions and disrupt the testing process.
- 🚀 **Impact:** Users who run YOLOv5's testing without WandB will experience a smoother process with no unnecessary logging attempts. Those who use WandB will see no change in functionality. It leads to a more robust testing procedure overall.