### PR TITLE
`cv2.imread(img, -1)` for IMREAD_UNCHANGED

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -181,7 +181,7 @@ class LoadImages:  # for inference
         else:
             # Read image
             self.count += 1
-            img0 = cv2.imread(path)  # BGR
+            img0 = cv2.imread(path,-1)  # BGR
             assert img0 is not None, 'Image Not Found ' + path
             print(f'image {self.count}/{self.nf} {path}: ', end='')
 

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -181,7 +181,7 @@ class LoadImages:  # for inference
         else:
             # Read image
             self.count += 1
-            img0 = cv2.imread(path,-1)  # BGR
+            img0 = cv2.imread(path, -1)  # BGR (-1 is IMREAD_UNCHANGED)
             assert img0 is not None, 'Image Not Found ' + path
             print(f'image {self.count}/{self.nf} {path}: ', end='')
 


### PR DESCRIPTION
if you train a 4 channel  model, Using the detet.py code will report an error 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image loading in YOLOv5 to support various image formats.

### 📊 Key Changes
- Modified the image reading function `cv2.imread` by adding the `-1` flag.

### 🎯 Purpose & Impact
- **Purpose:** To enable the loading of images with their original depth and channel settings (e.g., alpha channel in PNGs).
- **Impact:** Users can now train models with images that have multiple channels or non-standard encodings without pre-processing them. This could lead to more versatility in training datasets and potentially richer model inputs. 🌈🖼️