### PR TITLE
Add `check_git_status()` 5 second timeout

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -38,9 +38,9 @@ os.environ['NUMEXPR_MAX_THREADS'] = str(min(os.cpu_count(), 8))  # NumExpr max t
 
 class timeout(contextlib.ContextDecorator):
     # Usage: @timeout(seconds) decorator or 'with timeout(seconds):' context manager
-    def __init__(self, seconds, *, timeout_message="", suppress_timeout_errors=True):
+    def __init__(self, seconds, *, timeout_msg='', suppress_timeout_errors=True):
         self.seconds = int(seconds)
-        self.timeout_message = timeout_message
+        self.timeout_message = timeout_msg
         self.suppress = bool(suppress_timeout_errors)
 
     def _timeout_handler(self, signum, frame):
@@ -114,6 +114,7 @@ def check_online():
         return False
 
 
+@timeout(5, timeout_msg='skipping (timeout). For YOLOv5 updates check https://github.com/ultralytics/yolov5')
 def check_git_status():
     # Recommend 'git pull' if code is out of date
     print(colorstr('github: '), end='')

--- a/utils/general.py
+++ b/utils/general.py
@@ -114,7 +114,7 @@ def check_online():
         return False
 
 
-@timeout(5, timeout_msg='skipping (timeout). For YOLOv5 updates check https://github.com/ultralytics/yolov5')
+@timeout(5, timeout_msg='skipping (timeout). For YOLOv5 updates see https://github.com/ultralytics/yolov5')
 def check_git_status():
     # Recommend 'git pull' if code is out of date
     print(colorstr('github: '), end='')


### PR DESCRIPTION
This uses the new `timeout` class implemented in https://github.com/ultralytics/yolov5/pull/3460 to prevent the SSH Git bug that we were discussing @KalenMike

@AyushExel see this PR for example usage, might be applicable to the W&B timeout we were discussing.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved code maintainability and error messaging in `utils/general.py`.

### 📊 Key Changes
- Replaced direct usage of `subprocess` with `subprocess.check_output` import to streamline subprocess calls.
- Simplified the timeout class's parameter `timeout_message` to `timeout_msg`.
- Enhanced `check_git_status` with a default error message providing update instructions.
- Implemented a 5-second timeout for `check_output` calls in `check_git_status` to avoid hanging.

### 🎯 Purpose & Impact
- 🛠️ These revisions enhance code clarity and consistency, making future maintenance easier.
- 🚀 With the timeout for git operations, the code is safeguarded against potential delays due to network issues, leading to a smoother user experience.
- 📢 The added error messaging in `check_git_status` guides users more clearly when encountering issues, helping them to resolve problems on their own.

Overall, these updates should not affect the end functionality for users, but rather provide a more robust and user-friendly interaction with the code.