### PR TITLE
Update cache check

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -390,7 +390,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         cache_path = (p if p.is_file() else Path(self.label_files[0]).parent).with_suffix('.cache')  # cached labels
         if cache_path.is_file():
             cache, exists = torch.load(cache_path), True  # load
-            if cache['hash'] != get_hash(self.label_files + self.img_files) or cache['version'] != 0.3:
+            if cache['version'] != 0.3 or cache['hash'] != get_hash(self.label_files + self.img_files):
                 cache, exists = self.cache_labels(cache_path, prefix), False  # re-cache
         else:
             cache, exists = self.cache_labels(cache_path, prefix), False  # cache


### PR DESCRIPTION
Swapped order of operations for faster first per https://github.com/ultralytics/yolov5/commit/f527704cd32c42bc0bba9cce04601783b8563204#r52362419

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of Dataset Caching Validation in YOLOv5.

### 📊 Key Changes
- Reordered the condition checking the `cache['version']` and `cache['hash']` in the dataset initialization.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: The reordering is likely intended for a minor performance optimization, prioritizing the check that is most likely to fail based on version changes before checking the file hashes.
- 💡 **Impact**: The alteration may speed up the dataset loading process slightly, particularly when the cache version is outdated, saving time for users when they start training models or use the dataset. However, the overall impact on the end user's experience should be minimal.