### PR TITLE
Fix inconsistent NMS IoU value for COCO

### DIFF
--- a/train.py
+++ b/train.py
@@ -457,8 +457,6 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                     results, _, _ = test.run(data_dict,
                                              batch_size=batch_size // WORLD_SIZE * 2,
                                              imgsz=imgsz_test,
-                                             conf_thres=0.001,
-                                             iou_thres=0.7,
                                              model=attempt_load(m, device).half(),
                                              single_cls=single_cls,
                                              dataloader=testloader,


### PR DESCRIPTION
Evaluation of 'best' and 'last' models will use the same params as the evaluation during the training phase. 
This PR fixes https://github.com/ultralytics/yolov5/issues/3907

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced default testing configuration in YOLOv5 training script 🛠️.

### 📊 Key Changes
- Removed hardcoded confidence threshold (`conf_thres=0.001`) during testing.
- Removed hardcoded Intersection over Union (IoU) threshold (`iou_thres=0.7`) during testing.

### 🎯 Purpose & Impact
- 🎨 **Customizability**: Users can rely on default settings defined elsewhere or specify their own thresholds, leading to more flexible and customized model evaluations.
- 📈 **Generalization**: Eliminating hardcoded values can potentially lead to more accurate performance assessments across different datasets and use cases.
- 💡 **Transparency**: Allows users to have clearer insights into how their models perform with default parameters, fostering a better understanding and trust in the model's evaluation metrics.