### PR TITLE
check_requirements() exclude `opencv-python`

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -30,7 +30,8 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
     from utils.google_utils import attempt_download
     from utils.torch_utils import select_device
 
-    check_requirements(Path(__file__).parent / 'requirements.txt', exclude=('tensorboard', 'pycocotools', 'thop'))
+    check_requirements(requirements=Path(__file__).parent / 'requirements.txt',
+                       exclude=('tensorboard', 'pycocotools', 'thop', 'opencv-python'))
     set_logging(verbose=verbose)
 
     fname = Path(name).with_suffix('.pt')  # checkpoint filename


### PR DESCRIPTION
Duplicate of #3495 merged to `develop`. This PR will be merged to `master`.

Fixes https://github.com/ultralytics/yolov5/issues/3494.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced dependency checks for YOLOv5 model setup.

### 📊 Key Changes
- Modified the `check_requirements` function call in `hubconf.py`.
- Excluded `opencv-python` from the installation requirements check list.

### 🎯 Purpose & Impact
- **Purpose:** Streamline the setup process by preventing unnecessary checks for `opencv-python` during the model's initialization. This can help avoid conflicts or issues when `opencv-python` is not needed for certain users.
- **Impact:** Users who don't require `opencv-python` for their specific use cases will have a smoother setup experience with reduced chances of installation issues. The change could also potentially speed up the setup for all users, making the overall process more efficient. 🚀