### PR TITLE
Update DDP backend `if dist.is_nccl_available()`

### DIFF
--- a/train.py
+++ b/train.py
@@ -539,7 +539,7 @@ def main(opt):
         assert torch.cuda.device_count() > LOCAL_RANK, 'insufficient CUDA devices for DDP command'
         torch.cuda.set_device(LOCAL_RANK)
         device = torch.device('cuda', LOCAL_RANK)
-        dist.init_process_group(backend="gloo", timeout=timedelta(seconds=60))
+        dist.init_process_group(backend="nccl" if dist.is_nccl_available() else "gloo", timeout=timedelta(seconds=60))
         assert opt.batch_size % WORLD_SIZE == 0, '--batch-size must be multiple of CUDA device count'
         assert not opt.image_weights, '--image-weights argument is not compatible with DDP training'
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Distributed Data Parallel (DDP) backend selection in training script.

### 📊 Key Changes
- The DDP backend now dynamically selects "nccl" if available, otherwise falls back to "gloo".

### 🎯 Purpose & Impact
- This change optimizes the parallel data processing by preferring "nccl", which is generally faster and more suitable for GPUs. 🔥
- It ensures better performance and efficiency during multi-GPU training, leading to potentially faster training times and lower resource consumption. 🚀
- The fallback to "gloo" ensures compatibility, so there's no negative impact on users without "nccl" support. 👍