### PR TITLE
Updated filename attributes for YOLOv5 Hub results

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -254,12 +254,12 @@ class autoShape(nn.Module):
         n, imgs = (len(imgs), imgs) if isinstance(imgs, list) else (1, [imgs])  # number of images, list of images
         shape0, shape1, files = [], [], []  # image and inference shapes, filenames
         for i, im in enumerate(imgs):
+            f = f'image{i}'  # filename
             if isinstance(im, str):  # filename or uri
-                im, f = Image.open(requests.get(im, stream=True).raw if im.startswith('http') else im), im  # open
-                im.filename = f  # for uri
-            files.append(Path(im.filename).with_suffix('.jpg').name if isinstance(im, Image.Image) else f'image{i}.jpg')
-            if not isinstance(im, np.ndarray):
-                im = np.asarray(im)  # to numpy
+                im, f = np.asarray(Image.open(requests.get(im, stream=True).raw if im.startswith('http') else im)), im
+            elif isinstance(im, Image.Image):  # PIL Image
+                im, f = np.asarray(im), getattr(im, 'filename', f)
+            files.append(Path(f).with_suffix('.jpg').name)
             if im.shape[0] < 5:  # image in CHW
                 im = im.transpose((1, 2, 0))  # reverse dataloader .transpose(2, 0, 1)
             im = im[:, :, :3] if im.ndim == 3 else np.tile(im[:, :, None], 3)  # enforce 3ch input


### PR DESCRIPTION
Proposed fix for 'Model predict with forward will fail if PIL image does not have filename attribute' #2702

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in image handling within the YOLOv5 model pipeline.

### 📊 Key Changes
- Simplified filename assignment within the image preprocessing loop.
- Unified the conversion of both PIL Images and images read from file/URI to NumPy arrays.
- Ensured consistent .jpg filename extension when collecting file names.

### 🎯 Purpose & Impact
- **Purpose**: To streamline the code for handling input images, making it cleaner and more efficient.
- **Impact**: Users might experience slight improvements in input processing speed and less complexity in the code, leading to easier maintenance and understanding. It potentially reduces bugs by having a single pathway for image conversion to NumPy array format. 🔄🖼️🚀