### PR TITLE
AutoShape PosixPath support

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -1,7 +1,7 @@
 # YOLOv5 common modules
 
 from copy import copy
-from pathlib import Path
+from pathlib import Path, PosixPath
 
 import math
 import numpy as np
@@ -251,7 +251,7 @@ class AutoShape(nn.Module):
         shape0, shape1, files = [], [], []  # image and inference shapes, filenames
         for i, im in enumerate(imgs):
             f = f'image{i}'  # filename
-            if isinstance(im, (str, pathlib.PosixPath)):  # filename or uri
+            if isinstance(im, (str, PosixPath)):  # filename or uri
                 im, f = Image.open(requests.get(im, stream=True).raw if str(im).startswith('http') else im), im
                 im = np.asarray(exif_transpose(im))
             elif isinstance(im, Image.Image):  # PIL Image

--- a/models/common.py
+++ b/models/common.py
@@ -232,8 +232,8 @@ class AutoShape(nn.Module):
     @torch.no_grad()
     def forward(self, imgs, size=640, augment=False, profile=False):
         # Inference from various sources. For height=640, width=1280, RGB images example inputs are:
-        #   filename:   imgs = 'data/images/zidane.jpg'
-        #   URI:             = 'https://github.com/ultralytics/yolov5/releases/download/v1.0/zidane.jpg'
+        #   filename:   imgs = 'data/images/zidane.jpg'  # str or PosixPath
+        #   URI:             = 'https://ultralytics.com/images/zidane.jpg'
         #   OpenCV:          = cv2.imread('image.jpg')[:,:,::-1]  # HWC BGR to RGB x(640,1280,3)
         #   PIL:             = Image.open('image.jpg')  # HWC x(640,1280,3)
         #   numpy:           = np.zeros((640,1280,3))  # HWC
@@ -251,8 +251,8 @@ class AutoShape(nn.Module):
         shape0, shape1, files = [], [], []  # image and inference shapes, filenames
         for i, im in enumerate(imgs):
             f = f'image{i}'  # filename
-            if isinstance(im, str):  # filename or uri
-                im, f = Image.open(requests.get(im, stream=True).raw if im.startswith('http') else im), im
+            if isinstance(im, (str, pathlib.PosixPath)):  # filename or uri
+                im, f = Image.open(requests.get(im, stream=True).raw if str(im).startswith('http') else im), im
                 im = np.asarray(exif_transpose(im))
             elif isinstance(im, Image.Image):  # PIL Image
                 im, f = np.asarray(exif_transpose(im)), getattr(im, 'filename', f) or f


### PR DESCRIPTION
Usage example:

````python
from pathlib import Path

model = ...
file = Path('data/images/zidane.jpg')

results = model(file)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to YOLOv5 image loading with broader path support and URL updates.

### 📊 Key Changes
- 🛠️ Added `PosixPath` support to the existing path options for image loading.
- 🔄 Updated the example URI in the comments from a GitHub URL to the main Ultralytics website URL.
- 🧼 Code now handles file paths and URIs uniformly by converting `PosixPath` to `str` when needed.

### 🎯 Purpose & Impact
- ⚙️ The addition of `PosixPath` support makes the codebase more flexible, accommodating Pathlib objects in addition to strings for file paths. This helps developers who prefer Pathlib for filesystem operations.
- 📢 Changing the example URI reflects Ultralytics' current hosting location for images, providing users with up-to-date reference information.
- ✨ Overall, these updates contribute to a more intuitive user experience and slightly broaden compatibility with different Python coding styles, improving ease of use and maintainability.