### PR TITLE
hubconf.py bug fix

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -18,7 +18,7 @@ dependencies = ['torch', 'yaml']
 check_requirements(Path(__file__).parent / 'requirements.txt', exclude=('tensorboard', 'pycocotools', 'thop'))
 
 
-def create(name, pretrained, channels=3, classes=80, autoshape=True, verbose=True):
+def create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbose=True):
     """Creates a specified YOLOv5 model
 
     Arguments:


### PR DESCRIPTION
Bug fix for problem introduced in #3005

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving the default behavior for model creation in the Ultralytics YOLOv5 library.

### 📊 Key Changes
- Changed the `pretrained` parameter default value from unspecified to `True` in the `create` function of `hubconf.py`.

### 🎯 Purpose & Impact
- 🎯 **Ease of Use**: Defaults `pretrained` to `True` to simplify the function call for most users who generally prefer using pre-trained models for a quick start.
- 🚀 **Potential Impact**: Users who forget to specify the `pretrained` flag will now automatically receive a pre-trained model, leading to better out-of-the-box performance without extra setup.