### PR TITLE
Fix ONNX export using --grid --simplify --dynamic simultaneously

### DIFF
--- a/models/export.py
+++ b/models/export.py
@@ -26,8 +26,8 @@ if __name__ == '__main__':
     parser.add_argument('--weights', type=str, default='./yolov5s.pt', help='weights path')
     parser.add_argument('--img-size', nargs='+', type=int, default=[640, 640], help='image size')  # height, width
     parser.add_argument('--batch-size', type=int, default=1, help='batch size')
-    parser.add_argument('--grid', action='store_true', help='export Detect() layer grid')
     parser.add_argument('--device', default='cpu', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
+    parser.add_argument('--inplace', action='store_true', help='inplace ops')  # inplace = True
     parser.add_argument('--dynamic', action='store_true', help='dynamic ONNX axes')  # ONNX-only
     parser.add_argument('--simplify', action='store_true', help='simplify ONNX model')  # ONNX-only
     opt = parser.parse_args()
@@ -57,7 +57,7 @@ if __name__ == '__main__':
             elif isinstance(m.act, nn.SiLU):
                 m.act = SiLU()
         elif isinstance(m, models.yolo.Detect):
-            m.exp_grid = opt.grid
+            m.inplace = opt.inplace
             m.exp_dynamic = opt.dynamic
             # m.forward = m.forward_export  # assign forward (optional)
 

--- a/models/export.py
+++ b/models/export.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     parser.add_argument('--batch-size', type=int, default=1, help='batch size')
     parser.add_argument('--device', default='cpu', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--half', action='store_true', help='FP16 half-precision export')
-    parser.add_argument('--inplace', action='store_true', help='inplace ops')  # set YOLOv5 Detect() inplace=True
+    parser.add_argument('--inplace', action='store_true', help='set YOLOv5 Detect() inplace=True')
     parser.add_argument('--dynamic', action='store_true', help='dynamic ONNX axes')  # ONNX-only
     parser.add_argument('--simplify', action='store_true', help='simplify ONNX model')  # ONNX-only
     opt = parser.parse_args()

--- a/models/export.py
+++ b/models/export.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
                 m.act = SiLU()
         elif isinstance(m, models.yolo.Detect):
             m.inplace = opt.inplace
-            m.exp_dynamic = opt.dynamic
+            m.onnx_dynamic = opt.dynamic
             # m.forward = m.forward_export  # assign forward (optional)
 
     for _ in range(2):

--- a/models/export.py
+++ b/models/export.py
@@ -59,6 +59,7 @@ if __name__ == '__main__':
         # elif isinstance(m, models.yolo.Detect):
         #     m.forward = m.forward_export  # assign forward (optional)
     model.model[-1].export = not opt.grid  # set Detect() layer grid export
+    model.model[-1].dynamic = opt.dynamic
     for _ in range(2):
         y = model(img)  # dry runs
     print(f"\n{colorstr('PyTorch:')} starting from {opt.weights} ({file_size(opt.weights):.1f} MB)")

--- a/models/export.py
+++ b/models/export.py
@@ -56,11 +56,11 @@ if __name__ == '__main__':
                 m.act = Hardswish()
             elif isinstance(m.act, nn.SiLU):
                 m.act = SiLU()
-        # elif isinstance(m, models.yolo.Detect):
-        #     m.forward = m.forward_export  # assign forward (optional)
-    model.model[-1].export = not opt.grid  # set Detect() layer grid export
-    model.model[-1].exp_grid = opt.grid
-    model.model[-1].exp_dynamic = opt.dynamic
+        elif isinstance(m, models.yolo.Detect):
+            m.exp_grid = opt.grid
+            m.exp_dynamic = opt.dynamic
+            # m.forward = m.forward_export  # assign forward (optional)
+
     for _ in range(2):
         y = model(img)  # dry runs
     print(f"\n{colorstr('PyTorch:')} starting from {opt.weights} ({file_size(opt.weights):.1f} MB)")

--- a/models/export.py
+++ b/models/export.py
@@ -59,7 +59,8 @@ if __name__ == '__main__':
         # elif isinstance(m, models.yolo.Detect):
         #     m.forward = m.forward_export  # assign forward (optional)
     model.model[-1].export = not opt.grid  # set Detect() layer grid export
-    model.model[-1].dynamic = opt.dynamic
+    model.model[-1].exp_grid = opt.grid
+    model.model[-1].exp_dynamic = opt.dynamic
     for _ in range(2):
         y = model(img)  # dry runs
     print(f"\n{colorstr('PyTorch:')} starting from {opt.weights} ({file_size(opt.weights):.1f} MB)")

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -24,7 +24,6 @@ except ImportError:
 
 class Detect(nn.Module):
     stride = None  # strides computed during build
-    exp_grid = False
     exp_dynamic = False
 
     def __init__(self, nc=80, anchors=(), ch=(), inplace=True):  # detection layer
@@ -53,7 +52,7 @@ class Detect(nn.Module):
                     self.grid[i] = self._make_grid(nx, ny).to(x[i].device)
 
                 y = x[i].sigmoid()
-                if not self.exp_grid and self.inplace:
+                if self.inplace:
                     y[..., 0:2] = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
                     y[..., 2:4] = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
                 else:  # for YOLOv5 on AWS Inferentia https://github.com/ultralytics/yolov5/pull/2953

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -24,7 +24,6 @@ except ImportError:
 
 class Detect(nn.Module):
     stride = None  # strides computed during build
-    export = False  # onnx export
     exp_grid = False
     exp_dynamic = False
 
@@ -44,7 +43,6 @@ class Detect(nn.Module):
     def forward(self, x):
         # x = x.copy()  # for profiling
         z = []  # inference output
-        self.training |= self.export
         for i in range(self.nl):
             x[i] = self.m[i](x[i])  # conv
             bs, _, ny, nx = x[i].shape  # x(bs,255,20,20) to x(bs,3,20,20,85)

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -24,7 +24,7 @@ except ImportError:
 
 class Detect(nn.Module):
     stride = None  # strides computed during build
-    exp_dynamic = False
+    onnx_dynamic = False  # ONNX export parameter
 
     def __init__(self, nc=80, anchors=(), ch=(), inplace=True):  # detection layer
         super(Detect, self).__init__()
@@ -48,7 +48,7 @@ class Detect(nn.Module):
             x[i] = x[i].view(bs, self.na, self.no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
 
             if not self.training:  # inference
-                if self.grid[i].shape[2:4] != x[i].shape[2:4] or self.exp_dynamic:
+                if self.grid[i].shape[2:4] != x[i].shape[2:4] or self.onnx_dynamic:
                     self.grid[i] = self._make_grid(nx, ny).to(x[i].device)
 
                 y = x[i].sigmoid()

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -57,7 +57,7 @@ class Detect(nn.Module):
                     y[..., 2:4] = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
                 else:  # for YOLOv5 on AWS Inferentia https://github.com/ultralytics/yolov5/pull/2953
                     xy = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
-                    wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i].view(bs, self.na, 1, 1, 2)  # wh
+                    wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i].view(1, self.na, 1, 1, 2)  # wh
                     y = torch.cat((xy, wh, y[..., 4:]), -1)
                 z.append(y.view(bs, -1, self.no))
 

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -49,7 +49,7 @@ class Detect(nn.Module):
             x[i] = x[i].view(bs, self.na, self.no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
 
             if not self.training:  # inference
-                if self.exp_dynamic or self.grid[i].shape[2:4] != x[i].shape[2:4]:
+                if self.grid[i].shape[2:4] != x[i].shape[2:4] or self.exp_dynamic:
                     self.grid[i] = self._make_grid(nx, ny).to(x[i].device)
 
                 y = x[i].sigmoid()

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -25,7 +25,8 @@ except ImportError:
 class Detect(nn.Module):
     stride = None  # strides computed during build
     export = False  # onnx export
-    dynamic = False
+    exp_grid = False
+    exp_dynamic = False
 
     def __init__(self, nc=80, anchors=(), ch=(), inplace=True):  # detection layer
         super(Detect, self).__init__()
@@ -50,16 +51,16 @@ class Detect(nn.Module):
             x[i] = x[i].view(bs, self.na, self.no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
 
             if not self.training:  # inference
-                if self.dynamic or self.grid[i].shape[2:4] != x[i].shape[2:4]:
+                if self.exp_dynamic or self.grid[i].shape[2:4] != x[i].shape[2:4]:
                     self.grid[i] = self._make_grid(nx, ny).to(x[i].device)
 
                 y = x[i].sigmoid()
-                if self.inplace:
+                if not self.exp_grid and self.inplace:
                     y[..., 0:2] = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
                     y[..., 2:4] = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
                 else:  # for YOLOv5 on AWS Inferentia https://github.com/ultralytics/yolov5/pull/2953
                     xy = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
-                    wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
+                    wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i].view(bs, self.na, 1, 1, 2)  # wh
                     y = torch.cat((xy, wh, y[..., 4:]), -1)
                 z.append(y.view(bs, -1, self.no))
 


### PR DESCRIPTION
`python models/export.py --grid --dynamic --simplify` failed to export onnx model.

[#2856](https://github.com/ultralytics/yolov5/pull/2856) fix dynamic and simplify but still cannot work with grid, because the `self.grid[i]` mismatch the dynamic `y[..., 0:2]`. This pull request fixes it.

Also the removal of subscript assignments helps to avoid unsupported ScatterND nodes, so the onnx exported using `--grid` can be directly converted to tensorRT engine now

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved ONNX export flexibility for YOLOv5.

### 📊 Key Changes
- Removed the `--grid` flag from the command-line arguments in `export.py`.
- Added a new `--inplace` flag to control the `inplace` parameter for the YOLOv5 Detect() layer.
- Modified how the Detect() layer handles the export grid and the use of inplace operations.
- Updated the logic for dynamic axis computation in ONNX exports and grid generation during inference.

### 🎯 Purpose & Impact
- The changes aim to optimize the export process of YOLOv5 models for different use cases, such as dynamic batching.
- The `--inplace` flag provides users with the option to choose how Detect() processes inputs, which could lead to memory optimizations. 
- These adjustments may improve the model's compatibility with varying deployment environments, potentially enhancing performance and facilitating integration with platforms like AWS Inferentia. 🚀
- Users leveraging ONNX models should enjoy more flexibility and potentially better inference speed and device compatibility. 🌐