### PR TITLE
Multi-GPU default to single device 0

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -72,7 +72,7 @@ def select_device(device='', batch_size=None):
 
     cuda = not cpu and torch.cuda.is_available()
     if cuda:
-        devices = device.split(',') if device else range(torch.cuda.device_count())  # i.e. 0,1,6,7
+        devices = device.split(',') if device else '0'  # range(torch.cuda.device_count())  # i.e. 0,1,6,7
         n = len(devices)  # device count
         if n > 1 and batch_size:  # check batch_size is divisible by device_count
             assert batch_size % n == 0, f'batch-size {batch_size} not multiple of GPU count {n}'

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -76,7 +76,7 @@ def select_device(device='', batch_size=None):
         n = len(devices)  # device count
         if n > 1 and batch_size:  # check batch_size is divisible by device_count
             assert batch_size % n == 0, f'batch-size {batch_size} not multiple of GPU count {n}'
-        space = ' ' * len(s)
+        space = ' ' * (len(s) + 1)
         for i, d in enumerate(devices):
             p = torch.cuda.get_device_properties(i)
             s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / 1024 ** 2}MB)\n"  # bytes to MB


### PR DESCRIPTION
Default to device 0 on Multi-GPU systems. This may help prevent instances of DP training when DDP commands should be used for best results. See [Multi-GPU Tutorial](https://github.com/ultralytics/yolov5/issues/475) for full details.

## WARNING: BREAKING WORKFLOW CHANGES

- **Previously**: all available GPUs were used on Multi-GPU systems if no `--device` was passed.
- **This update**: device 0 will be used by default on Multi-GPU systems if no `--device`. You now need to **opt-in** to any GPU groupings using the `--device` argument, i.e. `python train.py --device 0,1,2,3`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplified default GPU selection in YOLOv5's device utility.

### 📊 Key Changes
- Changed the default GPU device from a range of all available GPUs to just '0' (the first GPU).
- Adjusted the padding space for better alignment in the printed output.

### 🎯 Purpose & Impact
- Ensures a single GPU is used by default, preventing possible unintended use of multiple GPUs when the device is unspecified.
- Improves the readability of the output by neatly aligning the CUDA device information.
- This change will mostly affect users who do not specify the GPUs they want to use; it ensures the script doesn't accidentally occupy all available GPUs, which is important for shared systems.