### PR TITLE
Add `output_names` argument for ONNX export with dynamic axes

### DIFF
--- a/models/export.py
+++ b/models/export.py
@@ -96,13 +96,14 @@ if __name__ == '__main__':
 
             print(f'{prefix} starting export with onnx {onnx.__version__}...')
             f = opt.weights.replace('.pt', '.onnx')  # filename
-            torch.onnx.export(model, img, f, verbose=False, opset_version=opt.opset_version, input_names=['images'],
+            torch.onnx.export(model, img, f, verbose=False, opset_version=opt.opset_version,
                               training=torch.onnx.TrainingMode.TRAINING if opt.train else torch.onnx.TrainingMode.EVAL,
                               do_constant_folding=not opt.train,
-                              output_names=['output0', 'output1', 'output2', 'output3'],
-                              dynamic_axes={'images': {0: 'batch', 2: 'height', 3: 'width'},  # size(1,3,640,640)
-                                            'output0': {0: 'batch'}, 'output1': {0: 'batch'},
-                                            'output2': {0: 'batch'}, 'output3': {0: 'batch'}} if opt.dynamic else None)
+                              input_names=['images'],
+                              output_names=['output'],
+                              dynamic_axes={'images': {0: 'batch', 2: 'height', 3: 'width'},  # shape(1,3,640,640)
+                                            'output': {0: 'batch', 1: 'anchors'}  # shape(1,25200,85)
+                                            } if opt.dynamic else None)
 
             # Checks
             model_onnx = onnx.load(f)  # load onnx model

--- a/models/export.py
+++ b/models/export.py
@@ -99,8 +99,10 @@ if __name__ == '__main__':
             torch.onnx.export(model, img, f, verbose=False, opset_version=opt.opset_version, input_names=['images'],
                               training=torch.onnx.TrainingMode.TRAINING if opt.train else torch.onnx.TrainingMode.EVAL,
                               do_constant_folding=not opt.train,
+                              output_names=['output0', 'output1', 'output2', 'output3'],
                               dynamic_axes={'images': {0: 'batch', 2: 'height', 3: 'width'},  # size(1,3,640,640)
-                                            'output': {0: 'batch', 2: 'y', 3: 'x'}} if opt.dynamic else None)
+                                            'output0': {0: 'batch'}, 'output1': {0: 'batch'},
+                                            'output2': {0: 'batch'}, 'output3': {0: 'batch'}} if opt.dynamic else None)
 
             # Checks
             model_onnx = onnx.load(f)  # load onnx model


### PR DESCRIPTION
Pull request regarding bug #3444 to fix the dynamic output shape issue.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced ONNX export functionality in YOLOv5.

### 📊 Key Changes
- 🛠 Refactored ONNX export arguments, separating `input_names` and `output_names`.
- 📐 Updated `dynamic_axes` definitions for inputs and outputs during ONNX export.

### 🎯 Purpose & Impact
- 🎨 Provides clearer code structure around names of inputs and outputs, easing understanding and maintenance.
- 🌉 Ensures better compatibility and flexibility with ONNX by explicitly naming inputs and outputs and adjusting dynamic axes, facilitating easier integration with ONNX-compatible tools.
- 💼 This may benefit users requiring custom input/output handling when exporting their models to ONNX, improving the model's interoperability and deployment potential.