### PR TITLE
Add tqdm pbar.close()

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -443,7 +443,8 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                 self.imgs[i], self.img_hw0[i], self.img_hw[i] = x  # img, hw_original, hw_resized = load_image(self, i)
                 gb += self.imgs[i].nbytes
                 pbar.desc = f'{prefix}Caching images ({gb / 1E9:.1f}GB)'
-
+            pbar.close()
+            
     def cache_labels(self, path=Path('./labels.cache'), prefix=''):
         # Cache dataset labels, check images and read shapes
         x = {}  # dict
@@ -487,7 +488,8 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
 
             pbar.desc = f"{prefix}Scanning '{path.parent / path.stem}' images and labels... " \
                         f"{nf} found, {nm} missing, {ne} empty, {nc} corrupted"
-
+        pbar.close()
+            
         if nf == 0:
             print(f'{prefix}WARNING: No labels found in {path}. See {help_url}')
 


### PR DESCRIPTION
When using tqdm, sometimes it can't print in one line and roll to next line.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved caching process for images and labels in YOLOv5 datasets.

### 📊 Key Changes
- Added `pbar.close()` statements to ensure that progress bars are properly closed after the caching process for images and labels.

### 🎯 Purpose & Impact
- 🎨 Ensures a cleaner terminal output by closing progress bars, which may enhance user experience and debug clarity.
- 🛠 Allows for better resource management by explicitly closing progress bars, which could potentially prevent minor memory leaks or resource contention issues.