### PR TITLE
Reduce test.py results spacing

### DIFF
--- a/test.py
+++ b/test.py
@@ -95,7 +95,7 @@ def test(data,
     confusion_matrix = ConfusionMatrix(nc=nc)
     names = {k: v for k, v in enumerate(model.names if hasattr(model, 'names') else model.module.names)}
     coco91class = coco80_to_coco91_class()
-    s = ('%20s' + '%12s' * 6) % ('Class', 'Images', 'Labels', 'P', 'R', 'mAP@.5', 'mAP@.5:.95')
+    s = ('%20s' + '%11s' * 6) % ('Class', 'Images', 'Labels', 'P', 'R', 'mAP@.5', 'mAP@.5:.95')
     p, r, f1, mp, mr, map50, map, t0, t1 = 0., 0., 0., 0., 0., 0., 0., 0., 0.
     loss = torch.zeros(3, device=device)
     jdict, stats, ap, ap_class, wandb_images = [], [], [], [], []
@@ -228,7 +228,7 @@ def test(data,
         nt = torch.zeros(1)
 
     # Print results
-    pf = '%20s' + '%12i' * 2 + '%12.3g' * 4  # print format
+    pf = '%20s' + '%11i' * 2 + '%11.3g' * 4  # print format
     print(pf % ('all', seen, nt.sum(), mp, mr, map50, map))
 
     # Print results per class


### PR DESCRIPTION
Should eliminate line-wrapping in notebook train section:
https://github.com/ultralytics/yolov5/blob/develop/tutorial.ipynb

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjustment in output formatting for test results in YOLOv5.

### 📊 Key Changes
- Modified the spacing in the string formatter used for displaying test results in the console.
- The number of spaces reserved for each output metric has been changed from 12 to 11. 

### 🎯 Purpose & Impact
- The purpose of this change is likely to improve readability or alignment of the test output.
- Users will experience a slight change in the way test results are presented, with no impact on functionality or performance. 
- The update might enhance visual clarity when users review the metrics of their trained models, contributing to a better user experience. 📈