### PR TITLE
W&B: fix refactor bugs

### DIFF
--- a/val.py
+++ b/val.py
@@ -215,7 +215,7 @@ def run(data,
                 save_one_txt(predn, save_conf, shape, file=save_dir / 'labels' / (path.stem + '.txt'))
             if save_json:
                 save_one_json(predn, jdict, path, class_map)  # append to COCO-JSON dictionary
-            if wandb_logger:
+            if wandb_logger and wandb_logger.wandb_run:
                 wandb_logger.val_one_image(pred, predn, path, names, img[si])
 
         # Plot images


### PR DESCRIPTION
Addresses https://github.com/ultralytics/yolov5/issues/4067

@glenn-jocher 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to the Weights & Biases (W&B) logging in YOLOv5's validation process.

### 📊 Key Changes
- Added a new attribute `max_imgs_to_log` to limit the number of images logged to W&B.
- Ensured the `data_dict` is correctly updated during W&B configuration in case of using `opt.upload_dataset`.
- Removed a redundant `log_imgs` attribute and replaced its usage with the new `max_imgs_to_log`.
- Modified condition for `wandb_logger` in `val.py` to only proceed if `wandb_logger.wandb_run` is not None, ensuring there's an active W&B run.

### 🎯 Purpose & Impact
- 🎈 **Consistency:** Ensures that the correct dataset information is logged to W&B for better traceability and reproducibility.
- 📉 **Resource Management:** Prevents logging an excessive number of images by setting a sensible default max limit, reducing clutter and potential overuse of resources.
- 🛠 **Code Clean-up:** Simplifies the code by removing unnecessary variables, ultimately making it easier to maintain and understand.
- 🛡 **Reliability:** Adds a safety check to avoid errors when logging validation images if there's no active W&B run. This ensures that users without W&B or with misconfigured W&B runs don't encounter issues during validation.