### PR TITLE
PyTorch Hub `crops = results.crop()` return values

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -657,8 +657,9 @@ def apply_classifier(x, model, img, im0):
     return x
 
 
-def save_one_box(xyxy, im, file='image.jpg', gain=1.02, pad=10, square=False, BGR=False):
-    # Save an image crop as {file} with crop size multiplied by {gain} and padded by {pad} pixels
+def save_one_box(xyxy, im, file='image.jpg', gain=1.02, pad=10, square=False, BGR=False, write=True):
+    # Save an image crop as {file} with crop size multiplied by {gain} and padded by {pad} pixels, only if write is True
+    # Returns cropped image
     xyxy = torch.tensor(xyxy).view(-1, 4)
     b = xyxy2xywh(xyxy)  # boxes
     if square:
@@ -667,7 +668,9 @@ def save_one_box(xyxy, im, file='image.jpg', gain=1.02, pad=10, square=False, BG
     xyxy = xywh2xyxy(b).long()
     clip_coords(xyxy, im.shape)
     crop = im[int(xyxy[0, 1]):int(xyxy[0, 3]), int(xyxy[0, 0]):int(xyxy[0, 2])]
-    cv2.imwrite(str(increment_path(file, mkdir=True).with_suffix('.jpg')), crop if BGR else crop[..., ::-1])
+    if not BGR: crop = crop[..., ::-1]
+    if write: cv2.imwrite(str(increment_path(file, mkdir=True).with_suffix('.jpg')), crop)
+    return crop
 
 
 def increment_path(path, exist_ok=False, sep='', mkdir=False):

--- a/utils/general.py
+++ b/utils/general.py
@@ -657,9 +657,8 @@ def apply_classifier(x, model, img, im0):
     return x
 
 
-def save_one_box(xyxy, im, file='image.jpg', gain=1.02, pad=10, square=False, BGR=False, write=True):
-    # Save an image crop as {file} with crop size multiplied by {gain} and padded by {pad} pixels, only if write is True
-    # Returns cropped image
+def save_one_box(xyxy, im, file='image.jpg', gain=1.02, pad=10, square=False, BGR=False, save=True):
+    # Save image crop as {file} with crop size multiple {gain} and {pad} pixels. Save and/or return crop
     xyxy = torch.tensor(xyxy).view(-1, 4)
     b = xyxy2xywh(xyxy)  # boxes
     if square:
@@ -667,9 +666,9 @@ def save_one_box(xyxy, im, file='image.jpg', gain=1.02, pad=10, square=False, BG
     b[:, 2:] = b[:, 2:] * gain + pad  # box wh * gain + pad
     xyxy = xywh2xyxy(b).long()
     clip_coords(xyxy, im.shape)
-    crop = im[int(xyxy[0, 1]):int(xyxy[0, 3]), int(xyxy[0, 0]):int(xyxy[0, 2])]
-    if not BGR: crop = crop[..., ::-1]
-    if write: cv2.imwrite(str(increment_path(file, mkdir=True).with_suffix('.jpg')), crop)
+    crop = im[int(xyxy[0, 1]):int(xyxy[0, 3]), int(xyxy[0, 0]):int(xyxy[0, 2]), ::(1 if BGR else -1)]
+    if save:
+        cv2.imwrite(str(increment_path(file, mkdir=True).with_suffix('.jpg')), crop)
     return crop
 
 


### PR DESCRIPTION
Made to work with other changes to common.py. See Loading cropped images and infered images

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced `save_one_box` function with optional saving and return crop feature.

### 📊 Key Changes
- Added a `save` parameter to `save_one_box` function to control whether the image crop should be saved to disk.
- Function now returns the cropped image regardless of the `save` parameter.

### 🎯 Purpose & Impact
- 🔍 Allows for more flexibility by giving the option to either save or not save the cropped image.
- 🔄 Users can now use the cropped image directly in their code if saving is not necessary, which can save I/O time and disk space.
- 🖼 This can be especially useful in scenarios where real-time processing is required, or when working with a large number of crops.