### PR TITLE
On-demand `pycocotools` pip install

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -175,7 +175,7 @@ if __name__ == '__main__':
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     opt = parser.parse_args()
     print(opt)
-    check_requirements(exclude=('tensorboard', 'pycocotools', 'thop'))
+    check_requirements(exclude=('tensorboard', 'thop'))
 
     if opt.update:  # update all models (to fix SourceChangeWarning)
         for opt.weights in ['yolov5s.pt', 'yolov5m.pt', 'yolov5l.pt', 'yolov5x.pt']:

--- a/hubconf.py
+++ b/hubconf.py
@@ -31,7 +31,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
     from utils.torch_utils import select_device
 
     check_requirements(requirements=Path(__file__).parent / 'requirements.txt',
-                       exclude=('tensorboard', 'pycocotools', 'thop', 'opencv-python'))
+                       exclude=('tensorboard', 'thop', 'opencv-python'))
     set_logging(verbose=verbose)
 
     fname = Path(name).with_suffix('.pt')  # checkpoint filename

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ pandas
 
 # extras --------------------------------------
 # Cython  # for pycocotools https://github.com/cocodataset/cocoapi/issues/172
-pycocotools>=2.0  # COCO mAP
+# pycocotools>=2.0  # COCO mAP
 thop  # FLOPs computation

--- a/test.py
+++ b/test.py
@@ -260,6 +260,7 @@ def test(data,
             json.dump(jdict, f)
 
         try:  # https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocoEvalDemo.ipynb
+            check_requirements(['pycocotools'])
             from pycocotools.coco import COCO
             from pycocotools.cocoeval import COCOeval
 
@@ -311,7 +312,7 @@ if __name__ == '__main__':
     opt.save_json |= opt.data.endswith('coco.yaml')
     opt.data = check_file(opt.data)  # check file
     print(opt)
-    check_requirements(exclude=('tensorboard', 'pycocotools', 'thop'))
+    check_requirements(exclude=('tensorboard', 'thop'))
 
     if opt.task in ('train', 'val', 'test'):  # run normally
         test(opt.data,

--- a/train.py
+++ b/train.py
@@ -495,7 +495,7 @@ if __name__ == '__main__':
     set_logging(opt.global_rank)
     if opt.global_rank in [-1, 0]:
         check_git_status()
-        check_requirements(exclude=('pycocotools', 'thop'))
+        check_requirements(exclude=['thop'])
 
     # Resume
     wandb_run = check_wandb_resume(opt)


### PR DESCRIPTION
Comments `pycocotools` from requirements.txt and instead scans and installs the package on demand when needed in test.py.

Possible fix for https://github.com/ultralytics/yolov5/issues/3543

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updates to dependency management and conditional requirement checks in YOLOv5's various scripts.

### 📊 Key Changes
- 🧹 Removed `pycocotools` from the excluded list in `check_requirements` in `detect.py`, `hubconf.py`, `test.py`, and `train.py`.
- 🚫 Commented out `pycocotools` in `requirements.txt`, changing its installation from mandatory to optional.
- ✅ Added a dynamic requirement check for `pycocotools` within the `test.py` script before using it.

### 🎯 Purpose & Impact
- **Simpler Installation:** The removal of `pycocotools` from the default requirements reduces installation complexity for users who do not need COCO mAP functionality, making it lighter and potentially avoiding compatibility issues.
- **Conditional Requirement:** By checking for `pycocotools` only where it's necessary (`test.py`), the impact is that only users performing COCO evaluation will need to install this dependency.
- **User Flexibility:** This approach provides more flexibility for users, only prompting for installation of additional packages when they are needed for specific functionality.