### PR TITLE
read img contains unicode characters in file path

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -625,7 +625,9 @@ def load_image(self, index):
     img = self.imgs[index]
     if img is None:  # not cached
         path = self.img_files[index]
-        img = cv2.imread(path)  # BGR
+        img = np.fromfile(path, np.uint8)
+        img = cv2.imdecode(img)
+        
         assert img is not None, 'Image Not Found ' + path
         h0, w0 = img.shape[:2]  # orig hw
         r = self.img_size / max(h0, w0)  # ratio

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -627,6 +627,7 @@ def load_image(self, index):
         path = self.img_files[index]
         img = np.fromfile(path, np.uint8)
         img = cv2.imdecode(img, cv2.IMREAD_UNCHANGED)
+        img = img[..., :3] if img.ndim == 3 else np.tile(img[..., None], 3)
         
         assert img is not None, 'Image Not Found ' + path
         h0, w0 = img.shape[:2]  # orig hw

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -626,7 +626,7 @@ def load_image(self, index):
     if img is None:  # not cached
         path = self.img_files[index]
         img = np.fromfile(path, np.uint8)
-        img = cv2.imdecode(img)
+        img = cv2.imdecode(img, cv2.IMREAD_COLOR)
         
         assert img is not None, 'Image Not Found ' + path
         h0, w0 = img.shape[:2]  # orig hw

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -626,7 +626,7 @@ def load_image(self, index):
     if img is None:  # not cached
         path = self.img_files[index]
         img = np.fromfile(path, np.uint8)
-        img = cv2.imdecode(img, cv2.IMREAD_COLOR)
+        img = cv2.imdecode(img, cv2.IMREAD_UNCHANGED)
         
         assert img is not None, 'Image Not Found ' + path
         h0, w0 = img.shape[:2]  # orig hw


### PR DESCRIPTION
read img contains unicode characters in file path

related issue

https://stackoverflow.com/questions/59823318/read-load-images-with-unicode-characters-in-image-path-chinese-japanese-korea

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in image loading for better compatibility across different image formats.

### 📊 Key Changes
- Replaced `cv2.imread()` with `np.fromfile()` and `cv2.imdecode()` for image loading.
- Added handling to ensure images with different numbers of channels are correctly processed.

### 🎯 Purpose & Impact
- **Robust Image Loading**: This change allows the system to read images in a format-agnostic manner, leading to fewer errors when dealing with non-standard image files.
- **Enhanced Compatibility**: Users can now expect the software to handle a wider variety of image types, potentially reducing the need for pre-processing or format conversion.
- **Consistent Image Channel Handling**: Ensures that images with different channel formats (e.g., grayscale images) are treated uniformly, simplifying subsequent image processing tasks.