### PR TITLE
Suppress wandb images size mismatch warning

### DIFF
--- a/utils/wandb_logging/wandb_utils.py
+++ b/utils/wandb_logging/wandb_utils.py
@@ -2,6 +2,9 @@
 import json
 import sys
 from pathlib import Path
+import logging
+from contextlib import contextmanager
+
 
 import torch
 import yaml
@@ -272,7 +275,7 @@ class WandbLogger():
                                  "box_caption": "%s" % (class_to_id[cls])})
                 img_classes[cls] = class_to_id[cls]
             boxes = {"ground_truth": {"box_data": box_data, "class_labels": class_to_id}}  # inference-space
-            table.add_data(si, wandb.Image(paths, classes=class_set, boxes=boxes), json.dumps(img_classes),
+            table.add_data(si, wandb.Image(paths, classes=class_set, boxes=boxes), list(img_classes.values()),
                            Path(paths).name)
         artifact.add(table, name)
         return artifact
@@ -306,8 +309,9 @@ class WandbLogger():
 
     def end_epoch(self, best_result=False):
         if self.wandb_run:
-            wandb.log(self.log_dict)
-            self.log_dict = {}
+            with all_logging_disabled():                
+                wandb.log(self.log_dict)
+                self.log_dict = {}
             if self.result_artifact:
                 train_results = wandb.JoinedTable(self.val_table, self.result_table, "id")
                 self.result_artifact.add(train_results, 'result')
@@ -321,3 +325,23 @@ class WandbLogger():
             if self.log_dict:
                 wandb.log(self.log_dict)
             wandb.run.finish()
+
+
+@contextmanager
+def all_logging_disabled(highest_level=logging.CRITICAL):
+    """
+    source - https://gist.github.com/simon-weber/7853144
+    A context manager that will prevent any logging messages
+    triggered during the body from being processed.
+    :param highest_level: the maximum logging level in use.
+      This would only need to be changed if a custom level greater than CRITICAL
+      is defined.
+    """
+    previous_level = logging.root.manager.disable
+
+    logging.disable(highest_level)
+
+    try:
+        yield
+    finally:
+        logging.disable(previous_level)

--- a/utils/wandb_logging/wandb_utils.py
+++ b/utils/wandb_logging/wandb_utils.py
@@ -323,7 +323,8 @@ class WandbLogger():
     def finish_run(self):
         if self.wandb_run:
             if self.log_dict:
-                wandb.log(self.log_dict)
+                with all_logging_disabled(): 
+                    wandb.log(self.log_dict)
             wandb.run.finish()
 
 

--- a/utils/wandb_logging/wandb_utils.py
+++ b/utils/wandb_logging/wandb_utils.py
@@ -1,19 +1,16 @@
 """Utilities and tools for tracking runs with Weights & Biases."""
-import json
-import sys
-from pathlib import Path
 import logging
+import sys
 from contextlib import contextmanager
+from pathlib import Path
 
-
-import torch
 import yaml
 from tqdm import tqdm
 
 sys.path.append(str(Path(__file__).parent.parent.parent))  # add utils/ to path
 from utils.datasets import LoadImagesAndLabels
 from utils.datasets import img2label_paths
-from utils.general import colorstr, xywh2xyxy, check_dataset, check_file
+from utils.general import colorstr, check_dataset, check_file
 
 try:
     import wandb
@@ -95,6 +92,7 @@ class WandbLogger():
     For more on how this logger is used, see the Weights & Biases documentation:
     https://docs.wandb.com/guides/integrations/yolov5
     """
+
     def __init__(self, opt, name, run_id, data_dict, job_type='Training'):
         # Pre-training routine --
         self.job_type = job_type
@@ -309,7 +307,7 @@ class WandbLogger():
 
     def end_epoch(self, best_result=False):
         if self.wandb_run:
-            with all_logging_disabled():                
+            with all_logging_disabled():
                 wandb.log(self.log_dict)
                 self.log_dict = {}
             if self.result_artifact:
@@ -323,25 +321,20 @@ class WandbLogger():
     def finish_run(self):
         if self.wandb_run:
             if self.log_dict:
-                with all_logging_disabled(): 
+                with all_logging_disabled():
                     wandb.log(self.log_dict)
             wandb.run.finish()
 
 
 @contextmanager
 def all_logging_disabled(highest_level=logging.CRITICAL):
-    """
-    source - https://gist.github.com/simon-weber/7853144
-    A context manager that will prevent any logging messages
-    triggered during the body from being processed.
+    """ source - https://gist.github.com/simon-weber/7853144
+    A context manager that will prevent any logging messages triggered during the body from being processed.
     :param highest_level: the maximum logging level in use.
-      This would only need to be changed if a custom level greater than CRITICAL
-      is defined.
+      This would only need to be changed if a custom level greater than CRITICAL is defined.
     """
     previous_level = logging.root.manager.disable
-
     logging.disable(highest_level)
-
     try:
         yield
     finally:


### PR DESCRIPTION
Addresses this issue https://github.com/ultralytics/yolov5/issues/3575
Run logs from this branch -> https://wandb.ai/cayush/yoloV5/runs/2f4wd84j/logs?workspace=user-cayush


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of Weights & Biases logging in YOLOv5 with proper logging control.

### 📊 Key Changes
- 🔧 Replaced `json` imports with `logging` for better log management.
- 💡 Added a `contextmanager` for temporarily disabling logging during specific operations.
- 🐞 Fixed the way image classes are logged in Wandb to use list of values instead of JSON strings.

### 🎯 Purpose & Impact
- 📈 Enhancing logging behaviour to ensure clean and clear logs without unnecessary clutter, especially for users tracking their model training in Weights & Biases.
- 🧹 Provides a cleaner way to handle cases when logging is not required, improving the readability of logs and reducing potential noise.
- ✅ Ensures image class data sent to Wandb is in the correct format, likely fixing a bug and providing better integration with Wandb features.