### PR TITLE
Skip HSV augmentation when hyperparameters are [0, 0, 0]

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -632,20 +632,18 @@ def load_image(self, index):
 
 
 def augment_hsv(img, hgain=0.5, sgain=0.5, vgain=0.5):
-    if hgain == 0.0 and sgain == 0.0 and vgain == 0.0:
-        return
+    if hgain or sgain or vgain:
+        r = np.random.uniform(-1, 1, 3) * [hgain, sgain, vgain] + 1  # random gains
+        hue, sat, val = cv2.split(cv2.cvtColor(img, cv2.COLOR_BGR2HSV))
+        dtype = img.dtype  # uint8
 
-    r = np.random.uniform(-1, 1, 3) * [hgain, sgain, vgain] + 1  # random gains
-    hue, sat, val = cv2.split(cv2.cvtColor(img, cv2.COLOR_BGR2HSV))
-    dtype = img.dtype  # uint8
+        x = np.arange(0, 256, dtype=r.dtype)
+        lut_hue = ((x * r[0]) % 180).astype(dtype)
+        lut_sat = np.clip(x * r[1], 0, 255).astype(dtype)
+        lut_val = np.clip(x * r[2], 0, 255).astype(dtype)
 
-    x = np.arange(0, 256, dtype=r.dtype)
-    lut_hue = ((x * r[0]) % 180).astype(dtype)
-    lut_sat = np.clip(x * r[1], 0, 255).astype(dtype)
-    lut_val = np.clip(x * r[2], 0, 255).astype(dtype)
-
-    img_hsv = cv2.merge((cv2.LUT(hue, lut_hue), cv2.LUT(sat, lut_sat), cv2.LUT(val, lut_val)))
-    cv2.cvtColor(img_hsv, cv2.COLOR_HSV2BGR, dst=img)  # no return needed
+        img_hsv = cv2.merge((cv2.LUT(hue, lut_hue), cv2.LUT(sat, lut_sat), cv2.LUT(val, lut_val)))
+        cv2.cvtColor(img_hsv, cv2.COLOR_HSV2BGR, dst=img)  # no return needed
 
 
 def hist_equalize(img, clahe=True, bgr=False):

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -632,6 +632,9 @@ def load_image(self, index):
 
 
 def augment_hsv(img, hgain=0.5, sgain=0.5, vgain=0.5):
+    if hgain == 0.0 and sgain == 0.0 and vgain == 0.0:
+        return
+
     r = np.random.uniform(-1, 1, 3) * [hgain, sgain, vgain] + 1  # random gains
     hue, sat, val = cv2.split(cv2.cvtColor(img, cv2.COLOR_BGR2HSV))
     dtype = img.dtype  # uint8


### PR DESCRIPTION
When HSV hyperparameter are all zero, the color augmentation process doesn't change the image, so we should short-circuit it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced color augmentation efficiency in image preprocessing.

### 📊 Key Changes
- Introduced a conditional check to only perform color augmentation if any of the `hgain`, `sgain`, or `vgain` parameters is non-zero.
- Maintained the original color augmentation logic under this new conditional block.

### 🎯 Purpose & Impact
- **Purpose**: The update is designed to skip unnecessary computations if no color augmentation is required, which improves the performance of image preprocessing.
- **Impact**: Users can expect speed improvements in data loading when color augmentation is not used, leading to quicker training and inference times in certain scenarios. The change does not affect the outcome when augmentations are active. 🚀