### PR TITLE
fix module count in parse_model

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -234,7 +234,7 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
             except:
                 pass
 
-        n = max(round(n * gd), 1) if n > 1 else n  # depth gain
+        n = n_ = max(round(n * gd), 1) if n > 1 else n  # depth gain
         if m in [Conv, GhostConv, Bottleneck, GhostBottleneck, SPP, DWConv, MixConv2d, Focus, CrossConv, BottleneckCSP,
                  C3, C3TR, C3SPP]:
             c1, c2 = ch[f], args[0]
@@ -264,7 +264,7 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
         t = str(m)[8:-2].replace('__main__.', '')  # module type
         np = sum([x.numel() for x in m_.parameters()])  # number params
         m_.i, m_.f, m_.type, m_.np = i, f, t, np  # attach index, 'from' index, type, number params
-        LOGGER.info('%3s%18s%3s%10.0f  %-40s%-30s' % (i, f, n, np, t, args))  # print
+        LOGGER.info('%3s%18s%3s%10.0f  %-40s%-30s' % (i, f, n_, np, t, args))  # print
         save.extend(x % i for x in ([f] if isinstance(f, int) else f) if x != -1)  # append to savelist
         layers.append(m_)
         if i == 0:


### PR DESCRIPTION
It seems the module count variable `n` in function `parse_model` will set to 1 when module is `BottleneckCSP`, `C3`, `C3TR`

https://github.com/ultralytics/yolov5/blob/e96c74b5a1c4a27934c5d8ad52cde778af248ed8/models/yolo.py#L245-L247

so the number in the log will always be 1.

I fix it by make a copy of `n`  




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated variable handling for layer depth in YOLOv5 model configuration.

### 📊 Key Changes
- Refactored the code to use a new variable `n_` to represent the actual layer depth after applying the depth gain.
- Updated the LOGGER information to use `n_` instead of `n` when outputting layer information.

### 🎯 Purpose & Impact
- 📈 **Enhanced Clarity**: This change ensures that the logging output reflects the true depth of the network layers after any scaling has been applied, making it clearer for developers to understand the model's architecture.
- 🔍 **Improved Debugging**: By assigning the scaled depth to a separate variable, developers can more easily track and debug layer depths during model configuration and experimentation.
- 🛠️ **Better Maintainability**: This separation of variables may also help in future proofing the code against changes in how layer depths are managed or scaled.