### PR TITLE
PyTorch Hub amp.autocast() inference

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -8,6 +8,7 @@ import requests
 import torch
 import torch.nn as nn
 from PIL import Image
+from torch.cuda import amp
 
 from utils.datasets import letterbox
 from utils.general import non_max_suppression, make_divisible, scale_coords, xyxy2xywh
@@ -219,17 +220,17 @@ class autoShape(nn.Module):
         x = torch.from_numpy(x).to(p.device).type_as(p) / 255.  # uint8 to fp16/32
         t.append(time_synchronized())
 
-        # Inference
-        with torch.no_grad():
+        with torch.no_grad(), amp.autocast(enabled=p.device.type != 'cpu'):
+            # Inference
             y = self.model(x, augment, profile)[0]  # forward
-        t.append(time_synchronized())
+            t.append(time_synchronized())
 
-        # Post-process
-        y = non_max_suppression(y, conf_thres=self.conf, iou_thres=self.iou, classes=self.classes)  # NMS
-        for i in range(n):
-            scale_coords(shape1, y[i][:, :4], shape0[i])
-        t.append(time_synchronized())
+            # Post-process
+            y = non_max_suppression(y, conf_thres=self.conf, iou_thres=self.iou, classes=self.classes)  # NMS
+            for i in range(n):
+                scale_coords(shape1, y[i][:, :4], shape0[i])
 
+        t.append(time_synchronized())
         return Detections(imgs, y, files, t, self.names, x.shape)
 
 


### PR DESCRIPTION
I think this should help speed up CUDA inference, as currently models may be running in FP32 inference mode on CUDA devices unnecesarily.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced inference and post-processing in YOLOv5 with mixed-precision support.

### 📊 Key Changes
- 🧠 Integrates mixed-precision inference using PyTorch's `amp` (Automatic Mixed Precision).
- 🏃 Updated the forward method to enable `amp` during both inference and post-processing.
- 📉 Code maintains CPU compatibility by enabling `amp` only when model executes on a GPU.

### 🎯 Purpose & Impact
- 👩‍💻 For developers and users with compatible hardware (NVIDIA GPUs), this change is intended to:
  - ⏩ Speed up inference, by allowing faster computations at lower precision while maintaining the accuracy.
  - ⚖️ Reduce GPU memory consumption, potentially enabling the use of larger models or batch sizes.
- 🛠️ For users on CPUs, the change does not affect performance or results.
- 🚀 The overall impact is a more efficient YOLOv5 model, enhancing usability for real-time applications.