### PR TITLE
Check_requirements() enclosing apostrophe bug fix

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -117,8 +117,8 @@ def check_requirements(requirements='requirements.txt', exclude=()):
             pkg.require(r)
         except Exception as e:  # DistributionNotFound or VersionConflict if requirements not met
             n += 1
-            print(f"{prefix} {e.req} not found and is required by YOLOv5, attempting auto-update...")
-            print(subprocess.check_output(f"pip install {e.req}", shell=True).decode())
+            print(f"{prefix} {r} not found and is required by YOLOv5, attempting auto-update...")
+            print(subprocess.check_output(f"pip install '{r}'", shell=True).decode())
 
     if n:  # if packages updated
         source = file.resolve() if 'file' in locals() else requirements


### PR DESCRIPTION
This fixes a bug where the '>' symbol in python package requirements was not running correctly with subprocess.check_output() commands.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved error handling for missing Python package requirements.

### 📊 Key Changes
- Enhanced the error message to display the correct package requirement that's missing.
- Updated the subprocess command to safely install the missing package(s).

### 🎯 Purpose & Impact
- Users will now receive clearer error messages regarding missing dependencies, making it easier to understand what's needed.
- The auto-update command now securely installs the missing package, reducing the risk of command injection vulnerabilities.
- 🛠️ This should create a smoother setup experience for new users and enhance security for the YOLOv5 project.