### PR TITLE
Updated detect.py to save each detected object as separate image

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -121,7 +121,7 @@ def detect(save_img=False):
                         img_ = im1.astype(np.uint8)
                         crop_img=img_[y:y+ h, x:x + w]                          
                             
-                        #!!rescale image !!!
+                        #!!Generating new file path for each detected object in an image !!!
                         filename=p.name
                         filename_no_extesion=filename.split('.')[0]
                         extension=filename.split('.')[1]

--- a/detect.py
+++ b/detect.py
@@ -17,7 +17,7 @@ from utils.torch_utils import select_device, load_classifier, time_synchronized
 
 
 def detect(save_img=False):
-    source, weights, view_img, save_txt, imgsz = opt.source, opt.weights, opt.view_img, opt.save_txt, opt.img_size
+    source, weights, view_img, save_obj, save_txt, imgsz = opt.source, opt.weights, opt.view_img, opt.save_obj, opt.save_txt, opt.img_size
     save_img = not opt.nosave and not source.endswith('.txt')  # save inference images
     webcam = source.isnumeric() or source.endswith('.txt') or source.lower().startswith(
         ('rtsp://', 'rtmp://', 'http://', 'https://'))


### PR DESCRIPTION
updated detect.py to save detected object as a separate image. I have added arg save_obj which give option whether to save the detected object as separate images in project/name/cropped dir.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
The PR introduces the ability to save cropped images of detected objects in YOLOv5.

### 📊 Key Changes
- Imported `numpy` as `np` to handle array operations.
- Added a `save_obj` argument to control whether cropped images of detected objects should be saved.
- Created a directory to store cropped object images if `save_obj` is set.
- Implemented code to save cropped detections as individual image files within the specified directory.

### 🎯 Purpose & Impact
- **Purpose**: This feature enables users to save just the portions of images containing detected objects, which can be useful for further analysis or for creating datasets.
- **Impact**: Users who require only the detected objects can now easily extract and save them without needing to manually crop images, thus streamlining workflows involving object detection.
- **Possible Drawbacks**: An increase in disk usage if many objects are detected and saved, and there could be a minor performance impact due to the additional I/O operations.