### PR TITLE
Backwards compatible cache version checks

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -390,7 +390,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         cache_path = (p if p.is_file() else Path(self.label_files[0]).parent).with_suffix('.cache')  # cached labels
         if cache_path.is_file():
             cache, exists = torch.load(cache_path), True  # load
-            if cache['version'] != 0.3 or cache['hash'] != get_hash(self.label_files + self.img_files):
+            if cache.get('version') != 0.3 or cache.get('hash') != get_hash(self.label_files + self.img_files):
                 cache, exists = self.cache_labels(cache_path, prefix), False  # re-cache
         else:
             cache, exists = self.cache_labels(cache_path, prefix), False  # cache


### PR DESCRIPTION
Fix for https://github.com/ultralytics/yolov5/issues/3707. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved label cache validation in dataset loading.

### 📊 Key Changes
- Switch from direct dictionary access to `.get()` method when validating cache version and hash.

### 🎯 Purpose & Impact
- **Robustness**: Prevents potential `KeyError` if 'version' or 'hash' keys are missing from the cache.
- **User Experience**: Enhances reliability of dataset caching system by safely handling unexpected cache formats.
- **Maintainability**: Using `.get()` is a defensive coding practice that makes the codebase more resilient to future changes.