### PR TITLE
Replace print() with logging.info() in trainloader

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -490,14 +490,14 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                 x[im_file] = [l, shape, segments]
             except Exception as e:
                 nc += 1
-                print(f'{prefix}WARNING: Ignoring corrupted image and/or label {im_file}: {e}')
+                logging.info(f'{prefix}WARNING: Ignoring corrupted image and/or label {im_file}: {e}')
 
             pbar.desc = f"{prefix}Scanning '{path.parent / path.stem}' images and labels... " \
                         f"{nf} found, {nm} missing, {ne} empty, {nc} corrupted"
         pbar.close()
 
         if nf == 0:
-            print(f'{prefix}WARNING: No labels found in {path}. See {help_url}')
+            logging.info(f'{prefix}WARNING: No labels found in {path}. See {help_url}')
 
         x['hash'] = get_hash(self.label_files + self.img_files)
         x['results'] = nf, nm, ne, nc, i + 1


### PR DESCRIPTION
Might indirectly help #3095 by providing better visibility on source of corruption.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Switching to a standardized logging system for corrupted image/label warnings.

### 📊 Key Changes
- Errors for corrupted images and labels now use `logging.info` instead of `print`.

### 🎯 Purpose & Impact
- **Increased Consistency:** Aligns error reporting with standardized logging practices.
- **Better Integration:** Facilitates integration with other systems and log monitoring tools.
- **User Clarity:** Maintains the communication of issues to the user, but in a more structured format.