### PR TITLE
Remove redundant speed/study `half` argument

### DIFF
--- a/test.py
+++ b/test.py
@@ -336,8 +336,7 @@ if __name__ == '__main__':
 
     elif opt.task == 'speed':  # speed benchmarks
         for w in opt.weights if isinstance(opt.weights, list) else [opt.weights]:
-            test(opt.data, w, opt.batch_size, opt.img_size, 0.25, 0.45, save_json=False, plots=False, half=True,
-                 opt=opt)
+            test(opt.data, w, opt.batch_size, opt.img_size, 0.25, 0.45, save_json=False, plots=False, opt=opt)
 
     elif opt.task == 'study':  # run over a range of settings and save/plot
         # python test.py --task study --data coco.yaml --iou 0.7 --weights yolov5s.pt yolov5m.pt yolov5l.pt yolov5x.pt
@@ -348,7 +347,7 @@ if __name__ == '__main__':
             for i in x:  # img-size
                 print(f'\nRunning {f} point {i}...')
                 r, _, t = test(opt.data, w, opt.batch_size, i, opt.conf_thres, opt.iou_thres, opt.save_json,
-                               plots=False, half=True, opt=opt)
+                               plots=False, opt=opt)
                 y.append(r + t)  # results and times
             np.savetxt(f, y, fmt='%10.4g')  # save
         os.system('zip -r study.zip study_*.txt')


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlined benchmark and study test arguments in YOLOv5 `test.py`.

### 📊 Key Changes
- Removed the `half` parameter from test function calls within 'speed' and 'study' tasks.
- Simplified the function call by omitting an explicit argument for mixed precision testing.

### 🎯 Purpose & Impact
- **Simplification**: Removing the `half` parameter simplifies the code and could potentially centralize mixed precision handling within the test function itself.
- **Consistency**: Ensures consistent function calls across different testing scenarios.
- **Performance**: This change may impact how the model runs during testing scenarios, particularly how it handles mixed precision for speed benchmarks and study tasks.