### PR TITLE
early assert for cpu and half option

### DIFF
--- a/models/export.py
+++ b/models/export.py
@@ -44,13 +44,14 @@ if __name__ == '__main__':
 
     # Load PyTorch model
     device = select_device(opt.device)
+    assert not (opt.device.lower() == 'cpu' and opt.half), '--half only compatible with GPU export, i.e. use --device 0'
+    
     model = attempt_load(opt.weights, map_location=device)  # load FP32 model
     labels = model.names
 
     # Checks
     gs = int(max(model.stride))  # grid size (max stride)
     opt.img_size = [check_img_size(x, gs) for x in opt.img_size]  # verify img_size are gs-multiples
-    assert not (opt.device.lower() == 'cpu' and opt.half), '--half only compatible with GPU export, i.e. use --device 0'
 
     # Input
     img = torch.zeros(opt.batch_size, 3, *opt.img_size).to(device)  # image size(1,3,320,192) iDetection

--- a/models/export.py
+++ b/models/export.py
@@ -45,15 +45,12 @@ if __name__ == '__main__':
     # Load PyTorch model
     device = select_device(opt.device)
     assert not (opt.device.lower() == 'cpu' and opt.half), '--half only compatible with GPU export, i.e. use --device 0'
-    
     model = attempt_load(opt.weights, map_location=device)  # load FP32 model
     labels = model.names
 
-    # Checks
+    # Input
     gs = int(max(model.stride))  # grid size (max stride)
     opt.img_size = [check_img_size(x, gs) for x in opt.img_size]  # verify img_size are gs-multiples
-
-    # Input
     img = torch.zeros(opt.batch_size, 3, *opt.img_size).to(device)  # image size(1,3,320,192) iDetection
 
     # Update model


### PR DESCRIPTION
early assert for cpu and half option

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced validation for mixed precision export in YOLOv5 model export script.

### 📊 Key Changes
- Added an assertion to prevent using the `--half` option when exporting the model to run on CPU.
- Cleaned code by reorganizing checks and input handling.

### 🎯 Purpose & Impact
- This change ensures users don't attempt to export models in half precision (FP16) when using a CPU, which isn't compatible. This prevents potential confusion and encourages correct usage.
- Simplifies the code structure for better readability and maintainability.

🛠️ Users can expect clearer instructions and error messages, preventing mishaps during model export. It helps in maintaining a smoother workflow for those utilizing YOLOv5 models across different hardware platforms.🖥️🔍