### PR TITLE
Update `dataset_stats()` for HUB

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -1094,11 +1094,9 @@ def dataset_stats(path='coco128.yaml', autodownload=False, verbose=False):
         autodownload:   Attempt to download dataset if not found locally
         verbose:        Print stats dictionary
     """
-    path = check_file(Path(path))
-    with open(path) as f:
+    with open(check_file(Path(path))) as f:
         data = yaml.safe_load(f)  # data dict
     check_dataset(data, autodownload)  # download dataset if missing
-
     nc = data['nc']  # number of classes
     stats = {'nc': nc, 'names': data['names']}  # statistics dictionary
     for split in 'train', 'val', 'test':

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -1086,17 +1086,18 @@ def verify_image_label(params):
         return [None] * 4 + [nm, nf, ne, nc]
 
 
-def dataset_stats(path='coco128.yaml', verbose=False):
+def dataset_stats(path='coco128.yaml', autodownload=False, verbose=False):
     """ Return dataset statistics dictionary with images and instances counts per split per class
-    Usage: from utils.datasets import *; dataset_stats('coco128.yaml')
+    Usage: from utils.datasets import *; dataset_stats('coco128.yaml', verbose=True)
     Arguments
         path:           Path to data.yaml
+        autodownload:   Attempt to download dataset if not found locally
         verbose:        Print stats dictionary
     """
     path = check_file(Path(path))
     with open(path) as f:
         data = yaml.safe_load(f)  # data dict
-    check_dataset(data)  # download dataset if missing
+    check_dataset(data, autodownload)  # download dataset if missing
 
     nc = data['nc']  # number of classes
     stats = {'nc': nc, 'names': data['names']}  # statistics dictionary

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -1086,9 +1086,9 @@ def verify_image_label(params):
         return [None] * 4 + [nm, nf, ne, nc]
 
 
-def dataset_stats(path='data/coco128.yaml', verbose=False):
+def dataset_stats(path='coco128.yaml', verbose=False):
     """ Return dataset statistics dictionary with images and instances counts per split per class
-    Usage: from utils.datasets import *; dataset_stats('data/coco128.yaml')
+    Usage: from utils.datasets import *; dataset_stats('coco128.yaml')
     Arguments
         path:           Path to data.yaml
         verbose:        Print stats dictionary

--- a/utils/general.py
+++ b/utils/general.py
@@ -220,14 +220,14 @@ def check_file(file):
         return files[0]  # return file
 
 
-def check_dataset(dict):
+def check_dataset(data, autodownload=True):
     # Download dataset if not found locally
-    val, s = dict.get('val'), dict.get('download')
+    val, s = data.get('val'), data.get('download')
     if val and len(val):
         val = [Path(x).resolve() for x in (val if isinstance(val, list) else [val])]  # val path
         if not all(x.exists() for x in val):
             print('\nWARNING: Dataset not found, nonexistent paths: %s' % [str(x) for x in val if not x.exists()])
-            if s and len(s):  # download script
+            if s and len(s) and autodownload:  # download script
                 if s.startswith('http') and s.endswith('.zip'):  # URL
                     f = Path(s).name  # filename
                     print(f'Downloading {s} ...')


### PR DESCRIPTION
Cleanup of b6fdd2e

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced dataset handling with autodownload feature and simplified usage.

### 📊 Key Changes
- Added an `autodownload` parameter to the `dataset_stats` function for conditional dataset downloading.
- Simplified data file paths by removing the 'data/' prefix from the default path argument.
- Streamlined the process of checking dataset existence and potential automatic download within `check_dataset` function.

### 🎯 Purpose & Impact
- 🔄 **Purpose**: The updates are intended to give users more control over dataset downloads and streamline the developer experience when working with datasets.
- ⬇️ **Impact**: Users now have the option to automatically download missing datasets during stat checks, reducing manual download steps, and potential errors associated with missing data. The simplification of the file paths makes the API smoother and more user-friendly.