### PR TITLE
Fix TypeError: 'PosixPath' object is not iterable

### DIFF
--- a/train.py
+++ b/train.py
@@ -419,7 +419,7 @@ def train(hyp, opt, device, tb_writer=None):
         # Test best.pt
         logger.info('%g epochs completed in %.3f hours.\n' % (epoch - start_epoch + 1, (time.time() - t0) / 3600))
         if opt.data.endswith('coco.yaml') and nc == 80:  # if COCO
-            for m in (last, best) if best.exists() else (last):  # speed, mAP tests
+            for m in [last, best] if best.exists() else [last]:  # speed, mAP tests
                 results, _, _ = test.test(opt.data,
                                           batch_size=batch_size * 2,
                                           imgsz=imgsz_test,


### PR DESCRIPTION
Fix for error produced when evolving:

```bash
Traceback (most recent call last):
  File "train.py", line 617, in <module>
    results = train(hyp.copy(), opt, device)
  File "train.py", line 422, in train
    for m in (last, best) if best.exists() else (last):  # speed, mAP tests
TypeError: 'PosixPath' object is not iterable
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved consistency in test model selection logic in training script.

### 📊 Key Changes
- Adjusted the tuple to a list when determining which models (`last`, `best`) to test after training.

### 🎯 Purpose & Impact
- The change ensures consistent behavior in the selection of models for testing, leading to more reliable post-training evaluations.
- Users can expect consistent testing of both the last and best models when they exist, without any unintended logic errors.