### PR TITLE
Remove `is_coco` argument from `test()`

### DIFF
--- a/test.py
+++ b/test.py
@@ -39,7 +39,6 @@ def test(data,
          wandb_logger=None,
          compute_loss=None,
          half_precision=True,
-         is_coco=False,
          opt=None):
     # Initialize/load model and set device
     training = model is not None
@@ -71,10 +70,10 @@ def test(data,
     # Configure
     model.eval()
     if isinstance(data, str):
-        is_coco = data.endswith('coco.yaml')
         with open(data) as f:
             data = yaml.safe_load(f)
     check_dataset(data)  # check
+    is_coco = data['val'].endswith('coco/val2017.txt')  # COCO dataset
     nc = 1 if single_cls else int(data['nc'])  # number of classes
     iouv = torch.linspace(0.5, 0.95, 10).to(device)  # iou vector for mAP@0.5:0.95
     niou = iouv.numel()

--- a/train.py
+++ b/train.py
@@ -365,8 +365,7 @@ def train(hyp, opt, device, tb_writer=None):
                                                  verbose=nc < 50 and final_epoch,
                                                  plots=plots and final_epoch,
                                                  wandb_logger=wandb_logger,
-                                                 compute_loss=compute_loss,
-                                                 is_coco=is_coco)
+                                                 compute_loss=compute_loss)
 
             # Write
             with open(results_file, 'a') as f:
@@ -434,8 +433,7 @@ def train(hyp, opt, device, tb_writer=None):
                                               dataloader=testloader,
                                               save_dir=save_dir,
                                               save_json=True,
-                                              plots=False,
-                                              is_coco=is_coco)
+                                              plots=False)
 
             # Strip optimizers
             for f in last, best:


### PR DESCRIPTION
@AyushExel I'm removing the `is_coco` argument from test() in test.py, we'll do the determination directly in test(). This should reduce arguments and simplify things a bit.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlining the `is_coco` parameter across test and train scripts.

### 📊 Key Changes
- Removed the `is_coco` parameter from the function signatures in `test.py` and `train.py`.
- Added automatic COCO dataset detection in `test.py` based on the dataset's validation file path.

### 🎯 Purpose & Impact
- **Simplicity**: Removes the need for manual specification of the `is_coco` flag, reducing the complexity of method calls.
- **Automation**: Enhances the user experience by auto-detecting if the dataset used is COCO, which could reduce configuration errors and streamline dataset handling.
- **Potential Impact**: Users no longer have to worry about a separate `is_coco` flag during testing and training, which simplifies the codebase and reduces potential bugs or misconfigurations.