### PR TITLE
Update `setattr()` default for Hub PIL images

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -255,7 +255,7 @@ class AutoShape(nn.Module):
                 im, f = Image.open(requests.get(im, stream=True).raw if im.startswith('http') else im), im
                 im = np.asarray(exif_transpose(im))
             elif isinstance(im, Image.Image):  # PIL Image
-                im, f = np.asarray(exif_transpose(im)), getattr(im, 'filename') or f
+                im, f = np.asarray(exif_transpose(im)), getattr(im, 'filename', f) or f
             files.append(Path(f).with_suffix('.jpg').name)
             if im.shape[0] < 5:  # image in CHW
                 im = im.transpose((1, 2, 0))  # reverse dataloader .transpose(2, 0, 1)


### PR DESCRIPTION
Fix inference from PIL source.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved robustness in image loading within the YOLOv5 model.

### 📊 Key Changes
- Updated the handling of image filenames to provide a default more reliably when accessing the 'filename' attribute of a PIL Image object.

### 🎯 Purpose & Impact
- Helps avoid attribute errors during image processing when the 'filename' attribute might be missing or unavailable.
- Ensures smoother operation for users when loading images from various sources, improving user experience and reliability of the model.