### PR TITLE
Evolution commented `hyp['anchors']` fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -596,6 +596,8 @@ def main(opt):
 
         with open(opt.hyp) as f:
             hyp = yaml.safe_load(f)  # load hyps dict
+            if 'anchors' not in hyp:  # anchors commented in hyp.yaml
+                hyp['anchors'] = 3
         assert LOCAL_RANK == -1, 'DDP mode not implemented for --evolve'
         opt.notest, opt.nosave = True, True  # only test/save final epoch
         # ei = [isinstance(x, (int, float)) for x in hyp.values()]  # evolvable indices


### PR DESCRIPTION
Fix for `KeyError: 'anchors'` error when start hyperparameter evolution:
```bash
python train.py --evolve
```

```bash
Traceback (most recent call last):
  File "E:\yolov5\train.py", line 623, in <module>
    hyp[k] = max(hyp[k], v[1])  # lower limit
KeyError: 'anchors'
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement to Hyperparameter Settings in YOLOv5 Training Script

### 📊 Key Changes
- Added a safety check to ensure 'anchors' key exists in hyperparameters (hyp).
- Default 'anchors' value is set to 3 if not specified in `hyp.yaml`.

### 🎯 Purpose & Impact
- 🛠️ Ensures consistency in training configurations by providing a default for 'anchors' when it's omitted.
- 🚀 Reduces the risk of errors during training setup, leading to smoother user experiences and potential bug prevention.
- 🧪 Users who comment out 'anchors' in their hyperparameters will not face unexpected behavior during model training.