### PR TITLE
download() ThreadPool update

### DIFF
--- a/data/objects365.yaml
+++ b/data/objects365.yaml
@@ -6,7 +6,7 @@
 #     /yolov5
 
 # train and val data as 1) directory: path/images/, 2) file: path/images.txt, or 3) list: [path1/images/, path2/images/]
-train: ../datasets/objects365/images/train  # 1.7 Million images
+train: ../datasets/objects365/images/train  # 1742289 images
 val: ../datasets/objects365/images/val # 5570 images
 
 # number of classes

--- a/data/objects365.yaml
+++ b/data/objects365.yaml
@@ -87,7 +87,7 @@ download: |
   for cid, cat in enumerate(names):
       catIds = coco.getCatIds(catNms=[cat])
       imgIds = coco.getImgIds(catIds=catIds)
-      for im in tqdm(coco.loadImgs(imgIds), desc=f'Class {cid}/{len(names)} {cat}'):
+      for im in tqdm(coco.loadImgs(imgIds), desc=f'Class {cid + 1}/{len(names)} {cat}'):
           width, height = im["width"], im["height"]
           path = Path(im["file_name"])  # image filename
           try:

--- a/data/objects365.yaml
+++ b/data/objects365.yaml
@@ -72,9 +72,14 @@ download: |
 
   # Download
   url = "https://dorc.ks3-cn-beijing.ksyun.com/data-set/2020Objects365%E6%95%B0%E6%8D%AE%E9%9B%86/train/"
-  download([url + 'zhiyuan_objv2_train.tar.gz'], dir=dir)  # annotations json
+  download([url + 'zhiyuan_objv2_train.tar.gz'], dir=dir, delete=False)  # annotations json
   download([url + f for f in [f'patch{i}.tar.gz' for i in range(51)]], dir=dir / 'images' / 'train',
            curl=True, delete=False, threads=8)
+
+  # Move
+  train = dir / 'images' / 'train'
+  for f in tqdm(train.rglob('*.jpg'), desc=f'Moving images'):
+      f.rename(train / f.name)  # move to /images/train
 
   # Labels
   coco = COCO(dir / 'zhiyuan_objv2_train.json')

--- a/utils/general.py
+++ b/utils/general.py
@@ -217,7 +217,10 @@ def download(url, dir='.', unzip=True, delete=True, curl=False, threads=1):
     dir = Path(dir)
     dir.mkdir(parents=True, exist_ok=True)  # make directory
     if threads > 1:
-        ThreadPool(threads).imap(lambda x: download_one(*x), zip(url, repeat(dir)))  # multi-threaded
+        pool = ThreadPool(threads)
+        pool.imap(lambda x: download_one(*x), zip(url, repeat(dir)))  # multi-threaded
+        pool.close()
+        pool.join()
     else:
         for u in tuple(url) if isinstance(url, str) else url:
             download_one(u, dir)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved data processing and multi-threaded download in YOLOv5 Objects365 configuration.

### 📊 Key Changes
- Updated the image count in the Objects365 training dataset config to an exact figure (1,742,289 images).
- Modified the download script to retain downloaded files by setting `delete=False`.
- Added functionality to move images into the correct directory after download.
- Enhanced classes enumeration consistency during label processing by incrementing class index by 1.
- Improved thread handling in multi-threaded downloads with thread pool `close` and `join` methods.

### 🎯 Purpose & Impact
- The exact image count provides clarity on the dataset size.
- Retaining downloads avoids re-downloading, saving time for users.
- Automatically moving images streamlines dataset organization, simplifying setup for training.
- Class index change ensures correct progress tracking and clear logging during data setup.
- Thread pool enhancements lead to more reliable downloads, preventing potential issues with unfinished threads.

Overall, these changes are set to enhance user experience with more efficient data handling and accurate progress tracking. This can be particularly beneficial for users training YOLOv5 on the Objects365 dataset, as it may lead to a smoother and more transparent training preparation phase. 🚀🔄