### PR TITLE
Remove DDP `nn.MultiheadAttention` fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -252,9 +252,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
     # DDP mode
     if cuda and RANK != -1:
-        model = DDP(model, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
-                    # nn.MultiheadAttention incompatibility with DDP https://github.com/pytorch/pytorch/issues/26698
-                    find_unused_parameters=any(isinstance(layer, nn.MultiheadAttention) for layer in model.modules()))
+        model = DDP(model, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK)
 
     # Model parameters
     hyp['box'] *= 3. / nl  # scale to layers


### PR DESCRIPTION
No longer necessary as https://github.com/pytorch/pytorch/issues/26698 resolved in https://github.com/pytorch/pytorch/pull/26826

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved DDP configuration in the training script.

### 📊 Key Changes
- Simplified the Distributed Data Parallel (DDP) model instantiation by removing the `find_unused_parameters` setting.

### 🎯 Purpose & Impact
- 🚀 **Efficiency**: Removing the `find_unused_parameters` can potentially improve performance since the check for unused parameters in each forward pass is skipped.
- 🎨 **Cleaner Code**: The deletion reduces code complexity, making it easier for developers to maintain and understand.
- ✅ **Compatibility**: Ensures that the codebase is up-to-date with the current state of PyTorch, reflecting that the previously encountered incompatibilities with `nn.MultiheadAttention` are resolved.
- 📈 **Potential Impact**: Users might experience faster training times and smoother scaling across multiple GPUs.