### PR TITLE
 ONNX export in `.train()` mode fix

### DIFF
--- a/models/export.py
+++ b/models/export.py
@@ -97,6 +97,8 @@ if __name__ == '__main__':
             print(f'{prefix} starting export with onnx {onnx.__version__}...')
             f = opt.weights.replace('.pt', '.onnx')  # filename
             torch.onnx.export(model, img, f, verbose=False, opset_version=opt.opset_version, input_names=['images'],
+                              training=torch.onnx.TrainingMode.TRAINING if opt.train else torch.onnx.TrainingMode.EVAL,
+                              do_constant_folding=not opt.train,
                               dynamic_axes={'images': {0: 'batch', 2: 'height', 3: 'width'},  # size(1,3,640,640)
                                             'output': {0: 'batch', 2: 'y', 3: 'x'}} if opt.dynamic else None)
 


### PR DESCRIPTION
This PR is submitted for this bug #3346

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced ONNX export options for different training modes.

### 📊 Key Changes
- 🔄 Added an option to specify training or evaluation mode during ONNX export.
- 🧱 Enabled or disabled constant folding depending on the selected mode (training or evaluation).

### 🎯 Purpose & Impact
- 🎛 This improvement allows developers to export their models in the proper mode, matching their intended use case (either for further training or for inference).
- 🚀 Users can now optimize their models' ONNX export for training with gradient updates or for faster inference without gradients.
- 🛠 The option to toggle constant folding can help in optimizing the model accordingly, potentially improving performance in inference scenarios.