### PR TITLE
Add NMS threshold checks

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -477,8 +477,8 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
     xc = prediction[..., 4] > conf_thres  # candidates
 
     # Checks
-    assert 0 <= conf_thres <= 1, f'Invalid IoU threshold {conf_thres}, valid values are between 0.0 and 1.0'
-    assert 0 <= iou_thres <= 1, f'Invalid Confidence threshold {iou_thres}, valid values are between 0.0 and 1.0'
+    assert 0 <= conf_thres <= 1, f'Invalid Confidence threshold {conf_thres}, valid values are between 0.0 and 1.0'
+    assert 0 <= iou_thres <= 1, f'Invalid IoU {iou_thres}, valid values are between 0.0 and 1.0'
 
     # Settings
     min_wh, max_wh = 2, 4096  # (pixels) minimum and maximum box width and height

--- a/utils/general.py
+++ b/utils/general.py
@@ -476,6 +476,10 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
     nc = prediction.shape[2] - 5  # number of classes
     xc = prediction[..., 4] > conf_thres  # candidates
 
+    # Checks
+    assert 0 <= conf_thres <= 1, f'Invalid IoU threshold {conf_thres}, valid values are between 0.0 and 1.0'
+    assert 0 <= iou_thres <= 1, f'Invalid Confidence threshold {iou_thres}, valid values are between 0.0 and 1.0'
+
     # Settings
     min_wh, max_wh = 2, 4096  # (pixels) minimum and maximum box width and height
     max_det = 300  # maximum number of detections per image


### PR DESCRIPTION
PR asserts IoU and Confidence thresholds lie between 0.0 and 1.0.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved input validation for non-maximum suppression in YOLOv5.

### 📊 Key Changes
- Added checks to ensure the confidence threshold (`conf_thres`) and intersection over union threshold (`iou_thres`) are between 0.0 and 1.0.

### 🎯 Purpose & Impact
- 🔒 **Enhanced Robustness**: Ensures the non-max suppression function only accepts valid threshold values, preventing potential errors or unexpected behavior during object detection.
- ✅ **Better User Guidance**: Provides clear error messages if the user inputs invalid thresholds, making it easier for users to debug issues.
- 🛠 **Code Reliability**: These defensive programming checks contribute to overall code quality and reliability of the YOLOv5 framework.