### PR TITLE
Suppress jit trace warning + graph once

### DIFF
--- a/train.py
+++ b/train.py
@@ -334,7 +334,7 @@ def train(hyp, opt, device, tb_writer=None):
                     if tb_writer and ni == 0:
                         with warnings.catch_warnings():
                             warnings.simplefilter('ignore')  # suppress jit trace warning
-                            tb_writer.add_graph(torch.jit.trace(de_parallel(model), imgs, strict=False), [])
+                            tb_writer.add_graph(torch.jit.trace(de_parallel(model), imgs, strict=False), [])  # graph
                 elif plots and ni == 10 and wandb_logger.wandb:
                     wandb_logger.log({'Mosaics': [wandb_logger.wandb.Image(str(x), caption=x.name) for x in
                                                   save_dir.glob('train*.jpg') if x.exists()]})

--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@ import math
 import os
 import random
 import time
+import warnings
 from copy import deepcopy
 from pathlib import Path
 from threading import Thread
@@ -323,18 +324,19 @@ def train(hyp, opt, device, tb_writer=None):
                 mloss = (mloss * i + loss_items) / (i + 1)  # update mean losses
                 mem = '%.3gG' % (torch.cuda.memory_reserved() / 1E9 if torch.cuda.is_available() else 0)  # (GB)
                 s = ('%10s' * 2 + '%10.4g' * 6) % (
-                    '%g/%g' % (epoch, epochs - 1), mem, *mloss, targets.shape[0], imgs.shape[-1])
+                    f'{epoch}/{epochs - 1}', mem, *mloss, targets.shape[0], imgs.shape[-1])
                 pbar.set_description(s)
 
                 # Plot
                 if plots and ni < 3:
                     f = save_dir / f'train_batch{ni}.jpg'  # filename
                     Thread(target=plot_images, args=(imgs, targets, paths, f), daemon=True).start()
-                    if tb_writer:
-                        tb_writer.add_graph(torch.jit.trace(de_parallel(model), imgs, strict=False), [])  # model graph
-                        # tb_writer.add_image(f, result, dataformats='HWC', global_step=epoch)
+                    if tb_writer and ni == 0:
+                        with warnings.catch_warnings():
+                            warnings.simplefilter('ignore')  # suppress jit trace warning
+                            tb_writer.add_graph(torch.jit.trace(de_parallel(model), imgs, strict=False), [])
                 elif plots and ni == 10 and wandb_logger.wandb:
-                    wandb_logger.log({"Mosaics": [wandb_logger.wandb.Image(str(x), caption=x.name) for x in
+                    wandb_logger.log({'Mosaics': [wandb_logger.wandb.Image(str(x), caption=x.name) for x in
                                                   save_dir.glob('train*.jpg') if x.exists()]})
 
             # end batch ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Suppress harmless jit trace warning on TensorBoard `add_graph()` call. Also fix multiple `add_graph()` calls bug, now only on batch 0.


```bash
     Epoch   gpu_mem       box       obj       cls     total    labels  img_size
       0/2     2.88G     0.041   0.06913   0.01847    0.1286       228       640:   0% 0/8 [00:02<?, ?it/s]/usr/local/lib/python3.7/dist-packages/torch/jit/_trace.py:728: UserWarning: The input to trace is already a ScriptModule, tracing it is a no-op. Returning the object as is.
  "The input to trace is already a ScriptModule, tracing it is a no-op. Returning the object as is."
       0/2     10.8G   0.04368     0.065   0.02127    0.1299       183       640: 100% 8/8 [00:11<00:00,  1.45s/it]
               Class      Images      Labels           P           R      mAP@.5  mAP@.5:.95: 100% 4/4 [00:05<00:00,  1.47s/it]
                 all         128         929       0.664       0.618       0.665       0.432
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to training logging and visualization in YOLOv5.

### 📊 Key Changes
- Added `warnings` import to handle potential warnings during training.
- Reformatted the logging string to use formatted string literals (f-strings) for better readability.
- Adjusted TensorBoard logging to suppress JIT trace warnings using a `warnings` filter.
- Limited TensorBoard model graph logging to only the first batch of each epoch.
- Modified Weights & Biases (wandb) logging for consistency by changing dictionary keys to single quotes.

### 🎯 Purpose & Impact
- Improving the training output readability and consistency for users monitoring their model's progress.
- Enhancing debuggability by suppressing non-critical warnings that could clutter the output.
- Reducing computational overhead by logging detailed graphs once per epoch, potentially speeding up the training process.
- Standardizing the use of quotes in wandb logging for better code style and maintainability. 

These changes aim to make the training experience smoother and more user-friendly, with clear, concise information provided to the user without unnecessary distraction or performance hits. 🚀