### PR TITLE
Explicitly convert artifact path to posix_path

### DIFF
--- a/utils/wandb_logging/wandb_utils.py
+++ b/utils/wandb_logging/wandb_utils.py
@@ -158,7 +158,8 @@ class WandbLogger():
 
     def download_dataset_artifact(self, path, alias):
         if isinstance(path, str) and path.startswith(WANDB_ARTIFACT_PREFIX):
-            dataset_artifact = wandb.use_artifact(remove_prefix(path, WANDB_ARTIFACT_PREFIX) + ":" + alias)
+            artifact_path = Path(remove_prefix(path, WANDB_ARTIFACT_PREFIX) + ":" + alias)
+            dataset_artifact = wandb.use_artifact(str(artifact_path.as_posix()))
             assert dataset_artifact is not None, "'Error: W&B dataset artifact doesn\'t exist'"
             datadir = dataset_artifact.download()
             return datadir, dataset_artifact

--- a/utils/wandb_logging/wandb_utils.py
+++ b/utils/wandb_logging/wandb_utils.py
@@ -159,7 +159,7 @@ class WandbLogger():
     def download_dataset_artifact(self, path, alias):
         if isinstance(path, str) and path.startswith(WANDB_ARTIFACT_PREFIX):
             artifact_path = Path(remove_prefix(path, WANDB_ARTIFACT_PREFIX) + ":" + alias)
-            dataset_artifact = wandb.use_artifact(str(artifact_path.as_posix()))
+            dataset_artifact = wandb.use_artifact(artifact_path.as_posix())
             assert dataset_artifact is not None, "'Error: W&B dataset artifact doesn\'t exist'"
             datadir = dataset_artifact.download()
             return datadir, dataset_artifact


### PR DESCRIPTION
This explicit check converts forward slashes in `WindowsPath` to back splashes supported by artifacts

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Weights & Biases (W&B) dataset artifact handling in Ultralytics YOLOv5.

### 📊 Key Changes
- Modified the `download_dataset_artifact` method in the `wandb_utils.py` file.
- Dataset artifacts are now managed using the `Path` library.

### 🎯 Purpose & Impact
- 🔄 The change ensures better path management and compatibility across different operating systems.
- 🛠 Fixes potential issues with incorrect path formatting when downloading dataset artifacts from W&B.
- 🤝 Users should experience a more reliable and seamless integration with W&B for tracking and sharing datasets.