### PR TITLE
bug fix: switched rows and cols for correct detections in confusion matrix

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -145,7 +145,7 @@ class ConfusionMatrix:
         for i, gc in enumerate(gt_classes):
             j = m0 == i
             if n and sum(j) == 1:
-                self.matrix[gc, detection_classes[m1[j]]] += 1  # correct
+                self.matrix[detection_classes[m1[j]], gc] += 1  # correct
             else:
                 self.matrix[self.nc, gc] += 1  # background FP
 


### PR DESCRIPTION
After a test run with the pretrained yolov5s weights on a image set containing only six classes of labels (person, bicycle, car, motorcycle, bus, truck), the created confusion matrix plot showed classes on the "true" axis that were not present in the image set.

![confusion_matrix](https://user-images.githubusercontent.com/75843816/115625283-1f913380-a2fc-11eb-8c3d-7c19a8c47691.png)

This was caused by false referencing rows and cols in the counter of the confusion matrix for the correctly detected objects in the `utils/metrics.py` file. After fixing this bug by switching the row and col reference, the confusion matrix now looks like it should.

![confusion_matrix](https://user-images.githubusercontent.com/75843816/115625770-d55c8200-a2fc-11eb-8e0b-77cbffb6c360.png)

Best
Michael

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced accuracy in object detection metric calculations.

### 📊 Key Changes
- Adjusted the indices in the confusion matrix update operation.

### 🎯 Purpose & Impact
- **Purpose:** To fix a bug in updating the confusion matrix used for evaluating object detection performance.
- **Impact:** Ensures precise metric computation which aids in accurately assessing and improving model performance. This fix benefits developers and researchers who rely on these metrics to validate and iterate their object detection models. 📈