### PR TITLE
Added support for fp16 (half) to export.py

### DIFF
--- a/models/export.py
+++ b/models/export.py
@@ -30,16 +30,26 @@ if __name__ == '__main__':
     parser.add_argument('--device', default='cpu', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--dynamic', action='store_true', help='dynamic ONNX axes')  # ONNX-only
     parser.add_argument('--simplify', action='store_true', help='simplify ONNX model')  # ONNX-only
+    parser.add_argument('--half', action='store_true', help='export with half precision')
     opt = parser.parse_args()
     opt.img_size *= 2 if len(opt.img_size) == 1 else 1  # expand
     print(opt)
     set_logging()
     t = time.time()
 
+    # Check if fp16 export can be performed
+    if opt.device == "cpu" and opt.half:
+        print("You cannot export a fp16 model on CPU. Please specify a CUDA device and try again.")
+        sys.exit()
+
     # Load PyTorch model
     device = select_device(opt.device)
     model = attempt_load(opt.weights, map_location=device)  # load FP32 model
     labels = model.names
+
+    # Use fp16 for model if requested
+    if opt.half:
+        model = model.half()
 
     # Checks
     gs = int(max(model.stride))  # grid size (max stride)
@@ -47,6 +57,10 @@ if __name__ == '__main__':
 
     # Input
     img = torch.zeros(opt.batch_size, 3, *opt.img_size).to(device)  # image size(1,3,320,192) iDetection
+
+    # Use fp16 for img if requested
+    if opt.half:
+        img = img.half()
 
     # Update model
     for k, m in model.named_modules():


### PR DESCRIPTION
This adds support for the --half argument when exporting a model.

Considerations
I have only tested this with torchscript. It might be a good idea to only support this for torchscript if you know of any problems with ONNX/CoreML and fp16. My focus is on torchscript. I can easily modify this pull request to load the model separately as half for only torchscript and also create a separate img for the trace.

Let me know your thoughts :)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added FP16 half-precision export option to YOLOv5 model exporter. 🚀

### 📊 Key Changes
- New `--half` argument to the model export script enabling FP16 half-precision exports. 🎛️
- Added an assertion to ensure FP16 export is not attempted on CPUs, as it's only compatible with GPUs. 🔒
- Conditional logic to convert the model and input image to FP16 when the `--half` flag is used. 🔧

### 🎯 Purpose & Impact
- The added `--half` flag allows users to export their models with reduced precision, which can lead to **performance gains** on compatible hardware (mostly GPUs) by reducing the computational workload. 📈
- This update emphasizes **efficiency**, as using FP16 can decrease model size and increase inference speed, which is beneficial for deployment on edge devices or in environments where resources are limited. 🏎️
- The assertion prevents users from inadvertently trying to export an FP16 model on unsupported devices like CPUs, avoiding potential errors and confusion. 🚫🖥️