### PR TITLE
Update FP16 `--half` argument for test.py and detect.py

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -172,7 +172,7 @@ if __name__ == '__main__':
     parser.add_argument('--line-thickness', default=3, type=int, help='bounding box thickness (pixels)')
     parser.add_argument('--hide-labels', default=False, action='store_true', help='hide labels')
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
-    parser.add_argument('--half', type=bool, default=False, help='use FP16 half-precision inference')
+    parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     opt = parser.parse_args()
     print(opt)
     check_requirements(exclude=('tensorboard', 'pycocotools', 'thop'))

--- a/test.py
+++ b/test.py
@@ -306,7 +306,7 @@ if __name__ == '__main__':
     parser.add_argument('--project', default='runs/test', help='save to project/name')
     parser.add_argument('--name', default='exp', help='save to project/name')
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
-    parser.add_argument('--half', type=bool, default=False, help='use FP16 half-precision inference')
+    parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     opt = parser.parse_args()
     opt.save_json |= opt.data.endswith('coco.yaml')
     opt.data = check_file(opt.data)  # check file


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved command-line argument parsing for half-precision inference.

### 📊 Key Changes
- Changed the `--half` argument to use `action='store_true'` instead of `type=bool` for better command-line usability.

### 🎯 Purpose & Impact
- **Enhances Usability:** Simplifies how users enable half-precision inference by just including the flag (`--half`) rather than specifying a boolean value.
- **Avoids Confusion:** Prevents potential user errors where the incorrect passage of boolean values could lead to unexpected behavior.
- **Impact on Users:** Users can more intuitively activate FP16 inference to potentially speed up model inference on compatible hardware.