### PR TITLE
Fix for AP calculation limits 0.0 - 1.0

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -91,8 +91,8 @@ def compute_ap(recall, precision):
     """
 
     # Append sentinel values to beginning and end
-    mrec = np.concatenate(([0.], recall, [recall[-1] + 0.01]))
-    mpre = np.concatenate(([1.], precision, [0.]))
+    mrec = np.concatenate(([0.0], recall, [1.0]))
+    mpre = np.concatenate(([1.0], precision, [0.0]))
 
     # Compute the precision envelope
     mpre = np.flip(np.maximum.accumulate(np.flip(mpre)))


### PR DESCRIPTION
This PR brings alignment in AP computation practices with Detectron2 and MMDetection. 

Problem first noted by @yusiyoh in https://github.com/ultralytics/yolov5/issues/4546

Results in a slight increase in repo mAP, i.e. 49.0 to 49.3 with YOLOv5x at --img 640.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved accuracy calculation in YOLOv5 model evaluation.

### 📊 Key Changes
- Modified the sentinel values appended to recall and precision in the `compute_ap` function.

### 🎯 Purpose & Impact
- 🎨 **Accuracy:** Adjusting sentinel values aids in a more accurate computation of Average Precision (AP), a key metric for evaluating object detection models.
- 🔍 **Clarity:** By setting the recall upper limit to 1.0, the AP calculation becomes more intuitive and aligned with standard practices.
- ✅ **User Confidence:** Improved metric calculations lead to better trust in the model's performance indicators for users who rely on YOLOv5 for object detection tasks.