### PR TITLE
Improved `check_requirements()` offline-handling

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -163,10 +163,11 @@ def check_requirements(requirements='requirements.txt', exclude=()):
         try:
             pkg.require(r)
         except Exception as e:  # DistributionNotFound or VersionConflict if requirements not met
-            n += 1
             print(f"{prefix} {r} not found and is required by YOLOv5, attempting auto-update...")
             try:
+                assert check_online(), f"'pip install {r}' skipped (offline)"
                 print(check_output(f"pip install '{r}'", shell=True).decode())
+                n += 1
             except Exception as e:
                 print(f'{prefix} {e}')
 


### PR DESCRIPTION
Improve robustness of `check_requirements()` function to offline environments (do not attempt pip installs when offline).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved package installation robustness in YOLOv5 by handling offline scenarios.

### 📊 Key Changes
- Added an assert statement to check for internet connectivity before attempting to auto-update missing or outdated packages.
- Incremented the package counter `n` only after the package installation attempt is made, rather than upon failure detection.

### 🎯 Purpose & Impact
- **Ensures Reliability**: The new check prevents the system from attempting to install packages when there is no internet connection, which could lead to failure messages or crashes.
- **Enhances User Feedback**: Users are now informed about connectivity issues before YOLOv5 tries to install required packages, resulting in a better user experience.
- **Maintains Count Accuracy**: Updating the counter after the installation attempt ensures that only attempted installations are counted, providing more accurate feedback to the user about the installation process.