### PR TITLE
Update google_utils.py

### DIFF
--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -26,8 +26,12 @@ def attempt_download(file, repo='ultralytics/yolov5'):
             assets = [x['name'] for x in response['assets']]  # release assets, i.e. ['yolov5s.pt', 'yolov5m.pt', ...]
             tag = response['tag_name']  # i.e. 'v1.0'
         except:  # fallback plan
-            assets = ['yolov5s.pt', 'yolov5m.pt', 'yolov5l.pt', 'yolov5x.pt']
-            tag = subprocess.check_output('git tag', shell=True).decode().split()[-1]
+            assets = ['yolov5s.pt', 'yolov5m.pt', 'yolov5l.pt', 'yolov5x.pt',
+                      'yolov5s6.pt', 'yolov5m6.pt', 'yolov5l6.pt', 'yolov5x6.pt']
+            try:
+                tag = subprocess.check_output('git tag', shell=True, stderr=subprocess.STDOUT).decode().split()[-1]
+            except:
+                tag = 'v5.0'  # current release
 
         name = file.name
         if name in assets:


### PR DESCRIPTION
Possible fix for #2894.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to backup download mechanism in `utils/google_utils.py` for model assets. 

### 📊 Key Changes
- Expanded the list of fallback assets to include models with a '6' suffix (e.g., `yolov5s6.pt`, `yolov5m6.pt`, etc.).
- Improved error handling by trying to get the latest tag name and falling back to a default value (`v5.0`) if unsuccessful.

### 🎯 Purpose & Impact
- **Ensures model availability:** The expanded asset list increases the chances that a user will be able to download the right model, even if the primary method fails.
- **Stability in version control:** By capturing errors when retrieving the latest git tag name, the system provides a stable fallback option, ensuring the functionality isn't broken if the git command fails.
- **User experience:** Non-expert users will experience a smoother setup process since the script is more robust and less likely to fail when downloading required model weights.