### PR TITLE
add base support for neptune.ai logger

### DIFF
--- a/utils/neptuneai_logging/neptuneai_utils.py
+++ b/utils/neptuneai_logging/neptuneai_utils.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from utils.general import colorstr
+
+try:
+    import neptune.new as neptune
+except ImportError:
+    neptune = None
+
+
+class NeptuneLogger:
+    def __init__(self, opt, name, data_dict, job_type='Training'):
+        # Pre-training routine --
+        self.job_type = job_type
+        self.neptune, self.neptune_run, self.data_dict = neptune, None, data_dict
+
+        if self.neptune and opt.neptune_token:
+            self.neptune_run = neptune.init(api_token=opt.neptune_token,
+                                            project=opt.neptune_project,
+                                            name=name)
+        if self.neptune_run:
+            if self.job_type == 'Training':
+                if not opt.resume:
+                    neptune_data_dict = data_dict
+                    self.neptune_run["opt"] = vars(opt)
+                    self.neptune_run["data_dict"] = neptune_data_dict
+                self.data_dict = self.setup_training(data_dict)
+            prefix = colorstr('neptune: ')
+            print(f"{prefix}NeptuneAI logging initiated successfully.")
+        else:
+            #prefix = colorstr('neptune: ')
+            #print(
+            #    f"{prefix}Install NeptuneAI for YOLOv5 logging with 'pip install neptune-client' (recommended)")
+            pass
+
+    def setup_training(self, data_dict):
+        self.log_dict, self.current_epoch = {}, 0  # Logging Constants
+        return data_dict
+
+    def log(self, log_dict):
+        if self.neptune_run:
+            for key, value in log_dict.items():
+                self.log_dict[key] = value
+
+    def end_epoch(self, best_result=False):
+        if self.neptune_run:
+            for key, value in self.log_dict.items():
+                self.neptune_run[key].log(value)
+                self.log_dict = {}
+
+    def finish_run(self):
+        if self.neptune_run:
+            if self.log_dict:
+                for key, value in self.log_dict.items():
+                    self.neptune_run[key].log(value)
+            self.neptune_run.stop()


### PR DESCRIPTION
this pr contains base logging functions for neptune.ai, after this pr its coverage can be increased similar to wandb logger

fixes https://github.com/ultralytics/yolov5/issues/3164

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Integration of Neptune.ai logging for enhanced tracking in YOLOv5 training.

### 📊 Key Changes
- Added NeptuneLogger class to handle Neptune.ai logging.
- Setup Neptune.ai logging alongside existing WandbLogger in `train.py`.
- Included additional command-line arguments for Neptune.ai API token and project specification.
- Incorporated logic to log metrics, epoch results, and finalize the logger state at the end of the training or upon training completion.
- Added condition to save Neptune.ai logs and run ID into the model checkpoint dictionary.

### 🎯 Purpose & Impact
- Provides users with the option to use Neptune.ai for experiment tracking, which is an alternative to Weights & Biases (wandb).
- Enables detailed logging and visualization of training metrics, hyperparameters, and outputs, potentially improving experiment management and reproducibility.
- Offers better organization and tracking capabilities for users who prefer or are already using Neptune.ai in their workflows.