### PR TITLE
Add `--include torchscript onnx coreml` argument

### DIFF
--- a/models/export.py
+++ b/models/export.py
@@ -33,10 +33,10 @@ if __name__ == '__main__':
     parser.add_argument('--optimize', action='store_true', help='optimize TorchScript for mobile')  # TorchScript-only
     parser.add_argument('--dynamic', action='store_true', help='dynamic ONNX axes')  # ONNX-only
     parser.add_argument('--simplify', action='store_true', help='simplify ONNX model')  # ONNX-only
-    parser.add_argument('--exclude', action='append', default=[], help='exclude [onnx, torchscript, coreml] exports')
+    parser.add_argument('--include', nargs='+', default=['onnx', 'torchscript', 'coreml'], help='include formats')
     opt = parser.parse_args()
     opt.img_size *= 2 if len(opt.img_size) == 1 else 1  # expand
-    opt.exclude = [x.lower() for x in opt.exclude]
+    opt.include = [x.lower() for x in opt.include]
     print(opt)
     set_logging()
     t = time.time()
@@ -76,7 +76,7 @@ if __name__ == '__main__':
     print(f"\n{colorstr('PyTorch:')} starting from {opt.weights} ({file_size(opt.weights):.1f} MB)")
 
     # TorchScript export -----------------------------------------------------------------------------------------------
-    if 'torchscript' not in opt.exclude:
+    if 'torchscript' in opt.include:
         prefix = colorstr('TorchScript:')
         try:
             print(f'\n{prefix} starting export with torch {torch.__version__}...')
@@ -88,7 +88,7 @@ if __name__ == '__main__':
             print(f'{prefix} export failure: {e}')
 
     # ONNX export ------------------------------------------------------------------------------------------------------
-    if 'onnx' not in opt.exclude:
+    if 'onnx' in opt.include:
         prefix = colorstr('ONNX:')
         try:
             import onnx
@@ -124,7 +124,7 @@ if __name__ == '__main__':
             print(f'{prefix} export failure: {e}')
 
     # CoreML export ----------------------------------------------------------------------------------------------------
-    if 'coreml' not in opt.exclude:
+    if 'coreml' in opt.include:
         prefix = colorstr('CoreML:')
         try:
             import coremltools as ct

--- a/models/export.py
+++ b/models/export.py
@@ -1,7 +1,7 @@
-"""Exports a YOLOv5 *.pt model to ONNX and TorchScript formats
+"""Exports a YOLOv5 *.pt model to TorchScript, ONNX, CoreML formats
 
 Usage:
-    $ export PYTHONPATH="$PWD" && python models/export.py --weights yolov5s.pt --img 640 --batch 1
+    $ python path/to/models/export.py --weights yolov5s.pt --img 640 --batch 1
 """
 
 import argparse


### PR DESCRIPTION
Some people might only want to export the models in certain formats (e.g. I only wanted *ONNX*). Although exporting in all the formats doesn't take much time (in my case, bulk exporting all 8 files took ~1min), this will become more handy when more formats will be available.

Initially I had a patch for line 12 as well (as yesterday I downloaded *v5* and I tried running the script from a different folder, which obviously failed), then I cloned the repo and noticed it was already fixed in *master*, so the only thing left to do was to fix comments.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model export capabilities for YOLOv5, now supporting CoreML format.

### 📊 Key Changes
- Extended the export functionality to include CoreML format, along with TorchScript and ONNX.
- Simplified the usage command by removing the need to set `PYTHONPATH`.
- Added a new `--include` argument to specify which formats to export.
- Conditional export statements now check the `--include` argument for format specification.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: To enable the deployment of YOLOv5 models in a wider range of environments by supporting additional export formats, especially targeting iOS devices with CoreML.
- ✅ **Impact**: Developers can now more easily convert YOLOv5 models for use in iOS apps and have more control over the export process with the `--include` option. The potential for simpler deployment processes and broader usage of models in different platforms is increased.