### PR TITLE
Remove DDP process group timeout

### DIFF
--- a/train.py
+++ b/train.py
@@ -493,7 +493,7 @@ def main(opt):
         assert not opt.sync_bn, '--sync-bn known training issue, see https://github.com/ultralytics/yolov5/issues/3998'
         torch.cuda.set_device(LOCAL_RANK)
         device = torch.device('cuda', LOCAL_RANK)
-        dist.init_process_group(backend="nccl" if dist.is_nccl_available() else "gloo", timeout=timedelta(seconds=60))
+        dist.init_process_group(backend="nccl" if dist.is_nccl_available() else "gloo")
 
     # Train
     if not opt.evolve:

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -35,10 +35,10 @@ def torch_distributed_zero_first(local_rank: int):
     Decorator to make all processes in distributed training wait for each local_master to do something.
     """
     if local_rank not in [-1, 0]:
-        dist.barrier()
+        dist.barrier(device_ids=[local_rank])
     yield
     if local_rank == 0:
-        dist.barrier()
+        dist.barrier(device_ids=[0])
 
 
 def init_torch_seeds(seed=0):


### PR DESCRIPTION
Attempted fix for torch 1.9.0 DDP issues.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced distributed training initialization and barriers for better device handling in YOLOv5 🚀

### 📊 Key Changes
- Removed the 60 second timeout when initializing the distributed processing group in `train.py`.
- Updated `dist.barrier()` calls to specify `device_ids` in `utils/torch_utils.py`, ensuring barriers are device-aware.

### 🎯 Purpose & Impact
- The removal of the timeout during distributed training could avoid unnecessary interruptions and may allow for more flexibility on systems with variable initialization times.
- Specifying `device_ids` for the barriers ensures that the synchronization is applied properly to specific GPUs, which could improve the efficiency and stability of distributed training.
- These changes may result in smoother and potentially faster training experiences for users utilizing distributed setups for their YOLOv5 trainings. 💨👩‍💻👨‍💻