### PR TITLE
Add feature_visualization in yolo.py

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -17,6 +17,7 @@ from models.common import *
 from models.experimental import *
 from utils.autoanchor import check_anchor_order
 from utils.general import make_divisible, check_file, set_logging
+from utils.plots import feature_visualization
 from utils.torch_utils import time_synchronized, fuse_conv_and_bn, model_info, scale_img, initialize_weights, \
     select_device, copy_attr
 
@@ -153,6 +154,11 @@ class Model(nn.Module):
 
             x = m(x)  # run
             y.append(x if m.i in self.save else None)  # save output
+            
+            feature_vis = True
+            if m.type == 'models.common.SPP' and feature_vis:
+                print(m.type, m.i)
+                feature_visualization(x, m.type, m.i)
 
         if profile:
             logger.info('%.1fms total' % sum(dt))


### PR DESCRIPTION
Add feature_visualization function in yolo.py, so that people can visualize feature map of model in yolo.py.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introduced feature visualization during forward passes in YOLOv5.

### 📊 Key Changes
- 🎨 Added an import for `feature_visualization` from `utils.plots`.
- ✨ Included conditional blocks to visualize feature maps after the 'SPP' (Spatial Pyramid Pooling) block during the forward pass.

### 🎯 Purpose & Impact
- 🌐 The purpose is to enhance debugging and understanding of the model by allowing visualization of intermediate feature maps.
- 🚀 Potential impact includes easier model interpretability for developers and researchers, and a helpful tool in educational settings to understand how specific layers process input data.