### PR TITLE
check `batch_size % utilized_device_count`

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -72,11 +72,12 @@ def select_device(device='', batch_size=None):
 
     cuda = not cpu and torch.cuda.is_available()
     if cuda:
-        n = torch.cuda.device_count()
-        if n > 1 and batch_size:  # check that batch_size is compatible with device_count
+        devices = device.split(',') if device else range(torch.cuda.device_count())  # i.e. 0,1,6,7
+        n = len(devices)  # device count
+        if n > 1 and batch_size:  # check batch_size is divisible by device_count
             assert batch_size % n == 0, f'batch-size {batch_size} not multiple of GPU count {n}'
         space = ' ' * len(s)
-        for i, d in enumerate(device.split(',') if device else range(n)):
+        for i, d in enumerate(devices):
             p = torch.cuda.get_device_properties(i)
             s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / 1024 ** 2}MB)\n"  # bytes to MB
     else:


### PR DESCRIPTION
Bug fix to check batch_size divisibility of utilized CUDA device count vs total system CUDA device count. Partially addresses issue #2491.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved CUDA device selection logic in the YOLOv5 codebase.

### 📊 Key Changes
- Modified the CUDA device selection to support specifying devices via a comma-separated string.
- Ensured the batch size is divisible by the number of selected GPUs, rather than the total available GPUs.
- Updated the display of GPU properties to reflect the new device selection method.

### 🎯 Purpose & Impact
- Allows users more flexibility in choosing specific GPUs for training, especially on systems with multiple GPUs. 🏗️
- Guarantees the batch size is appropriately set for the number of GPUs in use, which can enhance performance. 🚀
- Enhances clarity for users when multiple GPUs are selected by displaying the respective device properties. 🖥️