### PR TITLE
Updated cache v0.2 with `hashlib`

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -1,6 +1,7 @@
 # Dataset utils and dataloaders
 
 import glob
+import hashlib
 import logging
 import math
 import os
@@ -38,7 +39,10 @@ for orientation in ExifTags.TAGS.keys():
 
 def get_hash(paths):
     # Returns a single hash value of a list of paths (files or dirs)
-    return sum(os.path.getsize(p) for p in paths if os.path.exists(p))
+    size = sum(os.path.getsize(p) for p in paths if os.path.exists(p))  # sizes
+    h = hashlib.md5(str(size).encode())  # hash sizes
+    h.update(''.join(paths).encode())  # hash paths
+    return h.hexdigest()  # return hash
 
 
 def exif_size(img):
@@ -383,7 +387,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         cache_path = (p if p.is_file() else Path(self.label_files[0]).parent).with_suffix('.cache')  # cached labels
         if cache_path.is_file():
             cache, exists = torch.load(cache_path), True  # load
-            if cache['hash'] != get_hash(self.label_files + self.img_files + [str(cache_path.parent)]):  # changed
+            if cache['hash'] != get_hash(self.label_files + self.img_files):  # changed
                 cache, exists = self.cache_labels(cache_path, prefix), False  # re-cache
         else:
             cache, exists = self.cache_labels(cache_path, prefix), False  # cache
@@ -499,7 +503,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         if nf == 0:
             logging.info(f'{prefix}WARNING: No labels found in {path}. See {help_url}')
 
-        x['hash'] = get_hash(self.label_files + self.img_files + [str(path.parent)])
+        x['hash'] = get_hash(self.label_files + self.img_files)
         x['results'] = nf, nm, ne, nc, i + 1
         x['version'] = 0.2  # cache version
         try:


### PR DESCRIPTION
Possible fix for https://github.com/ultralytics/yolov5/issues/3349

This PR increments the cache file version to 0.2 and uses a new hashlib-based solution which detects changes in dataset contents **and location**, recaching on any changes in either.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved dataset hashing for better cache validation.

### 📊 Key Changes
- Modified the `get_hash` function to compute hashes based on paths (files or directories) instead of just file sizes.
- Hash now includes both the cumulative size and the actual paths of the dataset for a unique identifier.
- Removed check for 'version' in cache; now solely relies on the new hashing method to validate the cache.

### 🎯 Purpose & Impact
- **Enhanced Accuracy:** The new hashing method provides a more robust way to detect changes in the dataset, reducing the risk of using outdated cache entries.
- **Increased Reliability:** The combination of size and path in the hash helps prevent false cache invalidation, ensuring that cache is only rebuilt when necessary.
- **User Experience:** Users may observe faster setup times for repeat training sessions due to fewer unnecessary cache rebuilds.