### PR TITLE
Update datasets.py

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -1076,7 +1076,7 @@ def verify_image_label(args):
             if len(l):
                 assert l.shape[1] == 5, 'labels require 5 columns each'
                 assert (l >= 0).all(), 'negative labels'
-                assert (l[:, 1:] <= 1).all(), 'non-normalized or out of bounds coordinate labels'
+                assert (l[:, 1:] <= 1), 'non-normalized or out of bounds coordinate labels'
                 assert np.unique(l, axis=0).shape[0] == l.shape[0], 'duplicate labels'
             else:
                 ne = 1  # label empty


### PR DESCRIPTION
Fixed judgment rules. If any of xmin, ymin, xmax, or ymax is out of bounds, it will be treated as out of bounds.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced validation for image labels in YOLOv5's dataset utilities.

### 📊 Key Changes
- Modified an assertion condition in the image and label verification routine.

### 🎯 Purpose & Impact
- 🎯 **Purpose:** The change ensures that individual label coordinates are checked for normalization and bounds errors rather than checking the entire set at once. This provides clearer error messages when specific label instances are incorrect.
- 💥 **Impact:** Improves the debugging process for developers and users by isolating improper label coordinates, making it easier to identify and fix data-related issues.