### PR TITLE
Updated filename attributes for YOLOv5 Hub BytesIO

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -258,7 +258,7 @@ class autoShape(nn.Module):
             if isinstance(im, str):  # filename or uri
                 im, f = np.asarray(Image.open(requests.get(im, stream=True).raw if im.startswith('http') else im)), im
             elif isinstance(im, Image.Image):  # PIL Image
-                im, f = np.asarray(im), getattr(im, 'filename', f)
+                im, f = np.asarray(im), getattr(im, 'filename', f) or f
             files.append(Path(f).with_suffix('.jpg').name)
             if im.shape[0] < 5:  # image in CHW
                 im = im.transpose((1, 2, 0))  # reverse dataloader .transpose(2, 0, 1)


### PR DESCRIPTION
Fix 2 for 'Model predict with forward will fail if PIL image does not have filename attribute' #2702

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to image file handling in preprocessing.

### 📊 Key Changes
- Modified how file names are derived from PIL Image objects during preprocessing.

### 🎯 Purpose & Impact
- 🛠 Ensures more robust file name extraction from PIL Images, avoiding potential issues if the `filename` attribute is missing.
- 🚀 Users can expect more reliable image loading, particularly when using PIL Image inputs, enhancing the versatility and user-friendliness of the model.