### PR TITLE
Change default value of hide-conf argument to false

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -172,7 +172,7 @@ if __name__ == '__main__':
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     parser.add_argument('--line-thickness', default=3, type=int, help='bounding box thickness (pixels)')
     parser.add_argument('--hide-labels', default=False, action='store_true', help='hide labels')
-    parser.add_argument('--hide-conf', default=True, action='store_true', help='hide confidences')
+    parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
     opt = parser.parse_args()
     print(opt)
     check_requirements(exclude=('pycocotools', 'thop'))


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced default confidence display in `detect.py`.

### 📊 Key Changes
- Changed the default behavior of the `--hide-conf` flag from `True` to `False`.

### 🎯 Purpose & Impact
- **Purpose:** This change ensures that confidence scores are displayed by default when running the object detection, providing more detailed information to users without needing to explicitly disable the hiding of confidence scores.
- **Impact:** Users will now see the confidence levels of detections out of the box, which could improve their understanding of the model's performance and decision-making process. This is particularly useful for new users or for quick debugging sessions.