### PR TITLE
Fix default `--weights yolov5s.pt`

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -244,7 +244,7 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
 
 def parse_opt():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--weights', nargs='+', type=str, default='yolov5s.pb', help='model.pt path(s)')
+    parser.add_argument('--weights', nargs='+', type=str, default='yolov5s.pt', help='model.pt path(s)')
     parser.add_argument('--source', type=str, default='data/images', help='file/dir/URL/glob, 0 for webcam')
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[640], help='inference size h,w')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='confidence threshold')


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated the default model weight file in `detect.py`.

### 📊 Key Changes
- Changed the default weights file from `yolov5s.pb` to `yolov5s.pt`.

### 🎯 Purpose & Impact
- Ensures users are encouraged to use the correct model format `.pt` (PyTorch) instead of `.pb` (TensorFlow), aligning with YOLOv5's default model framework.
- It may prevent confusion and errors for new users starting out with the detection script, improving the out-of-the-box experience. 🛠️
- Current users who are using TensorFlow weights may need to adjust their workflow to use the specified PyTorch weights. 🔄