### PR TITLE
Create hyp.scratch-p6.yaml

### DIFF
--- a/data/hyps/hyp.scratch-p6.yaml
+++ b/data/hyps/hyp.scratch-p6.yaml
@@ -1,0 +1,33 @@
+# Hyperparameters for COCO training from scratch
+# python train.py --batch 32 --cfg yolov5m6.yaml --weights '' --data coco.yaml --img 1280 --epochs 300
+# See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials
+
+
+lr0: 0.01  # initial learning rate (SGD=1E-2, Adam=1E-3)
+lrf: 0.2  # final OneCycleLR learning rate (lr0 * lrf)
+momentum: 0.937  # SGD momentum/Adam beta1
+weight_decay: 0.0005  # optimizer weight decay 5e-4
+warmup_epochs: 3.0  # warmup epochs (fractions ok)
+warmup_momentum: 0.8  # warmup initial momentum
+warmup_bias_lr: 0.1  # warmup initial bias lr
+box: 0.05  # box loss gain
+cls: 0.3  # cls loss gain
+cls_pw: 1.0  # cls BCELoss positive_weight
+obj: 0.7  # obj loss gain (scale with pixels)
+obj_pw: 1.0  # obj BCELoss positive_weight
+iou_t: 0.20  # IoU training threshold
+anchor_t: 4.0  # anchor-multiple threshold
+# anchors: 3  # anchors per output layer (0 to ignore)
+fl_gamma: 0.0  # focal loss gamma (efficientDet default gamma=1.5)
+hsv_h: 0.015  # image HSV-Hue augmentation (fraction)
+hsv_s: 0.7  # image HSV-Saturation augmentation (fraction)
+hsv_v: 0.4  # image HSV-Value augmentation (fraction)
+degrees: 0.0  # image rotation (+/- deg)
+translate: 0.1  # image translation (+/- fraction)
+scale: 0.9  # image scale (+/- gain)
+shear: 0.0  # image shear (+/- deg)
+perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
+flipud: 0.0  # image flip up-down (probability)
+fliplr: 0.5  # image flip left-right (probability)
+mosaic: 1.0  # image mosaic (probability)
+mixup: 0.0  # image mixup (probability)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing a new set of hyperparameters for YOLOv5 model training from scratch on the COCO dataset.

### 📊 Key Changes
- 📝 Added a new hyperparameter file `hyp.scratch-p6.yaml` with pre-tuned values.
- 📈 Includes settings for initial learning rate, final learning rate, momentum, and weight decay.
- 🛠️ Configures warmup epochs, momentum during warmup, and initial bias learning rate.
- 💡 Loss function gains for box, classification, and objectness are specified.
- 🎛️ Sets anchors, focal loss gamma, and various data augmentation parameters like HSV color space adjustments, image scaling, translation, and flipping.

### 🎯 Purpose & Impact
- 🎯 The purpose is to provide a tailored set of hyperparameters optimized for training the YOLOv5 model on the COCO dataset starting from scratch, meaning without pre-trained weights.
- 🔍 Potential impact includes more efficient and effective training for users aiming to train the model from the ground up, which could potentially result in better model performance and accuracy.
- 🌱 For new users, this can serve as a recommended starting point that simplifies the experiment set up for training models on the COCO dataset.