### PR TITLE
Revert FP16 `test.py` and `detect.py` inference to FP32 default

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -29,7 +29,7 @@ def detect(opt):
     set_logging()
     device = select_device(opt.device)
 
-    half =opt.use_half and device.type != 'cpu'   # half precision only supported on CUDA
+    half =opt.half and device.type != 'cpu'   # half precision only supported on CUDA
 
     # Load model
     model = attempt_load(weights, map_location=device)  # load FP32 model
@@ -173,7 +173,7 @@ if __name__ == '__main__':
     parser.add_argument('--line-thickness', default=3, type=int, help='bounding box thickness (pixels)')
     parser.add_argument('--hide-labels', default=False, action='store_true', help='hide labels')
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
-    parser.add_argument('--use-half', type=bool, default=False, help='whether to use half precision for inference')
+    parser.add_argument('--half', type=bool, default=False, help='half-precision FP16 inference')
     opt = parser.parse_args()
     print(opt)
     check_requirements(exclude=('tensorboard', 'pycocotools', 'thop'))

--- a/detect.py
+++ b/detect.py
@@ -28,8 +28,7 @@ def detect(opt):
     # Initialize
     set_logging()
     device = select_device(opt.device)
-
-    half =opt.half and device.type != 'cpu'   # half precision only supported on CUDA
+    half = opt.half and device.type != 'cpu'   # half precision only supported on CUDA
 
     # Load model
     model = attempt_load(weights, map_location=device)  # load FP32 model

--- a/detect.py
+++ b/detect.py
@@ -172,7 +172,7 @@ if __name__ == '__main__':
     parser.add_argument('--line-thickness', default=3, type=int, help='bounding box thickness (pixels)')
     parser.add_argument('--hide-labels', default=False, action='store_true', help='hide labels')
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
-    parser.add_argument('--half', type=bool, default=False, help='half-precision FP16 inference')
+    parser.add_argument('--half', type=bool, default=False, help='use FP16 half-precision inference')
     opt = parser.parse_args()
     print(opt)
     check_requirements(exclude=('tensorboard', 'pycocotools', 'thop'))

--- a/detect.py
+++ b/detect.py
@@ -28,7 +28,7 @@ def detect(opt):
     # Initialize
     set_logging()
     device = select_device(opt.device)
-    half = opt.half and device.type != 'cpu'   # half precision only supported on CUDA
+    half = opt.half and device.type != 'cpu'  # half precision only supported on CUDA
 
     # Load model
     model = attempt_load(weights, map_location=device)  # load FP32 model

--- a/detect.py
+++ b/detect.py
@@ -28,7 +28,8 @@ def detect(opt):
     # Initialize
     set_logging()
     device = select_device(opt.device)
-    half = device.type != 'cpu'  # half precision only supported on CUDA
+
+    half =opt.use_half and device.type != 'cpu'   # half precision only supported on CUDA
 
     # Load model
     model = attempt_load(weights, map_location=device)  # load FP32 model
@@ -172,6 +173,7 @@ if __name__ == '__main__':
     parser.add_argument('--line-thickness', default=3, type=int, help='bounding box thickness (pixels)')
     parser.add_argument('--hide-labels', default=False, action='store_true', help='hide labels')
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
+    parser.add_argument('--use-half', type=bool, default=False, help='whether to use half precision for inference')
     opt = parser.parse_args()
     print(opt)
     check_requirements(exclude=('tensorboard', 'pycocotools', 'thop'))

--- a/test.py
+++ b/test.py
@@ -307,7 +307,6 @@ if __name__ == '__main__':
     parser.add_argument('--name', default='exp', help='save to project/name')
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     parser.add_argument('--half', type=bool, default=False, help='use FP16 half-precision inference')
-
     opt = parser.parse_args()
     opt.save_json |= opt.data.endswith('coco.yaml')
     opt.data = check_file(opt.data)  # check file

--- a/test.py
+++ b/test.py
@@ -306,7 +306,7 @@ if __name__ == '__main__':
     parser.add_argument('--project', default='runs/test', help='save to project/name')
     parser.add_argument('--name', default='exp', help='save to project/name')
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
-    parser.add_argument('--use-half', type=bool, default=False, help='whether to use half precision for inference')
+    parser.add_argument('--half', type=bool, default=False, help='use FP16 half-precision inference')
 
     opt = parser.parse_args()
     opt.save_json |= opt.data.endswith('coco.yaml')
@@ -328,7 +328,7 @@ if __name__ == '__main__':
              save_txt=opt.save_txt | opt.save_hybrid,
              save_hybrid=opt.save_hybrid,
              save_conf=opt.save_conf,
-             half_precision=opt.use_half,
+             half_precision=opt.half,
              opt=opt
              )
 

--- a/test.py
+++ b/test.py
@@ -306,6 +306,8 @@ if __name__ == '__main__':
     parser.add_argument('--project', default='runs/test', help='save to project/name')
     parser.add_argument('--name', default='exp', help='save to project/name')
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
+    parser.add_argument('--use-half', type=bool, default=False, help='whether to use half precision for inference')
+
     opt = parser.parse_args()
     opt.save_json |= opt.data.endswith('coco.yaml')
     opt.data = check_file(opt.data)  # check file
@@ -326,6 +328,7 @@ if __name__ == '__main__':
              save_txt=opt.save_txt | opt.save_hybrid,
              save_hybrid=opt.save_hybrid,
              save_conf=opt.save_conf,
+             half_precision=opt.use_half,
              opt=opt
              )
 


### PR DESCRIPTION
 We discussed the problem of half-precision inference failure in  #3280 
I think we can use this method to fix the half-precision inference failure when we run detect.py and test.py on some GPUs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Implementation of a user-controllable flag to enable FP16 half-precision inference in detection and testing.

### 📊 Key Changes
- Added an option `--half` to enable FP16 half-precision inference both in `detect.py` and `test.py`.
- Modified the `half` variable initialization to respect the new `--half` option, ensuring it's active only when requested by the user.

### 🎯 Purpose & Impact
- **Purpose**: This change provides users with the option to perform inference in half-precision mode, which can offer a significant speedup on compatible hardware (mostly GPUs) without substantially sacrificing accuracy.
- **Impact**: This enhancement empowers users, especially those with compatible CUDA-enabled GPUs, to opt into performance optimizations that were previously not available. This can be particularly useful for real-time applications or situations where compute resources are limited. 🚀