### PR TITLE
Update `check_python(minimum=3.6.2)`

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -136,7 +136,7 @@ def check_git_status(err_msg=', for updates see https://github.com/ultralytics/y
         print(f'{e}{err_msg}')
 
 
-def check_python(minimum='3.7.0', required=True):
+def check_python(minimum='3.6.2', required=True):
     # Check current python version vs. required python version
     current = platform.python_version()
     result = pkg.parse_version(current) >= pkg.parse_version(minimum)


### PR DESCRIPTION
In looking at the `torch` package they have a minimum of 3.6.2, we should probably stick to that, which I think will keep the R Pi people happy who run on 3.6.9.
https://pypi.org/project/torch/

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated the minimum required Python version for compatibility.

### 📊 Key Changes
- The minimum Python version check has been lowered from `3.7.0` to `3.6.2`.

### 🎯 Purpose & Impact
- **Purpose:** This change makes the software accessible to users who are running slightly older Python versions.
- **Impact:** Expands the user base by allowing installation on systems with Python `3.6.2+`, while previously systems needed `3.7.0+`. This can be particularly beneficial for those on environments with restrictions on software updates.🔄