### PR TITLE
Revert "`cv2.imread(img, -1)` for IMREAD_UNCHANGED"

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -181,7 +181,7 @@ class LoadImages:  # for inference
         else:
             # Read image
             self.count += 1
-            img0 = cv2.imread(path, -1)  # BGR (-1 is IMREAD_UNCHANGED)
+            img0 = cv2.imread(path)  # BGR
             assert img0 is not None, 'Image Not Found ' + path
             print(f'image {self.count}/{self.nf} {path}: ', end='')
 


### PR DESCRIPTION
Reverts ultralytics/yolov5#3379 due to errors loading jpgs in Kaggle.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement in image reading for consistent color channel handling.

### 📊 Key Changes
- Removed the `-1` flag from `cv2.imread()` in the `utils/datasets.py`.

### 🎯 Purpose & Impact
- Ensures images are read in a consistent BGR (Blue-Green-Red) format by OpenCV, avoiding potential issues with color channels.
- 🛠️ Provides better stability in image preprocessing, which can lead to improved model performance and reliability.
- Users can expect more predictable behavior when using custom datasets with varying image formats.