### PR TITLE
Fixed logging level in distributed mode

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -23,7 +23,6 @@ try:
 except ImportError:
     thop = None
 
-logging.basicConfig(format="%(message)s", level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
 
 
@@ -108,6 +107,7 @@ def profile(input, ops, n=10, device=None):
     #     profile(input, [m1, m2], n=100)  # profile over 100 iterations
 
     results = []
+    logging.basicConfig(format="%(message)s", level=logging.INFO)
     device = device or select_device()
     print(f"{'Params':>12s}{'GFLOPs':>12s}{'GPU_mem (GB)':>14s}{'forward (ms)':>14s}{'backward (ms)':>14s}"
           f"{'input':>24s}{'output':>24s}")


### PR DESCRIPTION
Hi, the 94686575024f055e603c1b20a36dcbfb1418c3fc commit break the **logging level setting** in distributed training mode. Now, everythings is logging multiply times when use distributed training. The logging level is only allowed to be setup once for each process. When `train.py` import `torch_utils.py`, the logging level is freeze to `INFO` in each process. The later called `set_logging` in `train.py` will make no effect. So I just move the `logging.basicConfig` statement in `torch_utils.py` into `profile` function which is this commit intends to do.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging setup in the YOLOv5 Torch utilities.

### 📊 Key Changes
- Removed the global logging configuration from the `torch_utils.py` module.
- Added logging configuration within the `profile` function.

### 🎯 Purpose & Impact
- 📈 **Flexibility:** By moving the logging setup, other parts of the code can now configure logging without conflicts, increasing modularity.
- 🐞 **Reduce Side Effects:** Limiting the scope of logging configuration to where it's needed prevents unintended logging behavior elsewhere in the application.
- 👩‍💻 **User Clarity:** Users will experience cleaner logs, as the configuration now only affects profiling operations, leading to less confusion due to unwanted log messages.