### PR TITLE
Fixed judgment rules. (#3656)

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -1075,8 +1075,8 @@ def verify_image_label(args):
                 l = np.array(l, dtype=np.float32)
             if len(l):
                 assert l.shape[1] == 5, 'labels require 5 columns each'
-                assert (l >= 0).all(), 'negative labels'
-                assert (l[:, 1:] <= 1).all(), 'non-normalized or out of bounds coordinate labels'
+                assert (l >= 0).any(), 'negative labels'
+                assert (l[:, 1:] <= 1).any(), 'non-normalized or out of bounds coordinate labels'
                 assert np.unique(l, axis=0).shape[0] == l.shape[0], 'duplicate labels'
             else:
                 ne = 1  # label empty


### PR DESCRIPTION
If any of xmin, ymin, xmax, or ymax is out of bounds, it will be treated as out of bounds.
If any of xmin, ymin, xmax, or ymax is negative, it will be treated as negative.
@glenn-jocher 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added tolerance for partial label data in dataset verification.

### 📊 Key Changes
- Changed assertions for verifying label values from `all()` to `any()`.

### 🎯 Purpose & Impact
- **Purpose**: To allow image labels that have at least one value within the expected range, providing more flexibility during the dataset verification stage.
- **Impact**: Users may experience a more lenient dataset verification process, potentially reducing the number of errors when labels contain some, but not exclusively, correct data. This could be particularly beneficial in datasets with minor inconsistencies. However, care should be taken as this could also introduce a risk of allowing some incorrect labels to go unnoticed.