### PR TITLE
Added option to Black out or Remove Frames which don't have objects to reduce overall output size 

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -52,6 +52,7 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
         hide_labels=False,  # hide labels
         hide_conf=False,  # hide confidences
         half=False,  # use FP16 half-precision inference
+        emptyframes=False,  # Black out frames which dont have an object
         ):
     save_img = not nosave and not source.endswith('.txt')  # save inference images
     webcam = source.isnumeric() or source.endswith('.txt') or source.lower().startswith(
@@ -230,6 +231,8 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
                             fps, w, h = 30, im0.shape[1], im0.shape[0]
                             save_path += '.mp4'
                         vid_writer[i] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
+                    if emptyframes and len(det)==0:
+                        im0=im0*0
                     vid_writer[i].write(im0)
 
     if save_txt or save_img:
@@ -268,6 +271,7 @@ def parse_opt():
     parser.add_argument('--hide-labels', default=False, action='store_true', help='hide labels')
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
+    parser.add_argument('--emptyframes', action='store_true', help='Black out frames which dont have an object')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     return opt

--- a/detect.py
+++ b/detect.py
@@ -52,7 +52,7 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
         hide_labels=False,  # hide labels
         hide_conf=False,  # hide confidences
         half=False,  # use FP16 half-precision inference
-        emptyframes=False,  # Black out frames which dont have an object
+        emptyframes=-1,  # Black out or remove frames which dont have an object
         ):
     save_img = not nosave and not source.endswith('.txt')  # save inference images
     webcam = source.isnumeric() or source.endswith('.txt') or source.lower().startswith(
@@ -231,9 +231,10 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
                             fps, w, h = 30, im0.shape[1], im0.shape[0]
                             save_path += '.mp4'
                         vid_writer[i] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
-                    if emptyframes and len(det)==0:
+                    if emptyframes==0 and len(det)==0:
                         im0=im0*0
-                    vid_writer[i].write(im0)
+                    if (not emptyframes==1) or (emptyframes==1 and len(det)>0):
+                        vid_writer[i].write(im0)
 
     if save_txt or save_img:
         s = f"\n{len(list(save_dir.glob('labels/*.txt')))} labels saved to {save_dir / 'labels'}" if save_txt else ''
@@ -271,7 +272,7 @@ def parse_opt():
     parser.add_argument('--hide-labels', default=False, action='store_true', help='hide labels')
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
-    parser.add_argument('--emptyframes', action='store_true', help='Black out frames which dont have an object')
+    parser.add_argument('--emptyframes', type=int, default=-1, help='specify 0 to Black out and 1 to remove frames which dont have an object')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     return opt


### PR DESCRIPTION
An Enhancement was requested in #4507 
The Enhancement requested was to add a feature/option which will remove or black out frames which don't have an object so that the output contains only useful frames for many purposes.
I have added an option  --emptyframes, passing it as an option will black out a frames if no objects were detected in that particular frame. I believe adding this option will help in many utilities while decreasing the output size of the video without disturbing any inference.
During detections on each frame, I have checked if number of detections are zero **and** if emptyframes as been passed as a parameter as well, then the image array to write is set to 0. The default value for emptyframes has been set to False.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
New feature to manage frames without detected objects in video processing.

### 📊 Key Changes
- Added an `emptyframes` parameter to the `run()` function in `detect.py`.
- Logic to either black out or remove frames without any detected objects during video file output.

### 🎯 Purpose & Impact
- **Purpose**: Provides users with the option to handle frames that don't contain any detected objects in a video. This could be useful for focusing on frames where objects are present, or for privacy reasons when objects aren't recognized.
- **Impact**: Users now can choose to have blank frames where no detections occur or to exclude these frames altogether, potentially saving on storage and making video analysis more efficient.