### PR TITLE
Fix ONNX dynamic axes export support with onnx simplifier, make onnx simplifier optional

### DIFF
--- a/models/export.py
+++ b/models/export.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
     model.model[-1].export = not opt.grid  # set Detect() layer grid export
     y = model(img)  # dry run
 
-    # TorchScript export
+    # TorchScript export -----------------------------------------------------------------------------------------------
     prefix = colorstr('TorchScript:')
     try:
         print(f'\n{prefix} starting export with torch {torch.__version__}...')
@@ -70,7 +70,7 @@ if __name__ == '__main__':
     except Exception as e:
         print(f'{prefix} export failure: {e}')
 
-    # ONNX export
+    # ONNX export ------------------------------------------------------------------------------------------------------
     prefix = colorstr('ONNX:')
     try:
         import onnx
@@ -105,7 +105,7 @@ if __name__ == '__main__':
     except Exception as e:
         print(f'{prefix} export failure: {e}')
 
-    # CoreML export
+    # CoreML export ----------------------------------------------------------------------------------------------------
     prefix = colorstr('CoreML:')
     try:
         import coremltools as ct


### PR DESCRIPTION
Onnxsim fails to optimize/simplify models with dynamic axes. This pull request fixes that.

To reproduce the problem:
  python models/export.py --dynamic

I also made the onnx simplifier optional though a new command line option (--onnx-simplify). It still crashes with certain combinations of options, so best to make it optional, especially given that the onnx simplifier can be quite slow.



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced ONNX export functionality with model simplification option in YOLOv5.

### 📊 Key Changes
- Added a new CLI argument `--simplify` for optional ONNX model simplification.
- Reorganized code comments to delineate sections more clearly with banners.
- Ensured that dynamic axes and input shapes are properly accounted for during ONNX export when using the new `--simplify` argument.

### 🎯 Purpose & Impact
- **Purpose**: The inclusion of the `--simplify` option provides users with the ability to streamline their ONNX models, potentially improving performance and compatibility.
- **Impact**: Users exporting YOLOv5 models to ONNX format can now produce simpler, more efficient models with just a command-line flag, enabling better integration into applications that consume ONNX models. 🚀