### PR TITLE
`is_coco` list fix

### DIFF
--- a/test.py
+++ b/test.py
@@ -78,7 +78,7 @@ def test(data,
         with open(data) as f:
             data = yaml.safe_load(f)
     check_dataset(data)  # check
-    is_coco = data['val'].endswith('coco/val2017.txt')  # COCO dataset
+    is_coco = type(data['val']) is str and data['val'].endswith('coco/val2017.txt')  # COCO dataset
     nc = 1 if single_cls else int(data['nc'])  # number of classes
     iouv = torch.linspace(0.5, 0.95, 10).to(device)  # iou vector for mAP@0.5:0.95
     niou = iouv.numel()


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved robustness in dataset type detection for COCO validation.

### 📊 Key Changes
- Enhanced the check for the COCO dataset by verifying the data type is a string before checking if the filepath ends with 'coco/val2017.txt'.

### 🎯 Purpose & Impact
- The purpose of the change is to prevent potential errors when the `data['val']` isn't a string but another data type, such as a list. This makes the COCO dataset detection more reliable.
- Users will benefit from reduced errors during test-time dataset checks, leading to smoother validation processes when using COCO or other datasets in their object detection tasks.