### PR TITLE
`--evolve 300` generations CLI argument

### DIFF
--- a/train.py
+++ b/train.py
@@ -495,7 +495,7 @@ def parse_opt(known=False):
     parser.add_argument('--nosave', action='store_true', help='only save final checkpoint')
     parser.add_argument('--notest', action='store_true', help='only test final epoch')
     parser.add_argument('--noautoanchor', action='store_true', help='disable autoanchor check')
-    parser.add_argument('--evolve', type=int, required=False, help='evolve hyperparameters for this many generations')
+    parser.add_argument('--evolve', nargs='?', const=300, help='evolve hyperparameters for this many generations')
     parser.add_argument('--bucket', type=str, default='', help='gsutil bucket')
     parser.add_argument('--cache-images', action='store_true', help='cache images for faster training')
     parser.add_argument('--image-weights', action='store_true', help='use weighted image selection for training')

--- a/train.py
+++ b/train.py
@@ -603,7 +603,7 @@ def main(opt):
         if opt.bucket:
             os.system('gsutil cp gs://%s/evolve.txt .' % opt.bucket)  # download evolve.txt if exists
 
-        for _ in range(300):  # generations to evolve
+        for _ in range(opt.evolve):  # generations to evolve
             if Path('evolve.txt').exists():  # if evolve.txt exists: select best hyps and mutate
                 # Select parent(s)
                 parent = 'single'  # parent selection method: 'single' or 'weighted'

--- a/train.py
+++ b/train.py
@@ -494,7 +494,7 @@ def parse_opt(known=False):
     parser.add_argument('--nosave', action='store_true', help='only save final checkpoint')
     parser.add_argument('--notest', action='store_true', help='only test final epoch')
     parser.add_argument('--noautoanchor', action='store_true', help='disable autoanchor check')
-    parser.add_argument('--evolve', action='store_true', help='evolve hyperparameters')
+    parser.add_argument('--evolve', type=int, required=False, help='evolve hyperparameters for this many generations')
     parser.add_argument('--bucket', type=str, default='', help='gsutil bucket')
     parser.add_argument('--cache-images', action='store_true', help='cache images for faster training')
     parser.add_argument('--image-weights', action='store_true', help='use weighted image selection for training')

--- a/train.py
+++ b/train.py
@@ -60,6 +60,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     save_dir, epochs, batch_size, weights, single_cls, evolve, data, cfg, resume, notest, nosave, workers, = \
         opt.save_dir, opt.epochs, opt.batch_size, opt.weights, opt.single_cls, opt.evolve, opt.data, opt.cfg, \
         opt.resume, opt.notest, opt.nosave, opt.workers
+    evolve = evolve is not None
 
     # Directories
     save_dir = Path(save_dir)
@@ -542,7 +543,7 @@ def main(opt):
         assert len(opt.cfg) or len(opt.weights), 'either --cfg or --weights must be specified'
         opt.img_size.extend([opt.img_size[-1]] * (2 - len(opt.img_size)))  # extend to 2 sizes (train, test)
         opt.name = 'evolve' if opt.evolve else opt.name
-        opt.save_dir = str(increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok | opt.evolve))
+        opt.save_dir = str(increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok | (opt.evolve is None)))
 
     # DDP mode
     device = select_device(opt.device, batch_size=opt.batch_size)
@@ -556,7 +557,7 @@ def main(opt):
         assert not opt.image_weights, '--image-weights argument is not compatible with DDP training'
 
     # Train
-    if not opt.evolve:
+    if opt.evolve is None:
         train(opt.hyp, opt, device)
         if WORLD_SIZE > 1 and RANK == 0:
             _ = [print('Destroying process group... ', end=''), dist.destroy_process_group(), print('Done.')]


### PR DESCRIPTION
Currently, using the provided docker image for hyperparameter evolution fixes the number of evolution generations. This PR changes the `--evolve` command line argument to take an integer argument, which is used as the range in the `for`-loop in which the evolution takes place. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced the `--evolve` argument in the YOLOv5 training script to specify the number of generations for hyperparameter evolution.

### 📊 Key Changes
- Modified `--evolve` argument from a boolean flag to an integer that accepts an optional value, setting a default of 300 generations if no specific number is provided.
- Adjusted the saving directory logic to support the new `--evolve` argument by using logical 'or' to set the `exist_ok` parameter.
- Updated the evolution loop to dynamically run for the specified number of generations passed to `--evolve`.

### 🎯 Purpose & Impact
- Gives users finer control over the hyperparameter evolution process by allowing them to set a specific number of generations.
- Enhances usability by providing a default value for users who prefer not to set the number of generations manually.
- 🚀 Potentially improves YOLOv5 models' performance by allowing more tailored and extensive hyperparameter tuning, leading to better optimized models.