### PR TITLE
Added '.mpo' to supported image formats

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -26,7 +26,7 @@ from utils.torch_utils import torch_distributed_zero_first
 
 # Parameters
 help_url = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
-img_formats = ['bmp', 'jpg', 'jpeg', 'png', 'tif', 'tiff', 'dng', 'webp']  # acceptable image suffixes
+img_formats = ['bmp', 'jpg', 'jpeg', 'png', 'tif', 'tiff', 'dng', 'webp', 'mpo']  # acceptable image suffixes
 vid_formats = ['mov', 'avi', 'mp4', 'mpg', 'mpeg', 'm4v', 'wmv', 'mkv']  # acceptable video suffixes
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
MPO is an image format that can contain different formats like png and jpeg. As such it's not guaranteed that any image that reads as MPO in Pillow will work as expected. Whether an image reports as MPO or the actual content format ist determined by an EXIF flag. Read up on it in this Pillow issue: https://github.com/python-pillow/Pillow/issues/1138

In my case, the images are JPEGs from a DJI drone, and worked flawlessly with yolov5.

Closes https://github.com/ultralytics/yolov5/issues/2446

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Expanded supported image formats to include 'mpo' files.

### 📊 Key Changes
- Added the 'mpo' format to the list of acceptable image suffixes.

### 🎯 Purpose & Impact
- **Purpose:** Enhances the YOLOv5 data preprocessing utility to recognize and handle `.mpo` images, which are often associated with 3D photos.
- **Impact:** Users can now train their models on datasets containing '.mpo' images, potentially improving model performance in applications that involve 3D imaging. 📸🔄