### PR TITLE
PyTorch Hub model.save() increment as runs/hub/exp

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -326,7 +326,7 @@ class Detections:
             if save:
                 f = self.files[i]
                 img.save(Path(save_dir) / f)  # save
-                print(f"{'Saved' * (i == 0)} {f},", end='' if i < self.n - 1 else f' to {save_dir}\n')
+                print(f"{'Saved' * (i == 0)} {f}", end=',' if i < self.n - 1 else f' to {save_dir}\n')
             if render:
                 self.imgs[i] = np.asarray(img)
 

--- a/models/common.py
+++ b/models/common.py
@@ -11,7 +11,7 @@ from PIL import Image
 from torch.cuda import amp
 
 from utils.datasets import letterbox
-from utils.general import non_max_suppression, make_divisible, scale_coords, xyxy2xywh
+from utils.general import non_max_suppression, make_divisible, scale_coords, increment_path, xyxy2xywh
 from utils.plots import color_list, plot_one_box
 from utils.torch_utils import time_synchronized
 
@@ -324,9 +324,9 @@ class Detections:
             if show:
                 img.show(self.files[i])  # show
             if save:
-                f = Path(save_dir) / self.files[i]
-                img.save(f)  # save
-                print(f"{'Saving' * (i == 0)} {f},", end='' if i < self.n - 1 else ' done.\n')
+                f = self.files[i]
+                img.save(Path(save_dir) / f)  # save
+                print(f"{'Saved' * (i == 0)} {f},", end='' if i < self.n - 1 else f' to {save_dir}\n')
             if render:
                 self.imgs[i] = np.asarray(img)
 
@@ -337,8 +337,9 @@ class Detections:
     def show(self):
         self.display(show=True)  # show results
 
-    def save(self, save_dir='results/'):
-        Path(save_dir).mkdir(exist_ok=True)
+    def save(self, save_dir='runs/hub/exp'):
+        save_dir = increment_path(save_dir, exist_ok=save_dir != 'runs/hub/exp')  # increment save_dir
+        Path(save_dir).mkdir(parents=True, exist_ok=True)
         self.display(save=True, save_dir=save_dir)  # save results
 
     def render(self):


### PR DESCRIPTION
This change will align PyTorch Hub results saving with the existing unified results saving directory structure and incrementing behavior, i.e.

```
runs/
  /train
  /detect
  /test
  /hub
    /exp
    /exp2
    ...
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image saving functionality in the Ultralytics YOLOv5 model's common utility scripts.

### 📊 Key Changes
- Imported the `increment_path` function from `utils.general`.
- Improved handling of file paths when saving images.
- Save directory path creation is now smarter, avoiding overwrites.

### 🎯 Purpose & Impact
- The purpose of the changes is to minimize the risk of overwriting files by intelligently managing save directory paths.
- These changes will benefit users by creating unique save directories when needed, ensuring that the results from different runs are separated and preserved.
- Overall user experience should improve due to clearer save messages and better file organization. 📁✨