### PR TITLE
`plot_one_box()` default `color=(128, 128, 128)`

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -68,11 +68,10 @@ def butter_lowpass_filtfilt(data, cutoff=1500, fs=50000, order=5):
     return filtfilt(b, a, data)  # forward-backward filter
 
 
-def plot_one_box(x, im, color=None, label=None, line_thickness=3):
+def plot_one_box(x, im, color=(128, 128, 128), label=None, line_thickness=3):
     # Plots one bounding box on image 'im' using OpenCV
     assert im.data.contiguous, 'Image not contiguous. Apply np.ascontiguousarray(im) to plot_on_box() input image.'
     tl = line_thickness or round(0.002 * (im.shape[0] + im.shape[1]) / 2) + 1  # line/font thickness
-    color = color or [random.randint(0, 255) for _ in range(3)]
     c1, c2 = (int(x[0]), int(x[1])), (int(x[2]), int(x[3]))
     cv2.rectangle(im, c1, c2, color, thickness=tl, lineType=cv2.LINE_AA)
     if label:
@@ -83,18 +82,16 @@ def plot_one_box(x, im, color=None, label=None, line_thickness=3):
         cv2.putText(im, label, (c1[0], c1[1] - 2), 0, tl / 3, [225, 255, 255], thickness=tf, lineType=cv2.LINE_AA)
 
 
-def plot_one_box_PIL(box, im, color=None, label=None, line_thickness=None):
+def plot_one_box_PIL(box, im, color=(128, 128, 128), label=None, line_thickness=None):
     # Plots one bounding box on image 'im' using PIL
     im = Image.fromarray(im)
     draw = ImageDraw.Draw(im)
     line_thickness = line_thickness or max(int(min(im.size) / 200), 2)
-    color = color or [random.randint(0, 255) for _ in range(3)]
-    draw.rectangle(box, width=line_thickness, outline=tuple(color))  # plot
+    draw.rectangle(box, width=line_thickness, outline=color)  # plot
     if label:
-        fontsize = max(round(max(im.size) / 40), 12)
-        font = ImageFont.truetype("Arial.ttf", fontsize)
+        font = ImageFont.truetype("Arial.ttf", size=max(round(max(im.size) / 40), 12))
         txt_width, txt_height = font.getsize(label)
-        draw.rectangle([box[0], box[1] - txt_height + 4, box[0] + txt_width, box[1]], fill=tuple(color))
+        draw.rectangle([box[0], box[1] - txt_height + 4, box[0] + txt_width, box[1]], fill=color)
         draw.text((box[0], box[1] - txt_height + 1), label, fill=(255, 255, 255), font=font)
     return np.asarray(im)
 

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -88,6 +88,7 @@ def plot_one_box_PIL(box, im, color=None, label=None, line_thickness=None):
     im = Image.fromarray(im)
     draw = ImageDraw.Draw(im)
     line_thickness = line_thickness or max(int(min(im.size) / 200), 2)
+    color = color or [random.randint(0, 255) for _ in range(3)]
     draw.rectangle(box, width=line_thickness, outline=tuple(color))  # plot
     if label:
         fontsize = max(round(max(im.size) / 40), 12)


### PR DESCRIPTION
 if color is None calling tuple(color) can cause error 'NoneType' object is not iterable

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Standardized default box color for bounding box plots.

### 📊 Key Changes
- Default color for bounding boxes in plots has been set to a mid-tone gray `(128, 128, 128)`.
- Removed random color selection for plots.
- Simplified font size calculation and arguments for plotting box labels.

### 🎯 Purpose & Impact
- 🎨 **Consistency in Visualization**: Default color standardization provides a uniform look for boxes when no specific color is given.
- ✅ **Simplified Codebase**: Removing random color generation reduces code complexity and potential for visual clutter.
- 🖨️ **Font Handling Improvement**: Streamlines the font size determination for labels, making it easier to maintain and potentially avoiding scaling issues across different image resolutions.
  
This PR enhances the overall usability and consistency of the visual output in YOLOv5, while also reducing potential bugs related to font sizing and randomization.