### PR TITLE
Remove conflicting nvidia-tensorboard package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt update && apt install -y zip htop screen libgl1-mesa-glx
 # Install python dependencies
 COPY requirements.txt .
 RUN python -m pip install --upgrade pip
+RUN pip uninstall -y nvidia-tensorboard nvidia-tensorboard-plugin-dlprof
 RUN pip install --no-cache -r requirements.txt gsutil notebook
 
 # Create working directory


### PR DESCRIPTION
Attempt to resolve tensorboard Docker error in https://github.com/ultralytics/yolov5/issues/2573

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to the Dockerfile for better dependency management.

### 📊 Key Changes
- Added a command to uninstall `nvidia-tensorboard` and `nvidia-tensorboard-plugin-dlprof`.

### 🎯 Purpose & Impact
- The change aims to prevent potential conflicts with NVIDIA packages not needed within the YOLOv5 Docker environment.
- This could lead to a smoother experience for users working with YOLOv5 in Docker, by ensuring that only necessary dependencies are installed, thus reducing image size and build time. 🚀