### PR TITLE
Multi-threaded dataset scanning

### DIFF
--- a/train.py
+++ b/train.py
@@ -189,7 +189,8 @@ def train(hyp, opt, device, tb_writer=None):
     dataloader, dataset = create_dataloader(train_path, imgsz, batch_size, gs, opt,
                                             hyp=hyp, augment=True, cache=opt.cache_images, rect=opt.rect, rank=rank,
                                             world_size=opt.world_size, workers=opt.workers,
-                                            image_weights=opt.image_weights, quad=opt.quad, prefix=colorstr('train: '))
+                                            image_weights=opt.image_weights, quad=opt.quad, prefix=colorstr('train: '),
+                                            cache_labels_workers=opt.cache_labels_workers)
     mlc = np.concatenate(dataset.labels, 0)[:, 0].max()  # max label class
     nb = len(dataloader)  # number of batches
     assert mlc < nc, 'Label class %g exceeds nc=%g in %s. Possible class labels are 0-%g' % (mlc, nc, opt.data, nc - 1)
@@ -199,7 +200,8 @@ def train(hyp, opt, device, tb_writer=None):
         testloader = create_dataloader(test_path, imgsz_test, batch_size * 2, gs, opt,  # testloader
                                        hyp=hyp, cache=opt.cache_images and not opt.notest, rect=True, rank=-1,
                                        world_size=opt.world_size, workers=opt.workers,
-                                       pad=0.5, prefix=colorstr('val: '))[0]
+                                       pad=0.5, prefix=colorstr('val: '),
+                                       cache_labels_workers=opt.cache_labels_workers)[0]
 
         if not opt.resume:
             labels = np.concatenate(dataset.labels, 0)
@@ -476,6 +478,7 @@ if __name__ == '__main__':
     parser.add_argument('--sync-bn', action='store_true', help='use SyncBatchNorm, only available in DDP mode')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
     parser.add_argument('--workers', type=int, default=8, help='maximum number of dataloader workers')
+    parser.add_argument('--cache_labels_workers', type=int, default=1, help='maximum number of workers used to create labels cache')
     parser.add_argument('--project', default='runs/train', help='save to project/name')
     parser.add_argument('--entity', default=None, help='W&B entity')
     parser.add_argument('--name', default='exp', help='save to project/name')


### PR DESCRIPTION
On a large dataset with 2m+ images I'm getting poor performance of cache_labels method. 
This diff adds an option --cache_labels_workers to build labels cache in parallel. 

For testing used the following wiki to set up the environment: https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data 

## With parallel processing enabled
`python train.py --img 416 --batch 32 --epochs 5 --data data.yaml --weights yolov5s.pt --device cpu --cache_labels_workers 8`

```
Scanning images: 100%|██████████| 765/765 [00:00<00:00, 11014.83it/s]
train: New cache created: bccd/train/labels.cache
Scanning images: 100%|██████████| 73/73 [00:00<00:00, 802.96it/s]
val: New cache created: bccd/valid/labels.cache
```

```
(base) vslaykovsky@vslaykovsky-ubuntu:~/yolov5$ ls -l bccd/*/labels.cache
-rw-rw-r-- 1 vslaykovsky vslaykovsky 413167 May 29 18:01 bccd/train/labels.cache
-rw-rw-r-- 1 vslaykovsky vslaykovsky  39855 May 29 18:01 bccd/valid/labels.cache

```

## With no parallel processing
`python train.py --img 416 --batch 32 --epochs 5 --data data.yaml --weights yolov5s.pt --device cpu --cache_labels_workers 1`

```
train: Scanning 'bccd/train/labels' images and labels... 765 found, 0 missing, 0 empty, 0 corrupted: 100%|██████████| 765/765 [00:00<00:00, 4798.18it/s]
train: New cache created: bccd/train/labels.cache
val: Scanning 'bccd/valid/labels' images and labels... 73 found, 0 missing, 0 empty, 0 corrupted: 100%|██████████| 73/73 [00:00<00:00, 2899.09it/s]
val: New cache created: bccd/valid/labels.cache
```

```
(base) vslaykovsky@vslaykovsky-ubuntu:~/yolov5$ rm -f  bccd/train/labels.cache bccd/valid/labels.cache 
(base) vslaykovsky@vslaykovsky-ubuntu:~/yolov5$ ls -l bccd/*/labels.cache
-rw-rw-r-- 1 vslaykovsky vslaykovsky 409391 May 29 18:02 bccd/train/labels.cache
-rw-rw-r-- 1 vslaykovsky vslaykovsky  38447 May 29 18:02 bccd/valid/labels.cache
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to the image and labels caching system in the YOLOv5 training pipeline with added multiprocessing support.

### 📊 Key Changes
- 🧵 Introduced a new argument (`--cache_labels_workers`) to the `train.py` allowing specification of the number of worker processes used for caching labels.
- 🔄 Modified the data loader creation process (`create_dataloader`) to accept the new `cache_labels_workers` argument.
- ♻️ Refactored `LoadImagesAndLabels` class to handle label verification and cache creation in a separate method named `parse_label`.
- ✨ Enabled parallel processing in label caching using `multiprocessing.Pool` if `cache_labels_workers` is set to more than 1.
  
### 🎯 Purpose & Impact
- 🔍 The new `--cache_labels_workers` argument aims to speed up the initial data preparation phase by using parallel processing, which can significantly decrease startup times for training, especially on large datasets.
- 🚀 Users with access to multi-core CPUs can benefit from faster data loading and preprocessing, leading to more efficient experimentation and model development cycles.
- 📈 This change potentially improves the user experience, especially for those working with large and complex datasets, by reducing the time spent waiting for data to be ready for training.