### PR TITLE
Parameterize max_det + inference default at 1000

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -68,7 +68,8 @@ def detect(opt):
         pred = model(img, augment=opt.augment)[0]
 
         # Apply NMS
-        pred = non_max_suppression(pred, opt.conf_thres, opt.iou_thres, classes=opt.classes, agnostic=opt.agnostic_nms, max_det=opt.max_det)
+        pred = non_max_suppression(pred, opt.conf_thres, opt.iou_thres, opt.classes, opt.agnostic_nms,
+                                   max_det=opt.max_det)
         t2 = time_synchronized()
 
         # Apply Classifier

--- a/detect.py
+++ b/detect.py
@@ -154,7 +154,7 @@ if __name__ == '__main__':
     parser.add_argument('--img-size', type=int, default=640, help='inference size (pixels)')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='object confidence threshold')
     parser.add_argument('--iou-thres', type=float, default=0.45, help='IOU threshold for NMS')
-    parser.add_argument('--max-det', type=int, default=300, help='maximum number of detections per image')
+    parser.add_argument('--max-det', type=int, default=1000, help='maximum number of detections per image')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--view-img', action='store_true', help='display results')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')

--- a/detect.py
+++ b/detect.py
@@ -68,7 +68,7 @@ def detect(opt):
         pred = model(img, augment=opt.augment)[0]
 
         # Apply NMS
-        pred = non_max_suppression(pred, opt.conf_thres, opt.iou_thres, classes=opt.classes, agnostic=opt.agnostic_nms)
+        pred = non_max_suppression(pred, opt.conf_thres, opt.iou_thres, classes=opt.classes, agnostic=opt.agnostic_nms, max_det=opt.max_det)
         t2 = time_synchronized()
 
         # Apply Classifier
@@ -153,6 +153,7 @@ if __name__ == '__main__':
     parser.add_argument('--img-size', type=int, default=640, help='inference size (pixels)')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='object confidence threshold')
     parser.add_argument('--iou-thres', type=float, default=0.45, help='IOU threshold for NMS')
+    parser.add_argument('--max-det', type=int, default=300, help='maximum number of detections per image')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--view-img', action='store_true', help='display results')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')

--- a/models/common.py
+++ b/models/common.py
@@ -215,7 +215,7 @@ class NMS(nn.Module):
     conf = 0.25  # confidence threshold
     iou = 0.45  # IoU threshold
     classes = None  # (optional list) filter by class
-    max_det = 300  # maximum number of detections per image
+    max_det = 1000  # maximum number of detections per image
 
     def __init__(self):
         super(NMS, self).__init__()
@@ -229,7 +229,7 @@ class AutoShape(nn.Module):
     conf = 0.25  # NMS confidence threshold
     iou = 0.45  # NMS IoU threshold
     classes = None  # (optional list) filter by class
-    max_det = 300  # maximum number of detections per image
+    max_det = 1000  # maximum number of detections per image
 
     def __init__(self, model):
         super(AutoShape, self).__init__()

--- a/models/common.py
+++ b/models/common.py
@@ -215,12 +215,13 @@ class NMS(nn.Module):
     conf = 0.25  # confidence threshold
     iou = 0.45  # IoU threshold
     classes = None  # (optional list) filter by class
+    max_det = 300 # maximum number of detections per image
 
     def __init__(self):
         super(NMS, self).__init__()
 
     def forward(self, x):
-        return non_max_suppression(x[0], conf_thres=self.conf, iou_thres=self.iou, classes=self.classes)
+        return non_max_suppression(x[0], conf_thres=self.conf, iou_thres=self.iou, classes=self.classes, max_det=self.max_det)
 
 
 class AutoShape(nn.Module):
@@ -228,6 +229,7 @@ class AutoShape(nn.Module):
     conf = 0.25  # NMS confidence threshold
     iou = 0.45  # NMS IoU threshold
     classes = None  # (optional list) filter by class
+    max_det = 300 # maximum number of detections per image
 
     def __init__(self, model):
         super(AutoShape, self).__init__()
@@ -285,7 +287,7 @@ class AutoShape(nn.Module):
             t.append(time_synchronized())
 
             # Post-process
-            y = non_max_suppression(y, conf_thres=self.conf, iou_thres=self.iou, classes=self.classes)  # NMS
+            y = non_max_suppression(y, conf_thres=self.conf, iou_thres=self.iou, classes=self.classes, max_det=self.max_det)  # NMS
             for i in range(n):
                 scale_coords(shape1, y[i][:, :4], shape0[i])
 

--- a/models/common.py
+++ b/models/common.py
@@ -215,13 +215,13 @@ class NMS(nn.Module):
     conf = 0.25  # confidence threshold
     iou = 0.45  # IoU threshold
     classes = None  # (optional list) filter by class
-    max_det = 300 # maximum number of detections per image
+    max_det = 300  # maximum number of detections per image
 
     def __init__(self):
         super(NMS, self).__init__()
 
     def forward(self, x):
-        return non_max_suppression(x[0], conf_thres=self.conf, iou_thres=self.iou, classes=self.classes, max_det=self.max_det)
+        return non_max_suppression(x[0], self.conf, iou_thres=self.iou, classes=self.classes, max_det=self.max_det)
 
 
 class AutoShape(nn.Module):
@@ -229,7 +229,7 @@ class AutoShape(nn.Module):
     conf = 0.25  # NMS confidence threshold
     iou = 0.45  # NMS IoU threshold
     classes = None  # (optional list) filter by class
-    max_det = 300 # maximum number of detections per image
+    max_det = 300  # maximum number of detections per image
 
     def __init__(self, model):
         super(AutoShape, self).__init__()

--- a/models/common.py
+++ b/models/common.py
@@ -287,7 +287,7 @@ class AutoShape(nn.Module):
             t.append(time_synchronized())
 
             # Post-process
-            y = non_max_suppression(y, conf_thres=self.conf, iou_thres=self.iou, classes=self.classes, max_det=self.max_det)  # NMS
+            y = non_max_suppression(y, self.conf, iou_thres=self.iou, classes=self.classes, max_det=self.max_det)  # NMS
             for i in range(n):
                 scale_coords(shape1, y[i][:, :4], shape0[i])
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -482,7 +482,7 @@ def wh_iou(wh1, wh2):
 
 
 def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=None, agnostic=False, multi_label=False,
-                        labels=()):
+                        labels=(), max_det=300):
     """Runs Non-Maximum Suppression (NMS) on inference results
 
     Returns:
@@ -498,7 +498,6 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
 
     # Settings
     min_wh, max_wh = 2, 4096  # (pixels) minimum and maximum box width and height
-    max_det = 300  # maximum number of detections per image
     max_nms = 30000  # maximum number of boxes into torchvision.ops.nms()
     time_limit = 10.0  # seconds to quit after
     redundant = True  # require redundant detections


### PR DESCRIPTION
In this pull request, I've changed `max_det` (the maximum number of detections per image) so that it's more easily configurable. Previously it was always hard-coded to 300, and the only way to change it was to edit the Python code.

Everything is backwards compatible — i.e., the default hasn't changed. Here's what's different:

* `utils.general.non_max_supression()` now takes a `max_det` parameter.
* `detect.py` now has a `--max-det` command-line parameter, which lets you set the value.
* The `NMS` and `AutoShape` classes in `models/common.py` allow overriding `max_det` by setting the attribute on the class.

I'm not sure whether the third thing (the `models/common.py` changes) is actually useful, as I don't know how that part of the code works. I sort of guessed based on the fact that the two classes already had some similar attributes (`conf`, `iou`, `classes`).

Finally, I should say it felt a bit dirty to copy the default `max_det=300` so that it's now duplicated in four separate places. I'd suggest putting that `300` value in a single constant somewhere, then change all four places to use the constant instead of hard-coding `300`. That way the value would only live in a single place. I'm happy to do this work; just let me know if there's an existing place for constants or whether I should create one.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjustment to the max number of detections in YOLOv5's NMS process.

### 📊 Key Changes
- The `max_det` parameter (maximum detections per image) has been introduced to `non_max_suppression` function.
- Default `max_det` value has been set to 1000, up from the previous hard-coded value of 300.
- The `detect.py`, `common.py`, and `general.py` files are updated to pass and use the `max_det` parameter.

### 🎯 Purpose & Impact
- **Purpose**: To allow configuration of the maximum number of detections, facilitating balance between performance and resource constraints for different use cases.
- **Impact**: Users now can detect more objects per image, which is particularly useful for high-resolution images or scenarios with numerous small objects. This may marginally impact the processing time and resources used during detection.