### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ We are super excited about our first-ever Ultralytics YOLOv5 🚀 EXPORT Competi
   
   * AP<sup>test</sup> denotes COCO [test-dev2017](http://cocodataset.org/#upload) server results, all other AP results denote val2017 accuracy.  
   * AP values are for single-model single-scale unless otherwise noted. **Reproduce mAP** by `python val.py --data coco.yaml --img 640 --conf 0.001 --iou 0.65`  
-  * Speed<sub>GPU</sub> averaged over 5000 COCO val2017 images using a GCP [n1-standard-16](https://cloud.google.com/compute/docs/machine-types#n1_standard_machine_types) V100 instance, and includes FP16 inference, postprocessing and NMS. **Reproduce speed** by `python val.py --data coco.yaml --img 640 --conf 0.25 --iou 0.45`  
+  * Speed<sub>GPU</sub> averaged over 5000 COCO val2017 images using a GCP [n1-standard-16](https://cloud.google.com/compute/docs/machine-types#n1_standard_machine_types) V100 instance, and includes FP16 inference, postprocessing and NMS. **Reproduce speed** by `python val.py --data coco.yaml --img 640 --conf 0.25 --iou 0.45 --half`  
   * All checkpoints are trained to 300 epochs with default settings and hyperparameters (no autoaugmentation). 
   * Test Time Augmentation ([TTA](https://github.com/ultralytics/yolov5/issues/303)) includes reflection and scale augmentation. **Reproduce TTA** by `python val.py --data coco.yaml --img 1536 --iou 0.7 --augment`
 </details>


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced speed reproduction instructions for YOLOv5 models.

### 📊 Key Changes
- Updated the command to reproduce inference speed by including the `--half` flag.

### 🎯 Purpose & Impact
- 🚀 The inclusion of the `--half` flag allows the testing script to use FP16 precision, which can increase the speed of inference on compatible GPUs.
- ✅ This update provides users with more accurate instructions to benchmark the model's speed, ensuring consistency with the reported Speed<sub>GPU</sub> in the README.
- 🧑‍💻 Practitioners and researchers can now better reproduce and verify the inference speeds claimed by the YOLOv5 models, facilitating transparent and reliable performance testing.