### PR TITLE
Fix missing labels after albumentations

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -568,8 +568,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         if self.augment:
             # Albumentations
             img, labels = self.albumentations(img, labels)
-
-            nl = len(labels) # update number of labels after augmentation
+            nl = len(labels) # update after albumentations
 
             # HSV color-space
             augment_hsv(img, hgain=hyp['hsv_h'], sgain=hyp['hsv_s'], vgain=hyp['hsv_v'])

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -569,6 +569,8 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
             # Albumentations
             img, labels = self.albumentations(img, labels)
 
+            nl = len(labels) # update number of labels after augmentation
+
             # HSV color-space
             augment_hsv(img, hgain=hyp['hsv_h'], sgain=hyp['hsv_s'], vgain=hyp['hsv_v'])
 


### PR DESCRIPTION
I was testing various Albumentations data augmentations for my model. When applied the methods that possibly result in losing bounding boxes such as RandomSizedCrop, RandomResizedCrop, etc. (see the docs [here](https://albumentations.ai/docs/api_reference/augmentations/crops/transforms/)), I got a Runtime Error because the labels were missing (due to transformation).
All we need to do is to update the number of labels after Albumentations transformation.

Thanks for creating a great repo. I just want to contribute a little! ;)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced label handling post-image augmentation in YOLOv5's data pipeline.

### 📊 Key Changes
- Added a line of code to update the number of labels after image augmentations using Albumentations.

### 🎯 Purpose & Impact
- Ensures the number of object labels remains accurate after any image transformations (such as rotations, flips, etc.), which is critical for correct model training.
- 📈 Improves data consistency, leading to potentially better model performance and reliability.
- 🛠️ Users can expect more robust training behavior, particularly when using advanced data augmentation techniques.