### PR TITLE
Parameterize ONNX `--opset-version`

### DIFF
--- a/models/export.py
+++ b/models/export.py
@@ -34,6 +34,7 @@ if __name__ == '__main__':
     parser.add_argument('--optimize', action='store_true', help='optimize TorchScript for mobile')  # TorchScript-only
     parser.add_argument('--dynamic', action='store_true', help='dynamic ONNX axes')  # ONNX-only
     parser.add_argument('--simplify', action='store_true', help='simplify ONNX model')  # ONNX-only
+    parser.add_argument('--opset-version', type=int, default=12, help='ONNX opset version')  # ONNX-only
     opt = parser.parse_args()
     opt.img_size *= 2 if len(opt.img_size) == 1 else 1  # expand
     opt.include = [x.lower() for x in opt.include]
@@ -95,7 +96,7 @@ if __name__ == '__main__':
 
             print(f'{prefix} starting export with onnx {onnx.__version__}...')
             f = opt.weights.replace('.pt', '.onnx')  # filename
-            torch.onnx.export(model, img, f, verbose=False, opset_version=12, input_names=['images'],
+            torch.onnx.export(model, img, f, verbose=False, opset_version=opt.opset_version, input_names=['images'],
                               dynamic_axes={'images': {0: 'batch', 2: 'height', 3: 'width'},  # size(1,3,640,640)
                                             'output': {0: 'batch', 2: 'y', 3: 'x'}} if opt.dynamic else None)
 


### PR DESCRIPTION
Ran into a situation where due to (external) constraints opset version 12 is unsupported (too new). Made it configurable in case anyone else needs it. The change is trivial, but I'm not sure whether it brings any value. It's always a matter of gains / losses: the gain is the ability of configuring the version, the loss is another argument (increased complexity). Perfectly fine if it's going to be rejected.

Might add some other enhancements (fixes) if I encounter problems along the way. One that caught my eye, but I didn't look into it yet is:

    ONNX: starting export with onnx 1.8.1...
    e:\Work\Dev\GitHub\CristiFati\yolov5\models\yolo.py:51: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
      if self.grid[i].shape[2:4] != x[i].shape[2:4] or self.onnx_dynamic:


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced customization for ONNX export with opset version selection.

### 📊 Key Changes
- Added command-line argument `--opset-version` to specify the ONNX opset version.

### 🎯 Purpose & Impact
- 🚀 Allows users to select the ONNX opset version during model export, offering greater control over model compatibility.
- ✨ May improve model performance and compatibility with different ONNX-supporting inference engines so users can optimize their workflows accordingly.