### PR TITLE
rename class autoShape -> AutoShape

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -223,18 +223,18 @@ class NMS(nn.Module):
         return non_max_suppression(x[0], conf_thres=self.conf, iou_thres=self.iou, classes=self.classes)
 
 
-class autoShape(nn.Module):
+class AutoShape(nn.Module):
     # input-robust model wrapper for passing cv2/np/PIL/torch inputs. Includes preprocessing, inference and NMS
     conf = 0.25  # NMS confidence threshold
     iou = 0.45  # NMS IoU threshold
     classes = None  # (optional list) filter by class
 
     def __init__(self, model):
-        super(autoShape, self).__init__()
+        super(AutoShape, self).__init__()
         self.model = model.eval()
 
     def autoshape(self):
-        print('autoShape already enabled, skipping... ')  # model already converted to model.autoshape()
+        print('AutoShape already enabled, skipping... ')  # model already converted to model.autoshape()
         return self
 
     @torch.no_grad()

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -215,8 +215,8 @@ class Model(nn.Module):
             self.model = self.model[:-1]  # remove
         return self
 
-    def autoshape(self):  # add autoShape module
-        logger.info('Adding autoShape... ')
+    def autoshape(self):  # add AutoShape module
+        logger.info('Adding AutoShape... ')
         m = AutoShape(self)  # wrap model
         copy_attr(m, self, include=('yaml', 'nc', 'hyp', 'names', 'stride'), exclude=())  # copy attributes
         return m

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -217,7 +217,7 @@ class Model(nn.Module):
 
     def autoshape(self):  # add autoShape module
         logger.info('Adding autoShape... ')
-        m = autoShape(self)  # wrap model
+        m = AutoShape(self)  # wrap model
         copy_attr(m, self, include=('yaml', 'nc', 'hyp', 'names', 'stride'), exclude=())  # copy attributes
         return m
 


### PR DESCRIPTION
follow other classes' naming convention

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved naming convention in YOLOv5 codebase.

### 📊 Key Changes
- Renamed `autoShape` class to `AutoShape` for consistency in class naming.
- Updated constructor and relevant print statements from `autoShape` to `AutoShape`.

### 🎯 Purpose & Impact
- 💅 **Code Readability:** Harmonizes class naming conventions for better clarity, adhering to Python's CapWords convention.
- 🛠️ **Refactoring:** Reflects best practices in software development, but no changes in functionality.
- 🔍 **User Transparency:** Clearer logging messages to inform users when AutoShape is enabled.