### PR TITLE
Ignore blank lines in `*.txt` labels

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -470,7 +470,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                 if os.path.isfile(lb_file):
                     nf += 1  # label found
                     with open(lb_file, 'r') as f:
-                        l = [x.split() for x in f.read().strip().splitlines()]
+                        l = [x.split() for x in f.read().strip().splitlines() if len(x)]
                         if any([len(x) > 8 for x in l]):  # is segment
                             classes = np.array([x[0] for x in l], dtype=np.float32)
                             segments = [np.array(x[1:], dtype=np.float32).reshape(-1, 2) for x in l]  # (cls, xy1...)


### PR DESCRIPTION
Fix for https://github.com/ultralytics/yolov5/issues/958#issuecomment-849512083

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced label parsing in dataset utility to ignore empty lines.

### 📊 Key Changes
- Updated label reading logic to skip empty lines when parsing label files.

### 🎯 Purpose & Impact
- **Purpose**: Prevents potential errors or misinterpretations of label files with unintended empty lines.
- **Impact**: Improves the robustness of dataset preparation by ensuring that label parsing is more fault-tolerant, leading to a smoother training process for YOLOv5 models. Users can expect more reliable data preprocessing, especially in cases where label files might have contained superfluous empty lines. 🛠️