### PR TITLE
check_requirements() exclude `opencv-python`

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -30,7 +30,8 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
     from utils.google_utils import attempt_download
     from utils.torch_utils import select_device
 
-    check_requirements(Path(__file__).parent / 'requirements.txt', exclude=('tensorboard', 'pycocotools', 'thop'))
+    check_requirements(requirements=Path(__file__).parent / 'requirements.txt',
+                       exclude=('tensorboard', 'pycocotools', 'thop', 'opencv-python'))
     set_logging(verbose=verbose)
 
     fname = Path(name).with_suffix('.pt')  # checkpoint filename


### PR DESCRIPTION
Fix for 3rd party or contrib versions of installed OpenCV and/or Jetson Nano environments as in https://github.com/ultralytics/yolov5/issues/3494.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced dependency management for YOLOv5 models.

### 📊 Key Changes
- Updated the `check_requirements` function call to explicitly exclude 'opencv-python' alongside previously excluded packages.

### 🎯 Purpose & Impact
- **Purpose:** The change aims to prevent unnecessary installation or verification of the 'opencv-python' package, possibly due to compatibility issues or to streamline the setup process.
- **Impact:** This update likely makes the installation process smoother for users by avoiding potential conflicts or errors related to the 'opencv-python' library, ensuring a better initial setup experience.