### PR TITLE
Assert non-premature end of JPEG images

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -1062,7 +1062,6 @@ def verify_image_label(args):
                 f.seek(-2, 2)
                 assert f.read() == b'\xff\xd9', 'corrupted JPEG'
 
-
         # verify labels
         segments = []  # instance segments
         if os.path.isfile(lb_file):

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -1057,6 +1057,11 @@ def verify_image_label(args):
         shape = exif_size(im)  # image size
         assert (shape[0] > 9) & (shape[1] > 9), f'image size {shape} <10 pixels'
         assert im.format.lower() in img_formats, f'invalid image format {im.format}'
+        if im.format.lower() in ('jpg', 'jpeg'):
+            with open(im_file, 'rb') as f:
+                f.seek(-2, 2)
+                assert f.read() == b'\xff\xd9', 'corrupted JPEG'
+
 
         # verify labels
         segments = []  # instance segments


### PR DESCRIPTION
`premature end of JPEG images` will occur when image is not complete. Add data checking in utils/datasets.py to avoid it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement in image verification to detect corrupted JPEG files.

### 📊 Key Changes
- Added a check to verify that JPEG images are not corrupted by ensuring they end with the proper byte sequence.

### 🎯 Purpose & Impact
- 🛡️ **Purpose**: To prevent issues during training or inference caused by loading corrupted JPEG images that may not be properly processed.
- 🛠️ **Impact**: Increases the reliability of the dataset by catching potentially problematic images early, ensuring more stable and robust model performance for users.