### PR TITLE
Update MixUp augmentation `alpha=beta=32.0`

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -535,7 +535,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
             # MixUp https://arxiv.org/pdf/1710.09412.pdf
             if random.random() < hyp['mixup']:
                 img2, labels2 = load_mosaic(self, random.randint(0, self.n - 1))
-                r = np.random.beta(8.0, 8.0)  # mixup ratio, alpha=beta=8.0
+                r = np.random.beta(32.0, 32.0)  # mixup ratio, alpha=beta=32.0
                 img = (img * r + img2 * (1 - r)).astype(np.uint8)
                 labels = np.concatenate((labels, labels2), 0)
 


### PR DESCRIPTION
Per VOC empirical results https://github.com/ultralytics/yolov5/issues/3380#issuecomment-853001307 by @developer0hye

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image augmentation with a finer MixUp ratio.

### 📊 Key Changes
- Adjusted the MixUp ratio from a beta distribution with parameters (alpha=beta=8.0) to (alpha=beta=32.0).

### 🎯 Purpose & Impact
- **Improved Augmentation**: Tweaking the MixUp ratio can potentially lead to better training augmentation, making the model more robust.
- **Finer Mixing**: A higher beta parameter results in images being mixed in a more subtle way, which could improve the diversity of training data without overly distorting the images.
- **User Experience**: This change might increase model performance and generalization, albeit slightly altering training dynamics. Users might notice improved detection accuracy in complex scenarios. 📈🤖

Remember, while this is a small change in a line of code, it could make a significant difference in how well the YOLOv5 model learns from varied data! 🎨✨