### PR TITLE
Uppercase model filenames enabled

### DIFF
--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -18,7 +18,7 @@ def gsutil_getsize(url=''):
 
 def attempt_download(file, repo='ultralytics/yolov5'):
     # Attempt file download if does not exist
-    file = Path(str(file).strip().replace("'", '').lower())
+    file = Path(str(file).strip().replace("'", ''))
 
     if not file.exists():
         try:


### PR DESCRIPTION
Converting the file path of the model weights to lowercase will cause problems if the path contains uppercase characters:
The model weights file can't be found locally and yolov5 will try to download it from an online resource. This causes yolov5 to crash without an internet connection or may cause problems when calling yolov5 too many times, which may trigger the github API query limit.

Please be aware that this is only an issue when checking for the model weights file. It doesn't prevent yolov5 from using the correct weights file later on. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving file handling in YOLOv5 by removing case-insensitivity from downloaded file paths.

### 📊 Key Changes
- Altered the `attempt_download` function in `utils/google_utils.py` to preserve the original case of filenames.

### 🎯 Purpose & Impact
- 🔍 **Purpose**: To make sure file downloads are consistent with the file's original naming conventions, reducing potential confusion and errors when case-sensitive file names are necessary.
- 💥 **Impact**: This change ensures users working with case-sensitive systems or file names will have a smoother experience, with fewer file-not-found errors due to mismatching case.