### PR TITLE
[WIP] Prune and quantize models during training - SparseML Intgration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ pandas
 # extras --------------------------------------
 thop  # FLOPS computation
 pycocotools>=2.0  # COCO mAP
+sparseml~=0.2

--- a/train.py
+++ b/train.py
@@ -21,6 +21,11 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.tensorboard import SummaryWriter
 from tqdm import tqdm
 
+from sparseml.pytorch.nn import replace_activations
+from sparseml.pytorch.optim import ScheduledModifierManager, ScheduledOptimizer
+from sparseml.pytorch.utils import PythonLogger, TensorBoardLogger, ModuleExporter
+from sparseml.pytorch.utils.quantization import skip_onnx_input_quantize
+
 import test  # import test.py to get mAP after each epoch
 from models.experimental import attempt_load
 from models.yolo import Model
@@ -87,7 +92,7 @@ def train(hyp, opt, device, tb_writer=None):
         ckpt = torch.load(weights, map_location=device)  # load checkpoint
         model = Model(opt.cfg or ckpt['model'].yaml, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
         exclude = ['anchor'] if (opt.cfg or hyp.get('anchors')) and not opt.resume else []  # exclude keys
-        state_dict = ckpt['model'].float().state_dict()  # to FP32
+        state_dict = ckpt['model'].float().state_dict() if isinstance(ckpt['model'], nn.Module) else ckpt['model']
         state_dict = intersect_dicts(state_dict, model.state_dict(), exclude=exclude)  # intersect
         model.load_state_dict(state_dict, strict=False)  # load
         logger.info('Transferred %g/%g items from %s' % (len(state_dict), len(model.state_dict()), weights))  # report
@@ -141,7 +146,7 @@ def train(hyp, opt, device, tb_writer=None):
     # plot_lr_scheduler(optimizer, scheduler, epochs)
 
     # EMA
-    ema = ModelEMA(model) if rank in [-1, 0] else None
+    ema = ModelEMA(model) if rank in [-1, 0] and not opt.disable_ema else None
 
     # Resume
     start_epoch, best_fitness = 0, 0.0
@@ -214,7 +219,8 @@ def train(hyp, opt, device, tb_writer=None):
             # Anchors
             if not opt.noautoanchor:
                 check_anchors(dataset, model=model, thr=hyp['anchor_t'], imgsz=imgsz)
-            model.half().float()  # pre-reduce anchor precision
+            if not opt.disable_amp:
+                model.half().float()  # pre-reduce anchor precision
 
     # DDP mode
     if cuda and rank != -1:
@@ -233,14 +239,47 @@ def train(hyp, opt, device, tb_writer=None):
     model.class_weights = labels_to_class_weights(dataset.labels, nc).to(device) * nc  # attach class weights
     model.names = names
 
+    # SparseML Integration
+    if opt.use_leaky_relu:  # use LeakyReLU activations
+        model = replace_activations(model, 'lrelu', inplace=True)
+
+    qat = False
+    if opt.sparseml_recipe:
+        manager = ScheduledModifierManager.from_yaml(opt.sparseml_recipe)
+        optimizer = ScheduledOptimizer(
+            optimizer,
+            model if not is_parallel(model) else model.module,
+            manager,
+            steps_per_epoch=len(dataloader),
+            loggers=[PythonLogger(), TensorBoardLogger(writer=tb_writer)]
+        )
+        # override lr scheduler if recipe makes any LR updates
+        if manager.learning_rate_modifiers:
+            logger.info('Disabling LR scheduler, managing LR using SparseML recipe')
+            scheduler = None
+        # override num epochs if recipe explicitly modifies epoch range
+        if manager.epoch_modifiers and manager.max_epochs:
+            epochs = manager.max_epochs or epochs  # override num_epochs
+            logger.info(f'Overriding number of epochs from SparseML manager to {manager.max_epochs}')
+        # mark that QAT will be applied, pickled QAT exports currently not supported
+        if manager.quantization_modifiers:
+            logger.info('Disabling pickling for model exports, QAT scheduled to run')
+            if not opt.use_leaky_relu:
+                logger.warning(
+                    'QAT detected in sparsification recipe, but --use-leaky-relu not set '
+                    'quantized model may not run well with default activations'
+                )
+            qat = True
+
     # Start training
     t0 = time.time()
     nw = max(round(hyp['warmup_epochs'] * nb), 1000)  # number of warmup iterations, max(3 epochs, 1k iterations)
     # nw = min(nw, (epochs - start_epoch) / 2 * nb)  # limit warmup to < 1/2 of training
     maps = np.zeros(nc)  # mAP per class
     results = (0, 0, 0, 0, 0, 0, 0)  # P, R, mAP@.5, mAP@.5-.95, val_loss(box, obj, cls)
-    scheduler.last_epoch = start_epoch - 1  # do not move
-    scaler = amp.GradScaler(enabled=cuda)
+    if scheduler:
+        scheduler.last_epoch = start_epoch - 1  # do not move
+    scaler = amp.GradScaler(enabled=(cuda and not opt.disable_amp))
     compute_loss = ComputeLoss(model)  # init loss class
     logger.info(f'Image sizes {imgsz} train, {imgsz_test} test\n'
                 f'Using {dataloader.num_workers} dataloader workers\n'
@@ -286,7 +325,8 @@ def train(hyp, opt, device, tb_writer=None):
                 accumulate = max(1, np.interp(ni, xi, [1, nbs / total_batch_size]).round())
                 for j, x in enumerate(optimizer.param_groups):
                     # bias lr falls from 0.1 to lr0, all other lrs rise from 0.0 to lr0
-                    x['lr'] = np.interp(ni, xi, [hyp['warmup_bias_lr'] if j == 2 else 0.0, x['initial_lr'] * lf(epoch)])
+                    if scheduler:
+                        x['lr'] = np.interp(ni, xi, [hyp['warmup_bias_lr'] if j == 2 else 0.0, x['initial_lr'] * lf(epoch)])
                     if 'momentum' in x:
                         x['momentum'] = np.interp(ni, xi, [hyp['warmup_momentum'], hyp['momentum']])
 
@@ -299,7 +339,7 @@ def train(hyp, opt, device, tb_writer=None):
                     imgs = F.interpolate(imgs, size=ns, mode='bilinear', align_corners=False)
 
             # Forward
-            with amp.autocast(enabled=cuda):
+            with amp.autocast(enabled=(cuda and not opt.disable_amp)):
                 pred = model(imgs)  # forward
                 loss, loss_items = compute_loss(pred, targets.to(device))  # loss scaled by batch_size
                 if rank != -1:
@@ -342,19 +382,21 @@ def train(hyp, opt, device, tb_writer=None):
 
         # Scheduler
         lr = [x['lr'] for x in optimizer.param_groups]  # for tensorboard
-        scheduler.step()
+        if scheduler:
+            scheduler.step()
 
         # DDP process 0 or single-GPU
         if rank in [-1, 0]:
             # mAP
-            ema.update_attr(model, include=['yaml', 'nc', 'hyp', 'gr', 'names', 'stride', 'class_weights'])
+            if ema:
+                ema.update_attr(model, include=['yaml', 'nc', 'hyp', 'gr', 'names', 'stride', 'class_weights'])
             final_epoch = epoch + 1 == epochs
             if not opt.notest or final_epoch:  # Calculate mAP
                 wandb_logger.current_epoch = epoch + 1
                 results, maps, times = test.test(data_dict,
                                                  batch_size=batch_size * 2,
                                                  imgsz=imgsz_test,
-                                                 model=ema.ema,
+                                                 model=ema.ema if ema else model,
                                                  single_cls=opt.single_cls,
                                                  dataloader=testloader,
                                                  save_dir=save_dir,
@@ -362,7 +404,8 @@ def train(hyp, opt, device, tb_writer=None):
                                                  plots=plots and final_epoch,
                                                  wandb_logger=wandb_logger,
                                                  compute_loss=compute_loss,
-                                                 is_coco=is_coco)
+                                                 is_coco=is_coco,
+                                                 half_precision=not opt.disable_amp)
 
             # Write
             with open(results_file, 'a') as f:
@@ -389,12 +432,15 @@ def train(hyp, opt, device, tb_writer=None):
 
             # Save model
             if (not opt.nosave) or (final_epoch and not opt.evolve):  # if save
+                ckpt_model = deepcopy(model.module if is_parallel(model) else model)
+                if qat:
+                    ckpt_model = model.state_dict()  # pickled QAT exports not currently supported
                 ckpt = {'epoch': epoch,
                         'best_fitness': best_fitness,
                         'training_results': results_file.read_text(),
-                        'model': deepcopy(model.module if is_parallel(model) else model).half(),
-                        'ema': deepcopy(ema.ema).half(),
-                        'updates': ema.updates,
+                        'model': ckpt_model.half() if not opt.disable_amp else ckpt_model,
+                        'ema': deepcopy(ema.ema).half() if ema else None,
+                        'updates': ema.updates if ema else None,
                         'optimizer': optimizer.state_dict(),
                         'wandb_id': wandb_logger.wandb_run.id if wandb_logger.wandb else None}
 
@@ -422,23 +468,39 @@ def train(hyp, opt, device, tb_writer=None):
         logger.info('%g epochs completed in %.3f hours.\n' % (epoch - start_epoch + 1, (time.time() - t0) / 3600))
         if opt.data.endswith('coco.yaml') and nc == 80:  # if COCO
             for m in (last, best) if best.exists() else (last):  # speed, mAP tests
+                test_model = attempt_load(m, device) if not qat else model
                 results, _, _ = test.test(opt.data,
                                           batch_size=batch_size * 2,
                                           imgsz=imgsz_test,
                                           conf_thres=0.001,
                                           iou_thres=0.7,
-                                          model=attempt_load(m, device).half(),
+                                          model=test_model.half() if not opt.disable_amp else test_model,
                                           single_cls=opt.single_cls,
                                           dataloader=testloader,
                                           save_dir=save_dir,
                                           save_json=True,
                                           plots=False,
-                                          is_coco=is_coco)
+                                          is_coco=is_coco,
+                                          half_precision=not opt.disable_amp)
+
+        # ONNX export
+        if opt.export_onnx:
+            try:
+                onnx_path = f'{save_dir}/model.onnx'
+                logger.info(f'training complete, exporting ONNX to {onnx_path}')
+                export_model = model.module if is_parallel_model(model) else model
+                export_model.model[-1].export = True  # do not export grid post-procesing
+                exporter = ModuleExporter(export_model, save_dir)
+                exporter.export_onnx(torch.randn(1, 3, imgsz, imgsz), convert_qat=True)
+                if qat:
+                    skip_onnx_input_quantize(onnx_path, onnx_path)
+            except Exception as e:
+                logger.warning(f'exception occured during ONNX export, model not exported to ONNX. error message {e}')
 
         # Strip optimizers
         final = best if best.exists() else last  # final model
         for f in last, best:
-            if f.exists():
+            if f.exists() and not qat:  # qat state dict incompatible
                 strip_optimizer(f)  # strip optimizers
         if opt.bucket:
             os.system(f'gsutil cp {final} gs://{opt.bucket}/weights')  # upload
@@ -489,6 +551,11 @@ if __name__ == '__main__':
     parser.add_argument('--bbox_interval', type=int, default=-1, help='Set bounding-box image logging interval for W&B')
     parser.add_argument('--save_period', type=int, default=-1, help='Log model after every "save_period" epoch')
     parser.add_argument('--artifact_alias', type=str, default="latest", help='version of dataset artifact to be used')
+    parser.add_argument('--sparseml-recipe', type=str, default=None, help='Path to a SparseML sparsification recipe, see <TODO: Link Here> for more information')
+    parser.add_argument('--use-leaky-relu', action='store_true', help='Override default SiLU activation with LeakyReLU')
+    parser.add_argument('--export-onnx', action='store_true', help='export final model to ONNX')
+    parser.add_argument('--disable-amp', action='store_true', help='Disable FP16 half precision (enabled by default)')
+    parser.add_argument('--disable-ema', action='store_true', help='Disable EMA model updates (enabled by default)')
     opt = parser.parse_args()
 
     # Set DDP variables

--- a/train.py
+++ b/train.py
@@ -270,6 +270,9 @@ def train(hyp, opt, device, tb_writer=None):
                     'quantized model may not run well with default activations'
                 )
             qat = True
+        # make sure that sparsity structure is held during EMA updates
+        if ema and manager.pruning_modifiers:
+            ema.pruning_manager = manager
 
     # Start training
     t0 = time.time()

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -276,17 +276,37 @@ class ModelEMA:
     GPU assignment and distributed training wrappers.
     """
 
-    def __init__(self, model, decay=0.9999, updates=0):
+    def __init__(self, model, decay=0.9999, updates=0, enabled=True):
         # Create EMA
         self.ema = deepcopy(model.module if is_parallel(model) else model).eval()  # FP32 EMA
         # if next(model.parameters()).device.type != 'cpu':
         #     self.ema.half()  # FP16 EMA
         self.updates = updates  # number of EMA updates
         self.decay = lambda x: decay * (1 - math.exp(-x / 2000))  # decay exponential ramp (to help early epochs)
+        self.enabled = enabled
         for p in self.ema.parameters():
             p.requires_grad_(False)
 
+    def state_dict(self, half_precision=True):
+        if not self.enabled:
+            return {}
+
+        ema = deepcopy(self.ema)
+        return {
+            'ema': ema.half() if half_precision else ema,
+            'updates': self.updates,
+        }
+
+    def load_state_dict(self, state_dict):
+        if 'ema' in state_dict:
+            self.ema.load_state_dict(state_dict['ema'].float().state_dict())
+        if 'updates' in state_dict:
+            self.updates = state_dict['updates']
+
     def update(self, model):
+        if not self.enabled:
+            return
+
         # Update EMA parameters
         with torch.no_grad():
             self.updates += 1
@@ -299,5 +319,8 @@ class ModelEMA:
                     v += (1. - d) * msd[k].detach()
 
     def update_attr(self, model, include=(), exclude=('process_group', 'reducer')):
+        if not self.enabled:
+            return
+
         # Update EMA attributes
         copy_attr(self.ema, model, include, exclude)


### PR DESCRIPTION
## What's Included
This change includes an integration with the [SparseML](https://github.com/neuralmagic/sparseml) package that enables easy model pruning and quantization.  Using this integration, *our team was able to prune YOLOv3 to 88% sparsity as well as prune and quantize the same model to 83% sparsity with INT8 quantization*.  The latter resulted in 5-6x speedups when running on cloud CPUs. More about this project can be found [in this blog post](https://neuralmagic.com/blog/benchmark-yolov3-on-cpus-with-deepsparse/).

This change adds an optional `--sparseml-recipe` argument to `train.py` that if enabled, can run SparseML optimizations during regular model training.  If no value is provided, then the existing training process is completely unaffected.

Some additional flags were added which may be generally useful:
* `--export-onnx`: when enabled the model will be exported to an ONNX file after training is complete.
* `--use-leaky-relu`: when enabled the default SiLU activations will be replaced with LeakyReLUs (SiLUs are not currently ONNX exportable and LeakyReLUs also work better for quantized inference)
* `--disable-ema`: disables EMA during training if activated (not currently supported with pruning)
* `--disable-amp`: disables mixed precision which is not currently supported by PyTorch for QAT.

Additionally, a few lines were added to support the PyTorch export of QAT models since they are currently not pickle-able.

This integration can be used to sparsify models supported in this repository as well as reproduce our blog's results.  Please let us know if you have any suggestions, questions, and how this fits into the existing infrastructure.  

Thanks again for creating and maintaining this great resource!

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced YOLOv5 model support for SparseML sparsification and quantization.

### 📊 Key Changes
- Integrated SparseML modifiers in the training pipeline.
- Implemented conditional execution for exporting ONNX models with sparsification.
- Added argument options for customizing sparsification and quantization.
- Adjusted loading logic for models with sparsification.
- Improved EMA (Exponential Moving Average) with options to disable and support for SparseML pruning.

### 🎯 Purpose & Impact
- **For Developers:**
  - Enables training YOLOv5 models with pruning and quantization for better optimization, potentially reducing model size and improving inference speed without significant loss in accuracy.
  - Offers more control over training hyperparameters and model architecture through the new command-line arguments.
- **For Users:**
  - Users can benefit from faster and more efficient models deployed in production, with less computational overhead.
- **Broader Impact:**
  - This enhances the YOLOv5 framework's capabilities, making it more versatile and suitable for edge devices and environments with limited computational resources.