### PR TITLE
Disallow resume for dataset uploading

### DIFF
--- a/utils/wandb_logging/log_dataset.py
+++ b/utils/wandb_logging/log_dataset.py
@@ -21,5 +21,6 @@ if __name__ == '__main__':
     parser.add_argument('--single-cls', action='store_true', help='train as single-class dataset')
     parser.add_argument('--project', type=str, default='YOLOv5', help='name of W&B Project')
     opt = parser.parse_args()
-
+    opt.resume = False # Explicitly disallow resume check for dataset upload Job
+    
     create_dataset_artifact(opt)


### PR DESCRIPTION
Upload dataset script is meant to upload the entire dataset in one go. Resume functionality is supported only for training.

btw @glenn-jocher this was in the previous DDP PR, I guess it got overwritten when merging? Anyway,, to execute correctly resume flag is needed, as wandb_logger first checks for opt.resume

EDIT: This is needed at 8AM pst. Please take a look when you get some time

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Weight & Biases (W&B) dataset logging in YOLOv5 by disabling resume checks for dataset uploads.

### 📊 Key Changes
- 🛠️ Modified `log_dataset.py` in the `wandb_logging` utility:
- ➕ Added a line to explicitly set `opt.resume` to `False` to prevent resume checks during dataset artifact creation.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To ensure dataset upload jobs to W&B are not mistakenly attempting to resume previous jobs, which could cause errors or inconsistencies.
- 💥 **Impact**: Users leveraging W&B for tracking datasets will experience more robust and error-free uploads. This change minimizes the risk of upload failures due to unwanted resume attempts, leading to a smoother integration with the W&B platform.