### PR TITLE
Add ConfusionMatrix `normalize=True` flag

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -158,11 +158,12 @@ class ConfusionMatrix:
     def matrix(self):
         return self.matrix
 
-    def plot(self, save_dir='', names=()):
+    def plot(self, normalize=True, save_dir='', names=()):
         try:
             import seaborn as sn
-
-            array = self.matrix / (self.matrix.sum(0).reshape(1, self.nc + 1) + 1E-6)  # normalize
+            
+            if normalize:
+                array = self.matrix / (self.matrix.sum(0).reshape(1, self.nc + 1) + 1E-6)  # normalize columns
             array[array < 0.005] = np.nan  # don't annotate (would appear as 0.00)
 
             fig = plt.figure(figsize=(12, 9), tight_layout=True)


### PR DESCRIPTION
Per #3533

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved customizable confusion matrix plotting in YOLOv5.

### 📊 Key Changes
- Added `normalize` parameter to the `plot` method within `utils/metrics.py`.
- Enabled optional normalization of the confusion matrix before plotting.

### 🎯 Purpose & Impact
- The `normalize` parameter allows users to choose whether or not they want to see their confusion matrix normalized, which provides flexibility in analyzing model performance.
- This can be especially useful for users wanting to understand the raw number of cases for each prediction category, or compare different models' performance more directly.
- The impact is mainly on improving the usability of the model evaluation tools, potentially making it easier for developers and data scientists to tune their models and communicate results. 📈