### PR TITLE
Add check_python()

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -107,10 +107,21 @@ def check_git_status():
         print(e)
 
 
+def check_python(minimum='3.7.0', required=True):
+    # Check current python version vs. required python version
+    from packaging import version
+    current = platform.python_version()
+    result = version.parse(current) >= version.parse(minimum)
+    if required:
+        assert result, f'Python {minimum} required by YOLOv5, but Python {current} is currently installed'
+    return result
+
+
 def check_requirements(requirements='requirements.txt', exclude=()):
     # Check installed dependencies meet requirements (pass *.txt file or list of packages)
     import pkg_resources as pkg
     prefix = colorstr('red', 'bold', 'requirements:')
+    check_python()  # check python version
     if isinstance(requirements, (str, Path)):  # requirements.txt file
         file = Path(requirements)
         if not file.exists():

--- a/utils/general.py
+++ b/utils/general.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 import pandas as pd
+import pkg_resources as pkg
 import torch
 import torchvision
 import yaml
@@ -109,7 +110,6 @@ def check_git_status():
 
 def check_python(minimum='3.7.0', required=True):
     # Check current python version vs. required python version
-    import pkg_resources as pkg
     current = platform.python_version()
     result = pkg.parse_version(current) >= pkg.parse_version(minimum)
     if required:
@@ -119,7 +119,6 @@ def check_python(minimum='3.7.0', required=True):
 
 def check_requirements(requirements='requirements.txt', exclude=()):
     # Check installed dependencies meet requirements (pass *.txt file or list of packages)
-    import pkg_resources as pkg
     prefix = colorstr('red', 'bold', 'requirements:')
     check_python()  # check python version
     if isinstance(requirements, (str, Path)):  # requirements.txt file

--- a/utils/general.py
+++ b/utils/general.py
@@ -109,9 +109,9 @@ def check_git_status():
 
 def check_python(minimum='3.7.0', required=True):
     # Check current python version vs. required python version
-    from packaging import version
+    import pkg_resources as pkg
     current = platform.python_version()
-    result = version.parse(current) >= version.parse(minimum)
+    result = pkg.parse_version(current) >= pkg.parse_version(minimum)
     if required:
         assert result, f'Python {minimum} required by YOLOv5, but Python {current} is currently installed'
     return result


### PR DESCRIPTION
Checks python version against minimum version of 3.7.0.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements in Python version checking and dependency management.

### 📊 Key Changes
- Added a function `check_python` to verify the current Python version against a minimum required version.
- Integrated Python version check into the `check_requirements` function.

### 🎯 Purpose & Impact
- Ensures that YOLOv5 is used with a compatible Python version, meeting a minimum version standard (🐍 Python `>= 3.7.0`).
- Prevents potential issues related to incompatibilities with older Python versions, improving user experience by providing clearer requirements (🚫 fewer bugs & errors).
- Users are now automatically alerted if their Python version is not up to par, avoiding troubleshooting and support requests (🔍 easier debugging).