### PR TITLE
Improve git_describe()

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -55,7 +55,8 @@ def git_describe(path=Path(__file__).parent):  # path must be a directory
     # return human-readable git description, i.e. v5.0-5-g3e25f1e https://git-scm.com/docs/git-describe
     s = f'git -C {path} describe --tags --long --always'
     try:
-        return subprocess.check_output(s, shell=True).decode()[:-1]
+        r = subprocess.check_output(s, shell=True).decode()[:-1]
+        return '' if r.startswith('fatal: not a git repository') else r
     except subprocess.CalledProcessError as e:
         return ''
 


### PR DESCRIPTION
Catch 'fatal: not a git repository' returns and return '' instead (observed in GCP Hub checks).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement to git description retrieval in YOLOv5's utility script.

### 📊 Key Changes
- Improved the `git_describe` function in `torch_utils.py` to handle cases where the code is not within a Git repository.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: Ensures the function returns an empty string instead of an error message when YOLOv5 codebase is not a Git repository.
- 💥 **Impact**: Provides a cleaner output for users and prevents potential confusion or errors in environments where the code is not version-controlled with Git.