### PR TITLE
Gracefully stop frame iteration

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -43,6 +43,8 @@ def detect(weights='yolov5s.pt',  # model.pt path(s)
     webcam = source.isnumeric() or source.endswith('.txt') or source.lower().startswith(
         ('rtsp://', 'rtmp://', 'http://', 'https://'))
 
+    stop_flag_path = Path('_detect_stop')
+
     # Directories
     save_dir = increment_path(Path(project) / name, exist_ok=exist_ok)  # increment run
     (save_dir / 'labels' if save_txt else save_dir).mkdir(parents=True, exist_ok=True)  # make dir
@@ -161,6 +163,10 @@ def detect(weights='yolov5s.pt',  # model.pt path(s)
                             save_path += '.mp4'
                         vid_writer = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
                     vid_writer.write(im0)
+
+        if stop_flag_path.exists():
+            print(f'Stop iterating frames (as `{stop_flag_path.name}` present in cwd)')
+            break
 
     if save_txt or save_img:
         s = f"\n{len(list(save_dir.glob('labels/*.txt')))} labels saved to {save_dir / 'labels'}" if save_txt else ''


### PR DESCRIPTION
Currently, there isn't (or at least I couldn't find) a way (other than <kbd>Ctrl + C</kbd>) to stop iterating frames in the dataset. This isn't very nice, and any possible action at the end is not carried out.

As a note, I see the *FS* approach as a last resort. A nicer way would be to act on user events (e.g. pressing <kbd>Esc</kbd>). But currently this is only possible by interpreting *cv2.waitKey* result (only when *--view-img* was passed). <br>A generic way would imply either:
- Introducing other modules (e.g. *keyboard*) dependencies
- Implementing it. As a side note, I wrote this functionality (via *select* on *Nix* and *msvcrt* on *Win*) and use it

but it's simply too complex, for its purpose.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced control over object detection with graceful stop feature.

### 📊 Key Changes
- 🆕 Added a feature to stop the detection process by checking for a file named `_detect_stop`.
- ✅ Enhanced the existing `detect.py` script by inserting a conditional stop mechanism during the frame iteration loop.

### 🎯 Purpose & Impact
- 🎮 Users can now interrupt the detection process in a controlled way by creating a file named `_detect_stop` in the current working directory.
- 🛑 This adds flexibility for longer-running detection tasks, allowing users to halt processing without resorting to more abrupt methods like killing the process.
- 👍 This feature can prevent unnecessary computation, saving time and resources, and provides a more user-friendly way to stop detections gracefully, which is especially useful during live video streaming or lengthy batch processing.