### PR TITLE
0 FPS stream bug fix

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -284,7 +284,7 @@ class LoadStreams:  # multiple IP or RTSP cameras
             assert cap.isOpened(), f'Failed to open {s}'
             w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
             h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-            self.fps = cap.get(cv2.CAP_PROP_FPS) % 100
+            self.fps = (cap.get(cv2.CAP_PROP_FPS) % 100) or 30.0  # assume 30 FPS if cap gets 0 FPS
             self.frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
 
             _, self.imgs[i] = cap.read()  # guarantee first frame


### PR DESCRIPTION
0 FPS stream fix for #3196

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved FPS handling for video streams in YOLOv5.

### 📊 Key Changes
- Modified the method of obtaining FPS from video captures to provide a default value.

### 🎯 Purpose & Impact
- 🎥 Ensures a fallback FPS of 30 when the capture FPS is incorrectly read as 0, leading to more consistent video processing.
- 🛠️ Prevents potential division by zero errors that could arise during frame rate calculations.
- ⏱️ Improves user experience by providing a reasonable default for video analysis tasks.