### PR TITLE
Update plots.py PIL box plotting

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -79,7 +79,7 @@ def plot_one_box(x, im, color=(128, 128, 128), label=None, line_thickness=3):
         cv2.putText(im, label, (c1[0], c1[1] - 2), 0, tl / 3, [225, 255, 255], thickness=tf, lineType=cv2.LINE_AA)
 
 
-def plot_one_box_PIL(box, im, color=(128, 128, 128), label=None, line_thickness=None):
+def plot_one_box_PIL(box, im, color=(128, 128, 128), label=None, line_thickness=3):
     # Plots one bounding box on image 'im' using PIL
     im = Image.fromarray(im)
     draw = ImageDraw.Draw(im)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced default line thickness for bounding box annotations.

### 📊 Key Changes
- The default `line_thickness` in the `plot_one_box_PIL` function is now set to `3`.

### 🎯 Purpose & Impact
- **Consistency:** This change aligns the default `line_thickness` of `plot_one_box_PIL` with the `plot_one_box` function, ensuring uniform appearance across different plotting methods.
- **Improved Visibility:** By setting a default line thickness, bounding boxes may become more visible, making it easier for users to identify objects in images. 🕵️‍♂️
- **User Convenience:** Users no longer need to specify a line thickness for a standard, aesthetically pleasing result. 👌