### PR TITLE
Assert `--image-weights` not combined with DDP

### DIFF
--- a/train.py
+++ b/train.py
@@ -525,6 +525,7 @@ if __name__ == '__main__':
         device = torch.device('cuda', opt.local_rank)
         dist.init_process_group(backend='nccl', init_method='env://')  # distributed backend
         assert opt.batch_size % opt.world_size == 0, '--batch-size must be multiple of CUDA device count'
+        assert not opt.image_weights, '--image-weights argument is not compatible with DDP training'
         opt.batch_size = opt.total_batch_size // opt.world_size
 
     # Hyperparameters


### PR DESCRIPTION
Improved error handling when users combine incompatible `--image-weights` argument with DDP. Resolves issues  https://github.com/ultralytics/yolov5/issues/2461 and https://github.com/ultralytics/yolov5/issues/3265.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved validation of training options in YOLOv5 DDP (Distributed Data Parallel) training mode. 

### 📊 Key Changes 
- Added a check to ensure the `--image-weights` argument is not used with DDP training.

### 🎯 Purpose & Impact 
- This change ensures the user is informed about incompatible training options, which helps prevent potential errors during the distributed training process.
- This clarification could lead to smoother user experiences and fewer issues for developers working on training models at scale. 🔄