### PR TITLE
Fix the bug that val fails to run during training

### DIFF
--- a/val.py
+++ b/val.py
@@ -84,7 +84,7 @@ def run(data,
         conf_thres=0.001,  # confidence threshold
         iou_thres=0.6,  # NMS IoU threshold
         task='val',  # train, val, test, speed or study
-        device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
+        device='0',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
         single_cls=False,  # treat as single-class dataset
         augment=False,  # augmented inference
         verbose=False,  # verbose output


### PR DESCRIPTION
`
python train.py --device 0,1,2,3,4,5,6,7
`
---
**Error**
---
```python
     Epoch   gpu_mem       box       obj       cls    labels  img_size
       0/4     7.23G   0.06394   0.02616         0       719      1280: 100%|███████████████████████████████████████████| 172/172 [04:09<00:00,  1.45s/it]
               Class     Images     Labels          P          R     mAP@.5 mAP@.5:.95:   0%|                                       | 0/6 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/home/ai/sabo/project/yolov5-master/train.py", line 600, in <module>
    main(opt)
  File "/home/ai/sabo/project/yolov5-master/train.py", line 498, in main
    train(opt.hyp, opt, device)
  File "/home/ai/sabo/project/yolov5-master/train.py", line 353, in train
    results, maps, _ = val.run(data_dict,
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/home/ai/sabo/project/yolov5-master/val.py", line 167, in run
    out, train_out = model(img, augment=augment)  # inference and training outputs
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/ai/sabo/project/yolov5-master/models/yolo.py", line 122, in forward
    return self.forward_once(x, profile, visualize)  # single-scale inference, train
  File "/home/ai/sabo/project/yolov5-master/models/yolo.py", line 153, in forward_once
    x = m(x)  # run
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/ai/sabo/project/yolov5-master/models/common.py", line 176, in forward
    return self.conv(torch.cat([x[..., ::2, ::2], x[..., 1::2, ::2], x[..., ::2, 1::2], x[..., 1::2, 1::2]], 1))
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/ai/sabo/project/yolov5-master/models/common.py", line 41, in forward
    return self.act(self.bn(self.conv(x)))
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/nn/modules/conv.py", line 399, in forward
    return self._conv_forward(input, self.weight, self.bias)
  File "/home/ai/anaconda3/lib/python3.8/site-packages/torch/nn/modules/conv.py", line 395, in _conv_forward
    return F.conv2d(input, weight, bias, self.stride,
RuntimeError: Unable to find a valid cuDNN algorithm to run convolution

```
---
**modified val.py -->val.run( ... device='0',...)**
---
```python
Epoch   gpu_mem       box       obj       cls    labels  img_size
       0/4     7.22G   0.06409   0.02592         0       719      1280: 100%|███████████████████████████████████████████| 172/172 [04:44<00:00,  1.65s/it]
               Class     Images     Labels          P          R     mAP@.5 mAP@.5:.95: 100%|███████████████████████████| 745/745 [02:13<00:00,  5.59it/s]
                 all        745      40587   0.000898   0.000567   4.86e-06   7.83e-07

     Epoch   gpu_mem       box       obj       cls    labels  img_size
       1/4     7.22G   0.06157   0.02216         0       722      1280: 100%|███████████████████████████████████████████| 172/172 [03:06<00:00,  1.08s/it]
               Class     Images     Labels          P          R     mAP@.5 mAP@.5:.95: 100%|███████████████████████████| 745/745 [01:38<00:00,  7.53it/s]
                 all        745      40587   0.000286   0.000788   1.91e-06   3.95e-07

     Epoch   gpu_mem       box       obj       cls    labels  img_size
       2/4     7.22G   0.06115   0.02191         0       738      1280: 100%|███████████████████████████████████████████| 172/172 [03:09<00:00,  1.10s/it]
               Class     Images     Labels          P          R     mAP@.5 mAP@.5:.95: 100%|███████████████████████████| 745/745 [02:11<00:00,  5.69it/s]
                 all        745      40587    0.00103   0.000838   6.58e-06   1.31e-06
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved default device setting for validation in YOLOv5.

### 📊 Key Changes
- Changed the default value for the `device` parameter from an empty string `''` to `'0'` in the validation script `val.py`.

### 🎯 Purpose & Impact
- Ensures that the validation script uses the first CUDA device by default if no device is specified, which might streamline the process for users who are less familiar with CUDA device settings.
- This change could improve the user experience by providing a sensible default that reduces initial setup effort.
- It might affect users running validation on systems with multiple GPUs, prompting them to specify the device explicitly if they do not want to use the first device (GPU 0).