### PR TITLE
Loading cropped images and infered images

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -352,16 +352,16 @@ class Detections:
         self.display(save=True, save_dir=save_dir)  # save results
 
     def crop(self, save_dir='runs/hub/exp', save=False):
-        # Return all cropped objects with bounding box as an array of images
+        # Return all cropped objects with bounding box as an dictionary where names map to cropped images
         # Does not write to a directory if save is False
-        list_imgs = []
+        dict_images = {}
         if save: save_dir = increment_path(save_dir, exist_ok=save_dir != 'runs/hub/exp', mkdir=True)  # increment save_dir only if saving
         for i, (im, pred) in enumerate(zip(self.imgs, self.pred)):
             if pred is not None:
                 for c in pred[:, -1].unique():
                     for *box, conf, cls in pred:
-                        list_imgs.append(save_one_box(box, im, file=save_dir / 'crops' / self.names[int(cls)] / self.files[i], write=save))
-        return list_imgs
+                        dict_images[self.names[int(cls)]] = save_one_box(box, im, file=save_dir / 'crops' / self.names[int(cls)] / self.files[i], write=save)
+        return dict_images
 
     def render(self):
         self.display(render=True)  # render results


### PR DESCRIPTION
Added ability to get images directly rather than having to write them to files. Simplifies processes for users.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to image cropping and inference results visualization in the Ultralytics YOLOv5 model.

### 📊 Key Changes
- The `crop` method now returns a dictionary of cropped images with identifiers, rather than saving them by default.
- Added functionality to overlay bounding boxes on images as NumPy arrays with the new `get_inferenced_imgs_as_numpy` method.

### 🎯 Purpose & Impact
- The updated `crop` method gives users the flexibility to handle images directly in code without having to write to disk, which is useful for real-time applications. 🔄
- The newly introduced method for overlaying bounding boxes provides a way for users to visualize detection results programmatically, making it easier to integrate with other image processing workflows. 🖼️🔍
- These updates offer more seamless integration with other tools and platforms, potentially increasing the efficiency of development and analysis workflows. ⚙️🚀