### PR TITLE
Add get_coco128.sh for downloading the coco128 dataset

### DIFF
--- a/data/scripts/get_coco128.sh
+++ b/data/scripts/get_coco128.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# COCO 2017 dataset http://cocodataset.org
+# COCO128 dataset https://www.kaggle.com/ultralytics/coco128
 # Download command: bash data/scripts/get_coco128.sh
 # Train command: python train.py --data coco128.yaml
 # Default dataset location is next to /yolov5:

--- a/data/scripts/get_coco128.sh
+++ b/data/scripts/get_coco128.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# COCO 2017 dataset http://cocodataset.org
+# Download command: bash data/scripts/get_coco128.sh
+# Train command: python train.py --data coco128.yaml
+# Default dataset location is next to /yolov5:
+#   /parent_folder
+#     /coco128
+#     /yolov5
+
+# Download/unzip images and labels
+d='../' # unzip directory
+url=https://github.com/ultralytics/yolov5/releases/download/v1.0/
+f='coco128.zip' # or 'coco2017labels-segments.zip', 68 MB
+echo 'Downloading' $url$f ' ...'
+curl -L $url$f -o $f && unzip -q $f -d $d && rm $f & # download, unzip, remove in background
+
+wait # finish background tasks


### PR DESCRIPTION
Add a script get_coco128.sh for downloading the coco128 dataset, which accelerates training validation and testing.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing a simple script for easy downloading of the COCO128 dataset.

### 📊 Key Changes
- New `get_coco128.sh` bash script added to automate dataset download and setup.
- Allows quick downloading and setup of the COCO128 dataset for training with just one command.

### 🎯 Purpose & Impact
- 🎯 Simplifies the process of obtaining the COCO128 dataset, making it more user-friendly for both beginners and advanced users.
- 🚀 Can accelerate the setup time for training YOLOv5 models, as it provides a quick way to access a small, yet useful dataset.
- 👩‍💻 Benefits users looking to experiment with or prototype object detection models without requiring the full COCO dataset's size and complexity.