### PR TITLE
W&B: Allow changed in config variable

### DIFF
--- a/utils/wandb_logging/wandb_utils.py
+++ b/utils/wandb_logging/wandb_utils.py
@@ -103,7 +103,11 @@ class WandbLogger():
                 model_artifact_name = WANDB_ARTIFACT_PREFIX + model_artifact_name
                 assert wandb, 'install wandb to resume wandb runs'
                 # Resume wandb-artifact:// runs here| workaround for not overwriting wandb.config
-                self.wandb_run = wandb.init(id=run_id, project=project, entity=entity, resume='allow')
+                self.wandb_run = wandb.init(id=run_id,
+                                            project=project,
+                                            entity=entity,
+                                            resume='allow',
+                                            allow_val_change=True)
                 opt.resume = model_artifact_name
         elif self.wandb:
             self.wandb_run = wandb.init(config=opt,
@@ -112,7 +116,8 @@ class WandbLogger():
                                         entity=opt.entity,
                                         name=name,
                                         job_type=job_type,
-                                        id=run_id) if not wandb.run else wandb.run
+                                        id=run_id,
+                                        allow_val_change=True) if not wandb.run else wandb.run
         if self.wandb_run:
             if self.job_type == 'Training':
                 if not opt.resume:


### PR DESCRIPTION
Fix for #3583 
This issue has been reported 3 times, so I figured we should relax this sanity check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved flexibility in logging with Weights & Biases (W&B) 📈

### 📊 Key Changes
- Added `allow_val_change=True` to `wandb.init()` calls.
- Ensured W&B run initiation handles parameter changes gracefully.

### 🎯 Purpose & Impact
- **Purpose**: To address issues with resuming W&B runs where hyperparameters may change, potentially causing conflicts without this option.
- **Impact**: Users can now resume W&B training runs with modified hyperparameters without encountering errors, leading to a smoother experiment tracking and hyperparameter tuning experience. 🔄