### PR TITLE
Update seeds for single-GPU reproducibility

### DIFF
--- a/train.py
+++ b/train.py
@@ -84,7 +84,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     # Configure
     plots = not evolve  # create plots
     cuda = device.type != 'cpu'
-    init_seeds(2 + RANK)
+    init_seeds(1 + RANK)
     with open(data) as f:
         data_dict = yaml.safe_load(f)  # data dict
 


### PR DESCRIPTION
For seed=0 on single-GPU.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved seed initialization for training consistency in YOLOv5.

### 📊 Key Changes
- Changed the seed value used during training initialization from `2 + RANK` to `1 + RANK`.

### 🎯 Purpose & Impact
- Ensures more consistent results when training models, potentially aiding in reproducibility.
- Might have a minor impact on users experimenting with different training runs, as results can vary slightly based on seed values.