### PR TITLE
simplify the way to load annotation file

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -473,13 +473,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
                 # verify labels
                 if os.path.isfile(lb_file):
                     nf += 1  # label found
-                    with open(lb_file, 'r') as f:
-                        l = [x.split() for x in f.read().strip().splitlines() if len(x)]
-                        if any([len(x) > 8 for x in l]):  # is segment
-                            classes = np.array([x[0] for x in l], dtype=np.float32)
-                            segments = [np.array(x[1:], dtype=np.float32).reshape(-1, 2) for x in l]  # (cls, xy1...)
-                            l = np.concatenate((classes.reshape(-1, 1), segments2boxes(segments)), 1)  # (cls, xywh)
-                        l = np.array(l, dtype=np.float32)
+                    l = np.loadtxt(lb_file, dtype=np.float32).reshape(-1, 5)
                     if len(l):
                         assert l.shape[1] == 5, 'labels require 5 columns each'
                         assert (l >= 0).all(), 'negative labels'


### PR DESCRIPTION
simplify the way to load annotation file

@glenn-jocher 

How about this way in terms of readability?

The below code is simple example code.

```python
import numpy as np

gt_file = np.array([[0, 0.5, 0.5, 0.5, 0.5],
                   [1, 0.5, 0.5, 0.5, 0.5]]).reshape(-1, 5)

np.savetxt("gt_file.txt", gt_file)

gt_file = np.loadtxt("gt_file.txt", dtype=np.float32).reshape(-1, 5)

print(gt_file)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplified label loading process in YOLOv5 datasets.

### 📊 Key Changes
- Removed complex label parsing logic with multiple condition checks.
- Replaced with a streamlined `np.loadtxt` for direct reading and reshaping of label files.

### 🎯 Purpose & Impact
- **Purpose**: To streamline the process of loading labels for images, making the codebase simpler and potentially faster.
- **Impact**: Users should experience more efficient label loading with fewer opportunities for errors during the label verification process. 🚀