### PR TITLE
Added support for fp16 in export.py

### DIFF
--- a/models/export.py
+++ b/models/export.py
@@ -57,6 +57,7 @@ if __name__ == '__main__':
     # Input
     img = torch.zeros(opt.batch_size, 3, *opt.img_size).to(device)  # image size(1,3,320,192) iDetection
 
+    # Use fp16 for img if requested
     if opt.half:
         img = img.half()
 


### PR DESCRIPTION
This adds support for the `--half` argument when exporting a model.

## Considerations

I have only tested this with torchscript. It might be a good idea to only support this for torchscript if you know of any problems with ONNX/CoreML and fp16. My focus is on torchscript. I can easily modify this pull request to load the model separately as half for only torchscript and also create a separate img for the trace.

Let me know your thoughts :)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added half-precision export option for YOLOv5 model.

### 📊 Key Changes
- New command-line argument `--half` that allows users to export the model in half precision (FP16).
- Validation to ensure that exporting in FP16 is not attempted on CPUs, which do not support this precision level.
- Logic to convert both the model and input images to FP16 when the `--half` option is used.

### 🎯 Purpose & Impact
- **Purpose**: To reduce the model size and potentially speed up inference by allowing exports in half-precision.
- **Impact**: Users with GPUs that support half-precision (like many NVIDIA GPUs) can take advantage of faster computations and reduced memory usage. However, attempting to use FP16 on CPUs will now result in an error message, guiding users to use compatible hardware.