### PR TITLE
Update GlobalWheat2020.yaml test: # 1276 images

### DIFF
--- a/data/GlobalWheat2020.yaml
+++ b/data/GlobalWheat2020.yaml
@@ -19,7 +19,7 @@ train: # 3422 images
 val: # 748 images (WARNING: train set contains ethz_1)
   - ../datasets/GlobalWheat2020/images/ethz_1
 
-test: # 1276
+test: # 1276 images
   - ../datasets/GlobalWheat2020/images/utokyo_1
   - ../datasets/GlobalWheat2020/images/utokyo_2
   - ../datasets/GlobalWheat2020/images/nau_1


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved documentation clarity in GlobalWheat2020 dataset configuration.

### 📊 Key Changes
- Modified the comment in the `GlobalWheat2020.yaml` to specify the number of images in the test dataset.

### 🎯 Purpose & Impact
- This change ensures that users have clear information about the number of images in the test set, improving dataset transparency.
- It may help users to better understand the dataset structure and to anticipate the computing resources needed for processing the test set.