### PR TITLE
Replace self.inplace with getattr for *.pt weights back-compatability

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -56,7 +56,7 @@ class Detect(nn.Module):
                     self.grid[i] = self._make_grid(nx, ny).to(x[i].device)
 
                 y = x[i].sigmoid()
-                if self.inplace:
+                if getattr(self, 'inplace', False):  # for *.pt weights back-compatability
                     y[..., 0:2] = (y[..., 0:2] * 2. - 0.5 + self.grid[i]) * self.stride[i]  # xy
                     y[..., 2:4] = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
                 else:  # for YOLOv5 on AWS Inferentia https://github.com/ultralytics/yolov5/pull/2953


### PR DESCRIPTION
Since `Detect` module in YOLOv5 v5.0 *.pt models has no `inplace` attribute, using `self.inplace` results in `AttributeError`( `inplace` not found).
Replace `self.inplace` with `getattr` with a default False value address this issue.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved backwards compatibility for YOLOv5 model weights.

### 📊 Key Changes
- Modified the `inplace` attribute check in the forward method to ensure compatibility with older `*.pt` model weights.

### 🎯 Purpose & Impact
- 🥅 **Purpose:** The change is meant to maintain support for loading and using older YOLOv5 model weights without encountering attribute errors.
- 💡 **Impact:** This ensures that users with legacy model files can still use the latest version of the codebase without issues, facilitating a smoother upgrade path and broadening model support.