### PR TITLE
bug fix

### DIFF
--- a/val.py
+++ b/val.py
@@ -84,7 +84,7 @@ def run(data,
         conf_thres=0.001,  # confidence threshold
         iou_thres=0.6,  # NMS IoU threshold
         task='val',  # train, val, test, speed or study
-        device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
+        device='0',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
         single_cls=False,  # treat as single-class dataset
         augment=False,  # augmented inference
         verbose=False,  # verbose output


### PR DESCRIPTION
**when I training own datasets,I got errors as flower:**
`python
 Epoch   gpu_mem       box       obj       cls    labels  img_size
       0/4     7.23G   0.06394   0.02616         0       719      1280: 100%|███████████████████████████████████████████| 172/172 [04:09<00:00,  1.45s/it]
               Class     Images     Labels          P          R     mAP@.5 mAP@.5:.95:   0%|                                       | 0/6 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/home/ai/sabo/project/yolov5-master/train.py", line 600, in <module>
    main(opt)
  File "/home/ai/sabo/project/yolov5-master/train.py", line 498, in main
    train(opt.hyp, opt, device)
  File "/home/ai/sabo/project/yolov5-master/train.py", line 353, in train
    results, maps, _ = val.run(data_dict,
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/home/ai/sabo/project/yolov5-master/val.py", line 167, in run
    out, train_out = model(img, augment=augment)  # inference and training outputs
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/ai/sabo/project/yolov5-master/models/yolo.py", line 122, in forward
    return self.forward_once(x, profile, visualize)  # single-scale inference, train
  File "/home/ai/sabo/project/yolov5-master/models/yolo.py", line 153, in forward_once
    x = m(x)  # run
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/ai/sabo/project/yolov5-master/models/common.py", line 176, in forward
    return self.conv(torch.cat([x[..., ::2, ::2], x[..., 1::2, ::2], x[..., ::2, 1::2], x[..., 1::2, 1::2]], 1))
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/ai/sabo/project/yolov5-master/models/common.py", line 41, in forward
    return self.act(self.bn(self.conv(x)))
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/nn/modules/conv.py", line 399, in forward
    return self._conv_forward(input, self.weight, self.bias)
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/nn/modules/conv.py", line 395, in _conv_forward
    return F.conv2d(input, weight, bias, self.stride,
RuntimeError: Unable to find a valid cuDNN algorithm to run convolution
`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced device selection defaults for model validation in YOLOv5.

### 📊 Key Changes
- Default CUDA device for validation changed from an empty string `''` to `'0'`.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: This update ensures that, by default, model validation will occur on the first CUDA-capable GPU device.
- 💡 **Impact**: Users who run validation without specifying a device will now automatically use GPU 0 if available, possibly leading to improved performance. This change primarily affects those who may have unknowingly been validating on CPU due to not setting the device parameter explicitly.