### PR TITLE
Fix `img2label_paths()` order

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -348,7 +348,7 @@ class LoadStreams:  # multiple IP or RTSP cameras
 def img2label_paths(img_paths):
     # Define label paths as a function of image paths
     sa, sb = os.sep + 'images' + os.sep, os.sep + 'labels' + os.sep  # /images/, /labels/ substrings
-    return ['txt'.join(x.replace(sa, sb, 1).rsplit(x.split('.')[-1], 1)) for x in img_paths]
+    return [sb.join(x.rsplit(sa, 1)).rsplit('.')[0] + '.txt' for x in img_paths]
 
 
 class LoadImagesAndLabels(Dataset):  # for training/testing

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -348,7 +348,7 @@ class LoadStreams:  # multiple IP or RTSP cameras
 def img2label_paths(img_paths):
     # Define label paths as a function of image paths
     sa, sb = os.sep + 'images' + os.sep, os.sep + 'labels' + os.sep  # /images/, /labels/ substrings
-    return [sb.join(x.rsplit(sa, 1)).rsplit('.')[0] + '.txt' for x in img_paths]
+    return [sb.join(x.rsplit(sa, 1)).rsplit('.', 1)[0] + '.txt' for x in img_paths]
 
 
 class LoadImagesAndLabels(Dataset):  # for training/testing


### PR DESCRIPTION
Correct order so only the **last** instance of /images/ is replaced with /labels/.

```python
import os

def img2label_paths(img_paths):
    # Define label paths as a function of image paths
    sa, sb = os.sep + 'images' + os.sep, os.sep + 'labels' + os.sep  # /images/, /labels/ substrings
    return ['txt'.join(x.replace(sa, sb, 1).rsplit(x.split('.')[-1], 1)) for x in img_paths]


def img2label_paths_fix(img_paths):
    # Define label paths as a function of image paths
    sa, sb = os.sep + 'images' + os.sep, os.sep + 'labels' + os.sep  # /images/, /labels/ substrings
    return ['txt'.join(sb.join(x.rsplit(sa, 1)).rsplit(x.split('.')[-1], 1)) for x in img_paths]


def img2label_paths_fix2(img_paths):
    # Define label paths as a function of image paths
    sa, sb = os.sep + 'images' + os.sep, os.sep + 'labels' + os.sep  # /images/, /labels/ substrings
    return [sb.join(x.rsplit(sa, 1)).rsplit('.', 1)[0] + '.txt' for x in img_paths]

images = ['dataset/images/images/img1.jpg'] * 100

print(img2label_paths(images[0:1]))
print(img2label_paths_fix(images[0:1]))
print(img2label_paths_fix2(images[0:1]))

%timeit img2label_paths(images)
%timeit img2label_paths_fix(images)
%timeit img2label_paths_fix2(images)

## OUTPUT
['dataset/labels/images/img1.txt']
['dataset/images/labels/img1.txt']
['dataset/images/labels/img1.txt']

54.4 µs ± 531 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
69.1 µs ± 429 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
51.3 µs ± 707 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

It looks like we have a winner.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of label path generation in YOLOv5.

### 📊 Key Changes
- Refactored the `img2label_paths` function for better readability and efficiency.
- Changed the string manipulation method to concatenate label paths.

### 🎯 Purpose & Impact
- **Purpose**: To streamline the process of converting image paths to corresponding label paths within the dataset handling code.
- **Impact**: Improved code clarity which may facilitate easier maintenance and potentially reduce the risk of bugs. This change could also lead to slight performance improvements in the data loading phase of model training or inference for end-users.