### PR TITLE
Allow data.yaml source for detect.py

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -21,14 +21,14 @@ sys.path.append(FILE.parents[0].as_posix())  # add yolov5/ to path
 from models.experimental import attempt_load
 from utils.datasets import LoadStreams, LoadImages
 from utils.general import check_img_size, check_requirements, check_imshow, colorstr, non_max_suppression, \
-    apply_classifier, scale_coords, xyxy2xywh, strip_optimizer, set_logging, increment_path, save_one_box
+    apply_classifier, scale_coords, xyxy2xywh, strip_optimizer, set_logging, increment_path, save_one_box, check_dataset
 from utils.plots import colors, plot_one_box
 from utils.torch_utils import select_device, load_classifier, time_sync
 
 
 @torch.no_grad()
 def run(weights='yolov5s.pt',  # model.pt path(s)
-        source='data/images',  # file/dir/URL/glob, 0 for webcam
+        source='data/images',  # file/dir/URL/glob/data.yaml, 0 for webcam
         imgsz=640,  # inference size (pixels)
         conf_thres=0.25,  # confidence threshold
         iou_thres=0.45,  # NMS IOU threshold
@@ -55,6 +55,9 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
     webcam = source.isnumeric() or source.endswith('.txt') or source.lower().startswith(
         ('rtsp://', 'rtmp://', 'http://', 'https://'))
+    if source.endswith('.yaml'):
+        source = check_dataset(source)['test']
+        webcam = False
 
     # Directories
     save_dir = increment_path(Path(project) / name, exist_ok=exist_ok)  # increment run
@@ -203,7 +206,7 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
 def parse_opt():
     parser = argparse.ArgumentParser()
     parser.add_argument('--weights', nargs='+', type=str, default='yolov5s.pt', help='model.pt path(s)')
-    parser.add_argument('--source', type=str, default='data/images', help='file/dir/URL/glob, 0 for webcam')
+    parser.add_argument('--source', type=str, default='data/images', help='file/dir/URL/glob/data.yaml, 0 for webcam')
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='inference size (pixels)')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='confidence threshold')
     parser.add_argument('--iou-thres', type=float, default=0.45, help='NMS IoU threshold')

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -161,8 +161,16 @@ class LoadImages:  # for inference
             files = sorted(glob.glob(p, recursive=True))  # glob
         elif os.path.isdir(p):
             files = sorted(glob.glob(os.path.join(p, '*.*')))  # dir
+
         elif os.path.isfile(p):
-            files = [p]  # files
+            if p.endswith('.txt'):
+                with open(p, 'r') as t:
+                    t = t.read().strip().splitlines()
+                    parent = str(Path(path).absolute().parent) + os.sep
+                    files = [x.replace('./', parent) if x.startswith('./') else x for x in t]  # local to global path
+                    print(files)
+            else:
+                files = [p]  # files
         else:
             raise Exception(f'ERROR: {p} does not exist')
 


### PR DESCRIPTION
* Use the test set path given in yaml file
* My specific use case is when I have used the autosplit script to generate text files, I do not want to have to create a folder with the test images rather simply use the data.yaml file

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved `detect.py` to accept YAML configuration files as input sources.

### 📊 Key Changes
- Extended the `--source` parameter to handle `.yaml` configuration files, in addition to existing sources.
- Updated `LoadImages` class to process `.txt` files correctly, resolving paths for images.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: Allows users to directly use YAML files to specify test datasets, simplifying the process of running detections on predefined datasets.
- 💡 **Impact**: Makes the tool more flexible and user-friendly, as users can now input a dataset configuration file to run detection tasks, streamlining the workflow for batch processing.