### PR TITLE
add an option to skip model info printing

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -64,7 +64,7 @@ class Detect(nn.Module):
 
 
 class Model(nn.Module):
-    def __init__(self, cfg='yolov5s.yaml', ch=3, nc=None, anchors=None):  # model, input channels, number of classes
+    def __init__(self, cfg='yolov5s.yaml', ch=3, nc=None, anchors=None, verbose=1):  # model, input channels, number of classes
         super(Model, self).__init__()
         if isinstance(cfg, dict):
             self.yaml = cfg  # model dict
@@ -99,7 +99,8 @@ class Model(nn.Module):
 
         # Init weights, biases
         initialize_weights(self)
-        self.info()
+        if verbose:
+            self.info()
         logger.info('')
 
     def forward(self, x, augment=False, profile=False):
@@ -198,8 +199,9 @@ class Model(nn.Module):
         model_info(self, verbose, img_size)
 
 
-def parse_model(d, ch):  # model_dict, input_channels(3)
-    logger.info('\n%3s%18s%3s%10s  %-40s%-30s' % ('', 'from', 'n', 'params', 'module', 'arguments'))
+def parse_model(d, ch, verbose=1):  # model_dict, input_channels(3)
+    if verbose:
+        logger.info('\n%3s%18s%3s%10s  %-40s%-30s' % ('', 'from', 'n', 'params', 'module', 'arguments'))
     anchors, nc, gd, gw = d['anchors'], d['nc'], d['depth_multiple'], d['width_multiple']
     na = (len(anchors[0]) // 2) if isinstance(anchors, list) else anchors  # number of anchors
     no = na * (nc + 5)  # number of outputs = anchors * (classes + 5)
@@ -243,7 +245,8 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
         t = str(m)[8:-2].replace('__main__.', '')  # module type
         np = sum([x.numel() for x in m_.parameters()])  # number params
         m_.i, m_.f, m_.type, m_.np = i, f, t, np  # attach index, 'from' index, type, number params
-        logger.info('%3s%18s%3s%10.0f  %-40s%-30s' % (i, f, n, np, t, args))  # print
+        if verbose:
+            logger.info('%3s%18s%3s%10.0f  %-40s%-30s' % (i, f, n, np, t, args))  # print
         save.extend(x % i for x in ([f] if isinstance(f, int) else f) if x != -1)  # append to savelist
         layers.append(m_)
         if i == 0:


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging verbosity control in YOLOv5 model initialization.

### 📊 Key Changes
- Added a `verbose` parameter to the `Model` class constructor to control the output of the initialization information.
- Modified the `parse_model` function to accept a `verbose` argument that determines whether model details are printed during parsing.
- Adjusted logging behavior in both `Model` initialization and `parse_model` function to conditionally display logs based on the `verbose` flag.

### 🎯 Purpose & Impact
- 🎛️ **Enhanced Flexibility**: Users can now control the amount of logging information displayed during model initialization, which is useful for keeping console output clean.
- 🧑‍💻 **Developer Convenience**: The addition of the `verbose` argument helps developers by providing options to either view detailed initialization logs or minimize noise during development tasks.
- 📉 **Potential Impact**: This update impacts users who prefer running YOLOv5 without extensive console logging, as they now have the option to limit output, leading to a more streamlined user experience.