### PR TITLE
Update check_requirements() exclude list

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -172,7 +172,7 @@ if __name__ == '__main__':
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
     opt = parser.parse_args()
     print(opt)
-    check_requirements(exclude=('pycocotools', 'thop'))
+    check_requirements(exclude=('tensorboard', 'pycocotools', 'thop'))
 
     with torch.no_grad():
         if opt.update:  # update all models (to fix SourceChangeWarning)

--- a/hubconf.py
+++ b/hubconf.py
@@ -15,7 +15,7 @@ from utils.google_utils import attempt_download
 from utils.torch_utils import select_device
 
 dependencies = ['torch', 'yaml']
-check_requirements(Path(__file__).parent / 'requirements.txt', exclude=('pycocotools', 'thop'))
+check_requirements(Path(__file__).parent / 'requirements.txt', exclude=('tensorboard', 'pycocotools', 'thop'))
 
 
 def create(name, pretrained, channels, classes, autoshape, verbose):

--- a/test.py
+++ b/test.py
@@ -310,7 +310,7 @@ if __name__ == '__main__':
     opt.save_json |= opt.data.endswith('coco.yaml')
     opt.data = check_file(opt.data)  # check file
     print(opt)
-    check_requirements()
+    check_requirements(exclude=('tensorboard', 'pycocotools', 'thop'))
 
     if opt.task in ('train', 'val', 'test'):  # run normally
         test(opt.data,

--- a/train.py
+++ b/train.py
@@ -497,7 +497,7 @@ if __name__ == '__main__':
     set_logging(opt.global_rank)
     if opt.global_rank in [-1, 0]:
         check_git_status()
-        check_requirements()
+        check_requirements(exclude=('pycocotools', 'thop'))
 
     # Resume
     wandb_run = check_wandb_resume(opt)

--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -3,7 +3,6 @@
 import numpy as np
 import torch
 import yaml
-from scipy.cluster.vq import kmeans
 from tqdm import tqdm
 
 from utils.general import colorstr
@@ -76,6 +75,8 @@ def kmean_anchors(path='./data/coco128.yaml', n=9, img_size=640, thr=4.0, gen=10
         Usage:
             from utils.autoanchor import *; _ = kmean_anchors()
     """
+    from scipy.cluster.vq import kmeans
+
     thr = 1. / thr
     prefix = colorstr('autoanchor: ')
 

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -16,7 +16,6 @@ import seaborn as sns
 import torch
 import yaml
 from PIL import Image, ImageDraw, ImageFont
-from scipy.signal import butter, filtfilt
 
 from utils.general import xywh2xyxy, xyxy2xywh
 from utils.metrics import fitness
@@ -54,6 +53,8 @@ def hist2d(x, y, n=100):
 
 
 def butter_lowpass_filtfilt(data, cutoff=1500, fs=50000, order=5):
+    from scipy.signal import butter, filtfilt
+
     # https://stackoverflow.com/questions/28536191/how-to-filter-smooth-with-scipy-numpy
     def butter_lowpass(cutoff, fs, order):
         nyq = 0.5 * fs


### PR DESCRIPTION
Adds some non-essential dependencies to the check_requirements() exclude list.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjusted dependency checks and lazy imports for specific packages.

### 📊 Key Changes
- Modified `check_requirements` calls in `detect.py`, `hubconf.py`, `test.py`, and `train.py` to exclude checking for `'tensorboard'`.
- Shifted the import statement for `kmeans` from scipy from the top of `autoanchor.py` file to within the function that requires it.
- Similarly, moved `butter` and `filtfilt` scipy imports in `plots.py` to the function scope where they are used.

### 🎯 Purpose & Impact
- 🚀 The primary purpose of these changes is to improve the efficiency and modularity of dependency checks, allowing for a more streamlined setup and reducing issues with unused dependencies.
- 🛠 This impacts users by potentially reducing installation times and avoiding errors that occur due to unneeded packages.
- 📦 Moving imports into function scope (lazy loading) is a common pattern when the import is heavy or not always used, which can help in reducing initial load times and saving memory in some scenarios.