### PR TITLE
Make cache saving optional

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -502,8 +502,11 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         x['hash'] = get_hash(self.label_files + self.img_files)
         x['results'] = nf, nm, ne, nc, i + 1
         x['version'] = 0.1  # cache version
-        torch.save(x, path)  # save for next time
-        logging.info(f'{prefix}New cache created: {path}')
+        try:
+            torch.save(x, path)  # save for next time
+            logging.info(f'{prefix}New cache created: {path}')
+        except Exception as e:
+            logging.info(f'{prefix}WARNING: Cache directory {path.parent} is not writeable: {e}')  # path not writeable
         return x
 
     def __len__(self):


### PR DESCRIPTION
Place dataset cache-saving ops into a `try: except` statement to catch non-writable directory failure mode in #2976.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved cache saving robustness for dataset labels in YOLOv5.

### 📊 Key Changes
- Added a try-except block around the cache label saving logic.
- Included exception handling for potential write errors.

### 🎯 Purpose & Impact
- **Ensures smoother user experience:** The change helps prevent the program from crashing if it cannot save the label cache file, informing the user instead of failing silently.
- **Better error logging:** If a cache cannot be written due to directory permissions, the user is alerted with a clear warning message.
- **Enhanced fault tolerance:** The update makes the system more robust by handling exceptions during file operations, which can occur in restricted file system environments.