### PR TITLE
Fix for corrupt JPEGs auto-fix PR

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -873,7 +873,7 @@ def verify_image_label(args):
             with open(im_file, 'rb') as f:
                 f.seek(-2, 2)
                 if f.read() != b'\xff\xd9':  # corrupt JPEG
-                    im.save(im_file, format='JPEG', subsampling=0, quality=100)  # re-save image
+                    Image.open(im_file).save(im_file, format='JPEG', subsampling=0, quality=100)  # re-save image
                     msg = f'{prefix}WARNING: corrupt JPEG restored and saved {im_file}'
 
         # verify labels


### PR DESCRIPTION
Auto-fix corrupt JPEGs PR #4548 introduced a bug whereby the f.seek() operation read all of the bytes in the image, resulting in the PIL image having nothing to read upon the .save() operation. 

Fix was to re-open the image using PIL before saving.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced JPEG image corruption handling in dataset utility.

### 📊 Key Changes
- Modified the way corrupt JPEG images are re-saved, using `Image.open()` to re-initialize the image before saving.

### 🎯 Purpose & Impact
- **Purpose:** The change aims to improve the robustness of the image corruption detection and handling during data loading.
- **Impact:** Users can expect a more reliable data pre-processing step, leading to potentially fewer errors when training models with corrupted JPEG files. 🛠📈