### PR TITLE
Fix: evolve with wandb

### DIFF
--- a/train.py
+++ b/train.py
@@ -439,7 +439,7 @@ def train(hyp, opt, device, tb_writer=None):
                 strip_optimizer(f)  # strip optimizers
         if opt.bucket:
             os.system(f'gsutil cp {final} gs://{opt.bucket}/weights')  # upload
-        if wandb_logger.wandb:  # Log the stripped model
+        if wandb_logger.wandb and not opt.evolve:  # Log the stripped model
             wandb_logger.wandb.log_artifact(str(final), type='model',
                                             name='run_' + wandb_logger.wandb_run.id + '_model',
                                             aliases=['last', 'best', 'stripped'])


### PR DESCRIPTION
Fix for #607 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging conditions for model artifacts in Weights & Biases integration.

### 📊 Key Changes
- Modified the condition for uploading stripped models to Weights & Biases (wandb).
- Stripped models are now only logged if not in hyperparameter evolution mode.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: This change ensures that when using the hyperparameter evolution feature of YOLOv5 (`opt.evolve`), model artifacts are not unnecessarily uploaded to wandb, which can clutter the project space with numerous files.
- 🔍 **Impact**: Users will experience cleaner logging in wandb, saving space and reducing redundancy, especially during the evolutionary search process which can produce a large number of models. This will make it easier for them to track and manage their experiment artifacts.