### PR TITLE
autocast enable=torch.cuda.is_available()

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -237,7 +237,7 @@ class autoShape(nn.Module):
         return self
 
     @torch.no_grad()
-    @torch.cuda.amp.autocast()
+    @torch.cuda.amp.autocast(torch.cuda.is_available())
     def forward(self, imgs, size=640, augment=False, profile=False):
         # Inference from various sources. For height=640, width=1280, RGB images example inputs are:
         #   filename:   imgs = 'data/samples/zidane.jpg'


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved device compatibility in model inference method.

### 📊 Key Changes
- Modified the decorator `@torch.cuda.amp.autocast()` to conditionally activate based on CUDA availability with `@torch.cuda.amp.autocast(torch.cuda.is_available())`.

### 🎯 Purpose & Impact
- **Purpose:** Ensures that the automatic mixed-precision (AMP) is only enabled when a CUDA-enabled GPU is available, preventing potential issues on non-CUDA environments.
- **Impact:** Users without CUDA-compatible hardware will experience better compatibility and fewer errors, while CUDA users maintain the benefits of AMP for faster, more efficient inference. 🚀