### PR TITLE
Enable direct `--weights URL` definition

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -41,8 +41,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
             cfg = list((Path(__file__).parent / 'models').rglob(f'{name}.yaml'))[0]  # model.yaml path
             model = Model(cfg, channels, classes)  # create model
             if pretrained:
-                attempt_download(fname)  # download if not found locally
-                ckpt = torch.load(fname, map_location=torch.device('cpu'))  # load
+                ckpt = torch.load(attempt_download(fname), map_location=torch.device('cpu'))  # load
                 msd = model.state_dict()  # model state_dict
                 csd = ckpt['model'].float().state_dict()  # checkpoint state_dict as FP32
                 csd = {k: v for k, v in csd.items() if msd[k].shape == v.shape}  # filter

--- a/models/experimental.py
+++ b/models/experimental.py
@@ -116,8 +116,7 @@ def attempt_load(weights, map_location=None, inplace=True):
     # Loads an ensemble of models weights=[a,b,c] or a single model weights=[a] or weights=a
     model = Ensemble()
     for w in weights if isinstance(weights, list) else [weights]:
-        attempt_download(w)
-        ckpt = torch.load(w, map_location=map_location)  # load
+        ckpt = torch.load(attempt_download(w), map_location=map_location)  # load
         model.append(ckpt['ema' if ckpt.get('ema') else 'model'].float().fuse().eval())  # FP32 model
 
     # Compatibility updates

--- a/train.py
+++ b/train.py
@@ -83,7 +83,7 @@ def train(hyp, opt, device, tb_writer=None):
     pretrained = weights.endswith('.pt')
     if pretrained:
         with torch_distributed_zero_first(rank):
-            attempt_download(weights)  # download if not found locally
+            weights = attempt_download(weights)  # download if not found locally
         ckpt = torch.load(weights, map_location=device)  # load checkpoint
         model = Model(opt.cfg or ckpt['model'].yaml, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
         exclude = ['anchor'] if (opt.cfg or hyp.get('anchors')) and not opt.resume else []  # exclude keys

--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -17,7 +17,7 @@ def gsutil_getsize(url=''):
 
 
 def safe_download(file, url, url2=None, min_bytes=1E0, error_msg=''):
-    # Attempts to download file from url or url2, checks and removes incomplete downloads < min_size bytes
+    # Attempts to download file from url or url2, checks and removes incomplete downloads < min_bytes
     file = Path(file)
     try:  # GitHub
         print(f'Downloading {url} to {file}...')

--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -32,7 +32,6 @@ def safe_download(file, url, url2=None, min_bytes=1E0, error_msg=''):
             file.unlink(missing_ok=True)  # remove partial downloads
             print(f'ERROR: Download failure: {error_msg or url}')
         print('')
-        return
 
 
 def attempt_download(file, repo='ultralytics/yolov5'):
@@ -68,7 +67,7 @@ def attempt_download(file, repo='ultralytics/yolov5'):
                           min_bytes=1E5,
                           error_msg=f'{file} missing, try downloading from https://github.com/{repo}/releases/')
 
-        return str(file)
+    return str(file)
 
 
 def gdrive_download(id='16TiPfZj7htmTyhntwcZyEEAejOUxuT6m', file='tmp.zip'):

--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -17,7 +17,7 @@ def gsutil_getsize(url=''):
 
 
 def safe_download(file, url, url2=None, min_bytes=1E0, error_msg=''):
-    # Attempts to download file from url or url2, checks and removes incomplete downloads < min_bytes
+    # Attempts to download file from url or url2, checks and removes incomplete downloads < min_size bytes
     file = Path(file)
     try:  # GitHub
         print(f'Downloading {url} to {file}...')
@@ -40,14 +40,15 @@ def attempt_download(file, repo='ultralytics/yolov5'):
     file = Path(str(file).strip().replace("'", ''))
 
     if not file.exists():
-        file.parent.mkdir(parents=True, exist_ok=True)  # make parent dir (if required)
-        name = file.name
-
         # URL specified
-        if str(file).startswith(('http://', 'https://')):  # download
-            safe_download(file=name, url=str(file), min_bytes=1E5)
+        name = file.name
+        if str(file).startswith(('http:/', 'https:/')):  # download
+            url = str(file).replace(':/', '://')  # Pathlib turns :// -> :/
+            safe_download(file=name, url=url, min_bytes=1E5)
+            return name
 
         # GitHub assets
+        file.parent.mkdir(parents=True, exist_ok=True)  # make parent dir (if required)
         try:
             response = requests.get(f'https://api.github.com/repos/{repo}/releases/latest').json()  # github api
             assets = [x['name'] for x in response['assets']]  # release assets, i.e. ['yolov5s.pt', 'yolov5m.pt', ...]
@@ -66,6 +67,8 @@ def attempt_download(file, repo='ultralytics/yolov5'):
                           url2=f'https://storage.googleapis.com/{repo}/ckpt/{name}',  # backup
                           min_bytes=1E5,
                           error_msg=f'{file} missing, try downloading from https://github.com/{repo}/releases/')
+
+        return str(file)
 
 
 def gdrive_download(id='16TiPfZj7htmTyhntwcZyEEAejOUxuT6m', file='tmp.zip'):

--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -16,12 +16,38 @@ def gsutil_getsize(url=''):
     return eval(s.split(' ')[0]) if len(s) else 0  # bytes
 
 
+def safe_download(file, url, url2=None, min_bytes=1E0, error_msg=''):
+    # Attempts to download file from url or url2, checks and removes incomplete downloads < min_size bytes
+    file = Path(file)
+    try:  # GitHub
+        print(f'Downloading {url} to {file}...')
+        torch.hub.download_url_to_file(url, str(file))
+        assert file.exists() and file.stat().st_size > min_bytes  # check
+    except Exception as e:  # GCP
+        file.unlink(missing_ok=True)  # remove partial downloads
+        print(f'Download error: {e}\nRe-attempting {url2 or url} to {file}...')
+        os.system(f"curl -L '{url2 or url}' -o '{file}' --retry 3 -C -")  # curl download, retry and resume on fail
+    finally:
+        if not file.exists() or file.stat().st_size < min_bytes:  # check
+            file.unlink(missing_ok=True)  # remove partial downloads
+            print(f'ERROR: Download failure: {error_msg or url}')
+        print('')
+        return
+
+
 def attempt_download(file, repo='ultralytics/yolov5'):
     # Attempt file download if does not exist
     file = Path(str(file).strip().replace("'", ''))
 
     if not file.exists():
         file.parent.mkdir(parents=True, exist_ok=True)  # make parent dir (if required)
+        name = file.name
+
+        # URL specified
+        if str(file).startswith(('http://', 'https://')):  # download
+            safe_download(file=name, url=str(file), min_bytes=1E5)
+
+        # GitHub assets
         try:
             response = requests.get(f'https://api.github.com/repos/{repo}/releases/latest').json()  # github api
             assets = [x['name'] for x in response['assets']]  # release assets, i.e. ['yolov5s.pt', 'yolov5m.pt', ...]
@@ -34,27 +60,12 @@ def attempt_download(file, repo='ultralytics/yolov5'):
             except:
                 tag = 'v5.0'  # current release
 
-        name = file.name
         if name in assets:
-            msg = f'{file} missing, try downloading from https://github.com/{repo}/releases/'
-            redundant = False  # second download option
-            try:  # GitHub
-                url = f'https://github.com/{repo}/releases/download/{tag}/{name}'
-                print(f'Downloading {url} to {file}...')
-                torch.hub.download_url_to_file(url, file)
-                assert file.exists() and file.stat().st_size > 1E6  # check
-            except Exception as e:  # GCP
-                print(f'Download error: {e}')
-                assert redundant, 'No secondary mirror'
-                url = f'https://storage.googleapis.com/{repo}/ckpt/{name}'
-                print(f'Downloading {url} to {file}...')
-                os.system(f"curl -L '{url}' -o '{file}' --retry 3 -C -")  # curl download, retry and resume on fail
-            finally:
-                if not file.exists() or file.stat().st_size < 1E6:  # check
-                    file.unlink(missing_ok=True)  # remove partial downloads
-                    print(f'ERROR: Download failure: {msg}')
-                print('')
-                return
+            safe_download(file,
+                          url=f'https://github.com/{repo}/releases/download/{tag}/{name}',
+                          url2=f'https://storage.googleapis.com/{repo}/ckpt/{name}',  # backup
+                          min_bytes=1E5,
+                          error_msg=f'{file} missing, try downloading from https://github.com/{repo}/releases/')
 
 
 def gdrive_download(id='16TiPfZj7htmTyhntwcZyEEAejOUxuT6m', file='tmp.zip'):

--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -63,7 +63,7 @@ def attempt_download(file, repo='ultralytics/yolov5'):
         if name in assets:
             safe_download(file,
                           url=f'https://github.com/{repo}/releases/download/{tag}/{name}',
-                          url2=f'https://storage.googleapis.com/{repo}/ckpt/{name}',  # backup
+                          # url2=f'https://storage.googleapis.com/{repo}/ckpt/{name}',  # backup url (optional)
                           min_bytes=1E5,
                           error_msg=f'{file} missing, try downloading from https://github.com/{repo}/releases/')
 


### PR DESCRIPTION
@KalenMike this PR will enable direct --weights URL definition. Example usage:
```bash
python train.py --weights https://storage.googleapis.com/bucket/dir/model.pt
python test.py --weights https://storage.googleapis.com/bucket/dir/model.pt
python detect.py --weights https://storage.googleapis.com/bucket/dir/model.pt

# Hub
model = torch.hub.load('ultralytics/yolov5', 'custom', 'https://storage.googleapis.com/bucket/dir/model.pt')
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of model downloading process in Ultralytics YOLOv5.

### 📊 Key Changes
- Simplified the code to download pre-trained models by merging the download and loading steps.
- Introduced `safe_download` function for more robust file downloading with error handling and retries.
- Ensured the `attempt_download` function supports direct HTTP/HTTPS URL downloads.

### 🎯 Purpose & Impact
- **Improved Reliability**: Incorporated more reliable file download checks, reducing the instances of incomplete downloads.
- **Simplified Error Handling**: New function streamlines the downloading process, which catches and handles errors more efficiently.
- **Easier Debugging**: Descriptive error messages will make it easier for both developers and users to troubleshoot download issues.
- **Direct URL Support**: Enhancements include the ability to download files directly from specified URLs, facilitating easier access to pre-trained models.
- **User Experience**: These changes can lead to a smoother and more dependable setup process for users working with YOLOv5 models, minimizing disruptions due to download errors.