### PR TITLE
Update augmentations.py

### DIFF
--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -25,7 +25,7 @@ class Albumentations:
                 A.ToGray(p=0.01)],
                 bbox_params=A.BboxParams(format='yolo', label_fields=['class_labels']))
 
-            logging.info(colorstr('albumentations: ') + ', '.join(f'{x}' for x in self.transform.transforms))
+            logging.info(colorstr('albumentations: ') + ', '.join(f'{x}' for x in self.transform.transforms if x.p))
         except ImportError:  # package not installed, skip
             pass
         except Exception as e:


### PR DESCRIPTION
Print only if probability > 0

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved logging for augmentation probabilities in image processing.

### 📊 Key Changes
- Modified the logging output in `augmentations.py` to only include transformations with a non-zero probability.

### 🎯 Purpose & Impact
- **Purpose:** To provide clearer logs by excluding augmentations that have zero probability and thus do not affect the dataset.
- **Impact:** Users will benefit from more readable log entries when understanding the augmentations being applied to their images, which can help in debugging and model fine-tuning. 📈