### PR TITLE
Add feature map visualization

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -156,7 +156,6 @@ class Model(nn.Module):
             y.append(x if m.i in self.save else None)  # save output
             
             if feature_vis and m.type == 'models.common.SPP':
-                print(m.type, m.i)
                 feature_visualization(x, m.type, m.i)
 
         if profile:

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -17,6 +17,7 @@ from models.common import *
 from models.experimental import *
 from utils.autoanchor import check_anchor_order
 from utils.general import make_divisible, check_file, set_logging
+from utils.plots import feature_visualization
 from utils.torch_utils import time_synchronized, fuse_conv_and_bn, model_info, scale_img, initialize_weights, \
     select_device, copy_attr
 
@@ -153,6 +154,11 @@ class Model(nn.Module):
 
             x = m(x)  # run
             y.append(x if m.i in self.save else None)  # save output
+            
+            feature_vis = True
+            if m.type == 'models.common.SPP' and feature_vis:
+                print(m.type, m.i)
+                feature_visualization(x, m.type, m.i)
 
         if profile:
             logger.info('%.1fms total' % sum(dt))

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -136,7 +136,7 @@ class Model(nn.Module):
             y.append(yi)
         return torch.cat(y, 1), None  # augmented inference, train
 
-    def forward_once(self, x, profile=False):
+    def forward_once(self, x, profile=False, feature_vis=False):
         y, dt = [], []  # outputs
         for m in self.model:
             if m.f != -1:  # if not from previous layer
@@ -155,8 +155,7 @@ class Model(nn.Module):
             x = m(x)  # run
             y.append(x if m.i in self.save else None)  # save output
             
-            feature_vis = True
-            if m.type == 'models.common.SPP' and feature_vis:
+            if feature_vis and m.type == 'models.common.SPP':
                 print(m.type, m.i)
                 feature_visualization(x, m.type, m.i)
 

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -15,6 +15,7 @@ import seaborn as sn
 import torch
 import yaml
 from PIL import Image, ImageDraw, ImageFont
+from torchvision import transforms
 
 from utils.general import xywh2xyxy, xyxy2xywh
 from utils.metrics import fitness
@@ -445,3 +446,39 @@ def plot_results(start=0, stop=0, bucket='', id=(), labels=(), save_dir=''):
 
     ax[1].legend()
     fig.savefig(Path(save_dir) / 'results.png', dpi=200)
+    
+
+def feature_visualization(features, model_type, model_id, feature_num=64):
+    """
+    features: The feature map which you need to visualization
+    model_type: The type of feature map
+    model_id: The id of feature map
+    feature_num: The amount of visualization you need
+    """
+    save_dir = "features/"
+    if not os.path.exists(save_dir):
+        os.makedirs(save_dir)
+
+    # print(features.shape)
+    # block by channel dimension
+    blocks = torch.chunk(features, features.shape[1], dim=1)
+
+    # # size of feature
+    # size = features.shape[2], features.shape[3]
+
+    plt.figure()
+    for i in range(feature_num):
+        torch.squeeze(blocks[i])
+        feature = transforms.ToPILImage()(blocks[i].squeeze())
+        # print(feature)
+        ax = plt.subplot(int(math.sqrt(feature_num)), int(math.sqrt(feature_num)), i+1)
+        ax.set_xticks([])
+        ax.set_yticks([])
+
+        plt.imshow(feature)
+        # gray feature
+        # plt.imshow(feature, cmap='gray')
+
+    # plt.show()
+    plt.savefig(save_dir + '{}_{}_feature_map_{}.png'
+                .format(model_type.split('.')[2], model_id, feature_num), dpi=300)   

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -450,10 +450,10 @@ def plot_results(start=0, stop=0, bucket='', id=(), labels=(), save_dir=''):
 
 def feature_visualization(features, module_type, module_idx, n=64):
     """
-    features: Features to be visualized
-    module_type: module type
-    module_idx: module layer index within model
-    n: Maximum number of feature maps to plot
+    features:       Features to be visualized
+    module_type:    Module type
+    module_idx:     Module layer index within model
+    n:              Maximum number of feature maps to plot
     """
     project, name = 'runs/features', 'exp'
     save_dir = increment_path(Path(project) / name)  # increment run

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -459,17 +459,15 @@ def feature_visualization(features, module_type, module_idx, n=64):
     save_dir = increment_path(Path(project) / name)  # increment run
     save_dir.mkdir(parents=True, exist_ok=True)  # make dir
 
-    plt.figure()
+    plt.figure(tight_layout=True)
     blocks = torch.chunk(features, features.shape[1], dim=1)  # block by channel dimension
     n = min(n, len(blocks))
     for i in range(n):
         feature = transforms.ToPILImage()(blocks[i].squeeze())
         ax = plt.subplot(int(math.sqrt(n)), int(math.sqrt(n)), i + 1)
-        ax.set_xticks([])
-        ax.set_yticks([])
-        plt.imshow(feature)
-        # plt.imshow(feature, cmap='gray')
+        ax.axis('off')
+        plt.imshow(feature)  # cmap='gray'
 
-    # plt.show()
-    plt.savefig(save_dir / f"{module_type.split('.')[2]}_{module_idx}_feature_map_{n}.png", dpi=300)
-    print(f'Features from {module_type} module in layer {module_idx} saved to {save_dir}')
+    f = f"layer_{module_idx}_{module_type.split('.')[-1]}_features.png"
+    print(f'Saving {save_dir / f}...')
+    plt.savefig(save_dir / f, dpi=300)


### PR DESCRIPTION
Add a feature_visualization function to visualize the mid feature map of the model in plots.py.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introduced feature visualization for SPP layer outputs during model inference in the YOLOv5 architecture.

### 📊 Key Changes
- 🧠 Added `feature_vis` argument to `forward_once` method in `yolo.py` to optionally enable feature visualization.
- 🖼 Implemented `feature_visualization` function in `plots.py` to create and save visualizations of feature maps.
- 📁 Created utility to incrementally generate a unique directory for saving feature visualizations.
- 🚀 Enhanced functionality without altering existing inference or training pipelines.

### 🎯 Purpose & Impact
- 👓 Developers can now visualize feature maps directly from the SPP layer during inference to understand model behavior.
- 🎨 Helps with debugging, model understanding, and educational purposes by providing insights into the model's feature extraction process.
- 📊 Feature visualizations can assist researchers and practitioners in tweaking the model's architecture or training for better performance.
- 🧩 No impact on users who do not utilize the new feature, ensuring seamless integration with current workflows.