### PR TITLE
Fix #3031 : use check_file for --data

### DIFF
--- a/utils/wandb_logging/wandb_utils.py
+++ b/utils/wandb_logging/wandb_utils.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 sys.path.append(str(Path(__file__).parent.parent.parent))  # add utils/ to path
 from utils.datasets import LoadImagesAndLabels
 from utils.datasets import img2label_paths
-from utils.general import colorstr, xywh2xyxy, check_dataset
+from utils.general import colorstr, xywh2xyxy, check_dataset, check_file
 
 try:
     import wandb
@@ -54,7 +54,7 @@ def check_wandb_resume(opt):
 
 
 def process_wandb_config_ddp_mode(opt):
-    with open(opt.data) as f:
+    with open(check_file(opt.data)) as f:
         data_dict = yaml.safe_load(f)  # data dict
     train_dir, val_dir = None, None
     if isinstance(data_dict['train'], str) and data_dict['train'].startswith(WANDB_ARTIFACT_PREFIX):
@@ -115,7 +115,7 @@ class WandbLogger():
     def check_and_upload_dataset(self, opt):
         assert wandb, 'Install wandb to upload dataset'
         check_dataset(self.data_dict)
-        config_path = self.log_dataset_artifact(opt.data,
+        config_path = self.log_dataset_artifact(check_file(opt.data),
                                                 opt.single_cls,
                                                 'YOLOv5' if opt.project == 'runs/train' else Path(opt.project).stem)
         print("Created dataset config file ", config_path)


### PR DESCRIPTION
Fix for #3031 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced robustness in Weights and Biases logging for YOLOv5 by ensuring dataset files are checked before use.

### 📊 Key Changes
- ✅ Added `check_file()` utility function call when opening dataset files in Weights and Biases (W&B) integration.
- 🔄 Modified `check_and_upload_dataset()` function to use `check_file()` when logging dataset artifact.

### 🎯 Purpose & Impact
- 🛠 **Purpose**: To prevent errors and ensure the correct dataset files are used during logging to W&B.
- 🔍 **Impact**: Users can expect more reliable dataset handling when using W&B, leading to fewer interruptions in their ML experiments and training jobs.