### PR TITLE
detect.py streaming source `--save-crop` bug fix

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -87,6 +87,7 @@ def detect(opt):
             txt_path = str(save_dir / 'labels' / p.stem) + ('' if dataset.mode == 'image' else f'_{frame}')  # img.txt
             s += '%gx%g ' % img.shape[2:]  # print string
             gn = torch.tensor(im0.shape)[[1, 0, 1, 0]]  # normalization gain whwh
+            imc = im0.copy if opt.save_crop else im0  # for opt.save_crop
             if len(det):
                 # Rescale boxes from img_size to im0 size
                 det[:, :4] = scale_coords(img.shape[2:], det[:, :4], im0.shape).round()
@@ -109,7 +110,7 @@ def detect(opt):
                         label = None if opt.hide_labels else (names[c] if opt.hide_conf else f'{names[c]} {conf:.2f}')
                         plot_one_box(xyxy, im0, label=label, color=colors(c, True), line_thickness=opt.line_thickness)
                         if opt.save_crop:
-                            save_one_box(xyxy, im0s, file=save_dir / 'crops' / names[c] / f'{p.stem}.jpg', BGR=True)
+                            save_one_box(xyxy, imc, file=save_dir / 'crops' / names[c] / f'{p.stem}.jpg', BGR=True)
 
             # Print time (inference + NMS)
             print(f'{s}Done. ({t2 - t1:.3f}s)')

--- a/detect.py
+++ b/detect.py
@@ -87,7 +87,7 @@ def detect(opt):
             txt_path = str(save_dir / 'labels' / p.stem) + ('' if dataset.mode == 'image' else f'_{frame}')  # img.txt
             s += '%gx%g ' % img.shape[2:]  # print string
             gn = torch.tensor(im0.shape)[[1, 0, 1, 0]]  # normalization gain whwh
-            imc = im0.copy if opt.save_crop else im0  # for opt.save_crop
+            imc = im0.copy() if opt.save_crop else im0  # for opt.save_crop
             if len(det):
                 # Rescale boxes from img_size to im0 size
                 det[:, :4] = scale_coords(img.shape[2:], det[:, :4], im0.shape).round()


### PR DESCRIPTION
Possible fix for #3100.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced 'save_crop' functionality in YOLOv5's detect module.

### 📊 Key Changes
- Introduction of an option to make a copy of the original image `im0` if `save_crop` is enabled.
- Modification of `save_one_box` to use the copied image `imc` instead of `im0s` when saving cropped images.

### 🎯 Purpose & Impact
- **Purpose**: These changes aim to preserve the original image for cropping so that the saved crop is unaffected by any drawing or annotations made on the detection output (`im0`).
- **Impact**: Users now have the ability to save cleaner cropped images without any overlaid drawings if they choose to do so, enhancing the usefulness of the crops for further analysis or usage.