### PR TITLE
make sure color is not none when in tuple

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -88,6 +88,7 @@ def plot_one_box_PIL(box, im, color=None, label=None, line_thickness=None):
     im = Image.fromarray(im)
     draw = ImageDraw.Draw(im)
     line_thickness = line_thickness or max(int(min(im.size) / 200), 2)
+    color = color or [random.randint(0, 2550 for _ in range(3)]
     draw.rectangle(box, width=line_thickness, outline=tuple(color))  # plot
     if label:
         fontsize = max(round(max(im.size) / 40), 12)


### PR DESCRIPTION
color parameter can be None by default. Before if you did tuple(color) you will get an error because NoneType isn't iterable.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced automatic box color assignment for object detection visualizations in YOLOv5.

### 📊 Key Changes
- Added a fallback to generate random colors if a color is not provided when plotting a bounding box.

### 🎯 Purpose & Impact
- 🎨 Improves the default visual aesthetics by automatically providing distinct colors for bounding boxes in detection results.
- 🤖 Allows users to more easily distinguish different detected objects without manually assigning colors.
- 🔍 May benefit presentations or demos with more engaging and clear visual results.