### PR TITLE
Fix incorrect end epoch

### DIFF
--- a/train.py
+++ b/train.py
@@ -341,8 +341,7 @@ def train(hyp, opt, device, tb_writer=None):
                                                   save_dir.glob('train*.jpg') if x.exists()]})
 
             # end batch ------------------------------------------------------------------------------------------------
-        # end epoch ----------------------------------------------------------------------------------------------------
-
+        
         # Scheduler
         lr = [x['lr'] for x in optimizer.param_groups]  # for tensorboard
         scheduler.step()


### PR DESCRIPTION
Epoch ends just before training ends, not just after batch ends.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved code cleanliness in the training loop of YOLOv5.

### 📊 Key Changes
- Removed unnecessary comments from the code.

### 🎯 Purpose & Impact
- The purpose of this change is to streamline the code by removing redundant comments, which makes the codebase cleaner and easier to read.
- This change has minimal direct impact on the end users but contributes to better code maintenance and clarity for developers working on the project. 🧹