### PR TITLE
Update `dataset_stats()` for zipped datasets

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -888,9 +888,11 @@ def verify_image_label(args):
 
 def dataset_stats(path='coco128.yaml', autodownload=False, verbose=False):
     """ Return dataset statistics dictionary with images and instances counts per split per class
-    Usage: from utils.datasets import *; dataset_stats('coco128.yaml', verbose=True)
+    Usage 1: from utils.datasets import *; dataset_stats('coco128.yaml', verbose=True)
+    Usage 2: from utils.datasets import *; dataset_stats('../datasets/coco128.zip', verbose=True)
+    
     Arguments
-        path:           Path to data.yaml
+        path:           Path to data.yaml or data.zip (with data.yaml inside data.zip)
         autodownload:   Attempt to download dataset if not found locally
         verbose:        Print stats dictionary
     """
@@ -899,8 +901,20 @@ def dataset_stats(path='coco128.yaml', autodownload=False, verbose=False):
         # Update labels to integer class and 6 decimal place floats
         return [[int(c), *[round(x, 6) for x in points]] for c, *points in labels]
 
-    with open(check_file(path)) as f:
+    def unzip(path):
+        # Unzip data.zip TODO: CONSTRAINT: path/to/abc.zip MUST unzip to 'path/to/abc/'
+        if str(path).endswith('.zip'):  # path is data.zip
+            assert os.system(f'unzip -q {path} -d {path.parent}') == 0, f'Error unzipping {path}'
+            data_dir = path.with_suffix('')  # dataset directory
+            return True, data_dir, list(data_dir.rglob('*.yaml'))[0]  # zipped(boolean), data dir, yaml path
+        else:  # path is data.yaml
+            return False, None, path  # zipped(boolean), data dir, yaml path
+
+    zipped, data_dir, yaml_path = unzip(Path(path))
+    with open(check_file(yaml_path)) as f:
         data = yaml.safe_load(f)  # data dict
+        if zipped:
+            data['path'] = data_dir  # TODO: should this be dir.resolve()?
     check_dataset(data, autodownload)  # download dataset if missing
     nc = data['nc']  # number of classes
     stats = {'nc': nc, 'names': data['names']}  # statistics dictionary

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -888,8 +888,8 @@ def verify_image_label(args):
 
 def dataset_stats(path='coco128.yaml', autodownload=False, verbose=False):
     """ Return dataset statistics dictionary with images and instances counts per split per class
-    Usage 1: from utils.datasets import *; dataset_stats('coco128.yaml', verbose=True)
-    Usage 2: from utils.datasets import *; dataset_stats('../datasets/coco128.zip', verbose=True)
+    Usage1: from utils.datasets import *; dataset_stats('coco128.yaml', verbose=True)
+    Usage2: from utils.datasets import *; dataset_stats('../datasets/coco128.zip', verbose=True)
     
     Arguments
         path:           Path to data.yaml or data.zip (with data.yaml inside data.zip)
@@ -906,9 +906,9 @@ def dataset_stats(path='coco128.yaml', autodownload=False, verbose=False):
         if str(path).endswith('.zip'):  # path is data.zip
             assert os.system(f'unzip -q {path} -d {path.parent}') == 0, f'Error unzipping {path}'
             data_dir = path.with_suffix('')  # dataset directory
-            return True, data_dir, list(data_dir.rglob('*.yaml'))[0]  # zipped(boolean), data dir, yaml path
+            return True, data_dir, list(data_dir.rglob('*.yaml'))[0]  # zipped, data_dir, yaml_path
         else:  # path is data.yaml
-            return False, None, path  # zipped(boolean), data dir, yaml path
+            return False, None, path
 
     zipped, data_dir, yaml_path = unzip(Path(path))
     with open(check_file(yaml_path)) as f:


### PR DESCRIPTION
@KalenMike I've updated `dataset_stats()` as discussed. Usage example:

## Step 1: Download/move data.zip 
Here I place coco128.zip in our /datasets directory:
<img width="962" alt="Screenshot 2021-07-07 at 19 19 57" src="https://user-images.githubusercontent.com/26833433/124802704-8c5db680-df58-11eb-9198-1885205f75cd.png">


## Step 2: Run `dataset_stats()`
```python
from utils.datasets import *

dataset_stats('../datasets/coco128.zip')
```

This will automatically:

1. Determine that you've passed a zip file and unzip it.
2. Update `yaml['path']` to the new dataset location
3. Scan the entire dataset (labels + images) running checks on everything.
4. Create statistics JSON
5. Create *.cache file

<img width="962" alt="Screenshot 2021-07-07 at 19 20 36" src="https://user-images.githubusercontent.com/26833433/124803037-e52d4f00-df58-11eb-8f97-3008f277cb90.png">


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced `dataset_stats` to support zipped datasets and improve data handling.

### 📊 Key Changes
- Added support for `.zip` dataset files in `dataset_stats()` function.
- Included a new `unzip` function to handle the extraction of zip files.
- Amended the `dataset_stats` function to handle both `.yaml` and `.zip` input paths.
- Unified usage instructions for both supported dataset types.

### 🎯 Purpose & Impact
- 📈 **Enhanced Usability**: Users can now directly pass `.zip` dataset files to get statistics.
- 🛠️ **Streamlined Workflow**: Simplifies the process of working with zipped datasets by automating extraction and analysis within `dataset_stats`.
- 🗂️ **Better Data Handling**: Ensures the data directory is updated correctly after unzipping for consistent dataset usage.