### PR TITLE
update ci-testing.yml

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -2,21 +2,18 @@ name: CI CPU testing
 
 on:  # https://help.github.com/en/actions/reference/events-that-trigger-workflows
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
-  schedule:
-    - cron: '0 0 * * *'  # Runs at 00:00 UTC every day
+    branches: [ master, develop ]
 
 jobs:
   cpu-tests:
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8]
         model: ['yolov5s']  # models to test
 

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -10,10 +10,11 @@ on:  # https://help.github.com/en/actions/reference/events-that-trigger-workflow
 jobs:
   cpu-tests:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8]
         model: ['yolov5s']  # models to test
 

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -16,7 +16,7 @@ jobs:
             git remote add upstream https://github.com/ultralytics/yolov5.git
             git fetch upstream
             git checkout feature  # <----- replace 'feature' with local branch name
-            git rebase upstream/master
+            git rebase upstream/develop
             git push -u origin -f
             ```
             - ✅ Verify all Continuous Integration (CI) **checks are passing**.


### PR DESCRIPTION
- Update `ci-testing.yml` to trigger tests on PRs to `develop` branch
- Optimization of GH minute consumption:
   - I don't see the point of running tests as a CRON job. If the tests passed the merge to `master` or `develop`, there is no reason for them to stop working.
   - As discussed, I am removing testing on operating systems other than Linux
- Update `greetings.yml` to instruct users to rebase on `develop` 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved CI/CD workflow targeting multiple branches and standardizing development practices.

### 📊 Key Changes
- Continuous Integration (CI) testing now triggers on both `master` and `develop` branches.
- Removed scheduled daily CI runs.
- Updated the greetings.yml workflow to rebase on the `develop` branch instead of `master`.

### 🎯 Purpose & Impact
- 🎭 Ensures testing covers both main and development branches, catching issues earlier in the development cycle.
- 🚀 Streamlines developer contributions by focusing on the development branch, which aligns with typical Git workflow practices.
- 🔄 Reduces unnecessary CI runs, saving resources and potentially speeding up the integration process.
- 👥 Encourages contributors to keep their feature branches up to date with the latest changes in the development branch to minimize merge conflicts.