### PR TITLE
Fix rename `utils.google_utils` to `utils.downloads`

### DIFF
--- a/data/scripts/download_weights.sh
+++ b/data/scripts/download_weights.sh
@@ -9,7 +9,7 @@
 #     └── ...
 
 python - <<EOF
-from utils.google_utils import attempt_download
+from utils.downloads import attempt_download
 
 for x in ['s', 'm', 'l', 'x']:
     attempt_download(f'yolov5{x}.pt')

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -36,7 +36,7 @@ def safe_download(file, url, url2=None, min_bytes=1E0, error_msg=''):
         print('')
 
 
-def attempt_download(file, repo='ultralytics/yolov5'):  # from utils.google_utils import *; attempt_download()
+def attempt_download(file, repo='ultralytics/yolov5'):  # from utils.downloads import *; attempt_download()
     # Attempt file download if does not exist
     file = Path(str(file).strip().replace("'", ''))
 
@@ -74,7 +74,7 @@ def attempt_download(file, repo='ultralytics/yolov5'):  # from utils.google_util
 
 
 def gdrive_download(id='16TiPfZj7htmTyhntwcZyEEAejOUxuT6m', file='tmp.zip'):
-    # Downloads a file from Google Drive. from yolov5.utils.google_utils import *; gdrive_download()
+    # Downloads a file from Google Drive. from yolov5.utils.downloads import *; gdrive_download()
     t = time.time()
     file = Path(file)
     cookie = Path('cookie')  # gdrive cookie


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced download script by adjusting import paths and download utility references.

### 📊 Key Changes
- Modified the import statement in `download_weights.sh`, switching from `google_utils` to `downloads`.
- Updated comments in `downloads.py` to reflect the change of the import path from `google_utils` to `downloads`.

### 🎯 Purpose & Impact
- 🚀 Improves code maintainability by consolidating download functions into a single module, making it easier to manage.
- 🔍 Ensures that documentation within the code (comments) matches the actual code usage, reducing confusion for developers.
- 📦 This update should be seamless for users but set the stage for more straightforward updates or enhancements to downloading utilities in the future.