### PR TITLE
Add Open in Kaggle badge

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -517,7 +517,8 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/ultralytics/yolov5/blob/master/tutorial.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/ultralytics/yolov5/blob/master/tutorial.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>",
+        "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/ultralytics/yolov5/blob/master/tutorial.ipynb\" target=\"_parent\"><img alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>"        
       ]
     },
     {


### PR DESCRIPTION
Add Open in Kaggle badge like in https://github.com/ultralytics/yolov3/pull/1773
@glenn-jocher 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced accessibility to YOLOv5 tutorial by adding "Open in Kaggle" option.

### 📊 Key Changes
- Inserted a link and button to open the YOLOv5 tutorial notebook directly in Kaggle.
- Maintained the existing "Open in Colab" button for Google Colab users.

### 🎯 Purpose & Impact
- 🎈 Provides users with an additional platform (Kaggle) to run the tutorial, increasing convenience.
- 🚀 Broadens the tutorial's reach, potentially attracting users who prefer Kaggle over Colab.
- ✨ Facilitates easier experimentation and learning for users by leveraging Kaggle's data science community and resources.