### PR TITLE
Add the choice to have see-through labels in plots.py

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -65,19 +65,33 @@ def butter_lowpass_filtfilt(data, cutoff=1500, fs=50000, order=5):
     return filtfilt(b, a, data)  # forward-backward filter
 
 
-def plot_one_box(x, im, color=(128, 128, 128), label=None, line_thickness=3):
+def plot_one_box(x, im, color=(128, 128, 128), label=None, line_thickness=2):
+    see_through = False
     # Plots one bounding box on image 'im' using OpenCV
     assert im.data.contiguous, 'Image not contiguous. Apply np.ascontiguousarray(im) to plot_on_box() input image.'
     tl = line_thickness or round(0.002 * (im.shape[0] + im.shape[1]) / 2) + 1  # line/font thickness
-    c1, c2 = (int(x[0]), int(x[1])), (int(x[2]), int(x[3]))
-    cv2.rectangle(im, c1, c2, color, thickness=tl, lineType=cv2.LINE_AA)
+    c1, c2 = (int(x[0]), int(x[1])), (int(x[2]), int(x[3]))  # x comes in as top left x,y and bottom left x,y
+    cv2.rectangle(im, c1, c2, color, thickness=tl, lineType=cv2.LINE_AA)  # Object Box
     if label:
         tf = max(tl - 1, 1)  # font thickness
-        t_size = cv2.getTextSize(label, 0, fontScale=tl / 3, thickness=tf)[0]
-        c2 = c1[0] + t_size[0], c1[1] - t_size[1] - 3
-        cv2.rectangle(im, c1, c2, color, -1, cv2.LINE_AA)  # filled
-        cv2.putText(im, label, (c1[0], c1[1] - 2), 0, tl / 3, [225, 255, 255], thickness=tf, lineType=cv2.LINE_AA)
+        t_size = cv2.getTextSize(label, 2, fontScale=tl / 3, thickness=tf)[0]
+        c3 = c1[0] + t_size[0], c1[1] - t_size[1] - 3  # c1 becomes bottom left x,y and c3 top right of x,y of label_box
 
+        if see_through:
+            # First we crop the label area from the image
+            label_area = im[c3[1]:c1[1], c1[0]:c3[0]]  # y is first section x is second section
+
+            for i in range(3):  # Then we merge the bbox color with label area using a weighted sum
+                label_area[:, :, i] = label_area[:, :, i] * 0.5 + color[i] * 0.2
+
+            im[c3[1]:c1[1], c1[0]:c3[0]] = label_area  # Insert the label area back into the image
+            label_frame_color = np.array(color)/2  # To give the frame a light border
+
+        if see_through:  # Plot  see_through label or normal on image
+            cv2.rectangle(im, c1, c3, label_frame_color, 1, cv2.LINE_AA)  # Label Box See_Through
+        else:
+            cv2.rectangle(im, c1, c3, color, -1, cv2.LINE_AA)  # Label Box Filled
+        cv2.putText(im, label, (c1[0], c1[1] - 2), 2, tl / 3, [255, 255, 255], thickness=tf, lineType=cv2.LINE_AA)
 
 def plot_one_box_PIL(box, im, color=(128, 128, 128), label=None, line_thickness=None):
     # Plots one bounding box on image 'im' using PIL


### PR DESCRIPTION
Good day. 
I have been working on a script to make the labels see-through and just overall better looking in my opinion. To see the comparison please refer to Propose see-through labels. #4335
This is a boolean flag that is set to False by default so it won't change anything unless someone wants it then they can activate it by setting that flag to True. In my opinion, the see-through labels make it look much more elegant and would be a nice feature to have.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced object bounding box visualization in images with optional see-through labels.

### 📊 Key Changes
- Changed default line thickness from 3 to 2 for bounding boxes.
- Added `see_through` optional feature to make label backgrounds translucent.
- Improved text readability by blending bounding box colors with the label background.
- Provided a lighter border to the label frame when `see_through` is enabled.

### 🎯 Purpose & Impact
- 💅 **Visual Clarity**: Adjusting the line thickness fine-tunes the visual presentation of bounding boxes.
- **Flexibility**: The see-through label feature offers an alternative way to display labels, enhancing the visibility of underlying image details.
- 📈 **User Experience**: This makes it easier for users to interpret images, especially in congested scenes where multiple labels might overlap.
- **Increased Readability**: Merging label and bounding box colors aids in maintaining text legibility, ensuring labels are not only seen but also read clearly.