### PR TITLE
Add EarlyStopping feature

### DIFF
--- a/train.py
+++ b/train.py
@@ -348,6 +348,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         lr = [x['lr'] for x in optimizer.param_groups]  # for loggers
         scheduler.step()
 
+        stop = False
         if RANK in [-1, 0]:
             # mAP
             callbacks.on_train_epoch_end(epoch=epoch)

--- a/train.py
+++ b/train.py
@@ -391,12 +391,13 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 del ckpt
                 callbacks.on_model_save(last, epoch, final_epoch, best_fitness, fi)
 
-            # Stop
+        # Stop
+        with torch_distributed_zero_first(RANK):
             stop = stopper(epoch=epoch, fitness=fi)
             if RANK == 0:
                 dist.broadcast_object_list([stop])
-        if stop:
-            break
+            if stop:
+                break
 
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training -----------------------------------------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -392,8 +392,11 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 callbacks.on_model_save(last, epoch, final_epoch, best_fitness, fi)
 
             # Stop
-            if stopper(epoch=epoch, fitness=fi):
-                break
+            stop = stopper(epoch=epoch, fitness=fi)
+            if RANK == 0:
+                dist.broadcast_object_list([stop])
+        if stop:
+            break
 
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training -----------------------------------------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -399,6 +399,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
         # Stop
         with torch_distributed_zero_first(RANK):
+            print(RANK, stop)
             if stop:
                 break
 

--- a/train.py
+++ b/train.py
@@ -395,12 +395,14 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
             # Stop
             stop = stopper(epoch=epoch, fitness=fi)
             if RANK == 0:
-                dist.broadcast_object_list([stop])
+                dist.Store.set('stop', stop)
 
         # Stop
-        # with torch_distributed_zero_first(RANK):
-        if stop:
-            break
+        with torch_distributed_zero_first(RANK):
+            if RANK != -1:
+                stop = dist.Store.get('stop')
+            if stop:
+                break
 
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training -----------------------------------------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -395,7 +395,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
             if stopper(epoch=epoch, fitness=fi):
                 break
 
-            # Stop DDP
+            # Stop DDP TODO: known issues shttps://github.com/ultralytics/yolov5/pull/4576
             # stop = stopper(epoch=epoch, fitness=fi)
             # if RANK == 0:
             #    dist.broadcast_object_list([stop], 0)  # broadcast 'stop' to all ranks

--- a/train.py
+++ b/train.py
@@ -395,12 +395,10 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
             # Stop
             stop = stopper(epoch=epoch, fitness=fi)
             if RANK == 0:
-                dist.Store.set('stop', stop)
+                dist.broadcast_object_list([stop], 0)
 
         # Stop
         with torch_distributed_zero_first(RANK):
-            if RANK != -1:
-                stop = dist.Store.get('stop')
             if stop:
                 break
 

--- a/train.py
+++ b/train.py
@@ -391,13 +391,15 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 del ckpt
                 callbacks.on_model_save(last, epoch, final_epoch, best_fitness, fi)
 
-        # Stop
-        with torch_distributed_zero_first(RANK):
+            # Stop
             stop = stopper(epoch=epoch, fitness=fi)
-            # if RANK == 0:
-            #    dist.broadcast_object_list([stop])
-            if stop:
-                break
+            if RANK == 0:
+                dist.broadcast_object_list([stop])
+
+        # Stop
+        # with torch_distributed_zero_first(RANK):
+        if stop:
+            break
 
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training -----------------------------------------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -391,14 +391,13 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 del ckpt
                 callbacks.on_model_save(last, epoch, final_epoch, best_fitness, fi)
 
-            stop = stopper(epoch=epoch, fitness=fi)
-
         # Stop
         with torch_distributed_zero_first(RANK):
-            if RANK == 0:
-                dist.broadcast_object_list([stop])
-        if stop:
-            break
+            stop = stopper(epoch=epoch, fitness=fi)
+            # if RANK == 0:
+            #    dist.broadcast_object_list([stop])
+            if stop:
+                break
 
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training -----------------------------------------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -391,13 +391,14 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 del ckpt
                 callbacks.on_model_save(last, epoch, final_epoch, best_fitness, fi)
 
+            stop = stopper(epoch=epoch, fitness=fi)
+
         # Stop
         with torch_distributed_zero_first(RANK):
-            stop = stopper(epoch=epoch, fitness=fi)
             if RANK == 0:
                 dist.broadcast_object_list([stop])
-            if stop:
-                break
+        if stop:
+            break
 
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training -----------------------------------------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -348,7 +348,6 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         lr = [x['lr'] for x in optimizer.param_groups]  # for loggers
         scheduler.step()
 
-        stop = False
         if RANK in [-1, 0]:
             # mAP
             callbacks.on_train_epoch_end(epoch=epoch)
@@ -394,14 +393,14 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
             # Stop
             stop = stopper(epoch=epoch, fitness=fi)
-            #if RANK == 0:
-            #    dist.broadcast_object_list([stop], 0)
+            if RANK == 0:
+                dist.broadcast_object_list([stop], 0)
 
         # Stop
-        #with torch_distributed_zero_first(RANK):
-        print(RANK, stop)
-        if stop:
-            break
+        with torch_distributed_zero_first(RANK):
+            print(RANK, stop)
+            if stop:
+                break
 
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training -----------------------------------------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -40,7 +40,8 @@ from utils.general import labels_to_class_weights, increment_path, labels_to_ima
 from utils.downloads import attempt_download
 from utils.loss import ComputeLoss
 from utils.plots import plot_labels, plot_evolve
-from utils.torch_utils import ModelEMA, select_device, intersect_dicts, torch_distributed_zero_first, de_parallel
+from utils.torch_utils import EarlyStopping, ModelEMA, de_parallel, intersect_dicts, select_device, \
+    torch_distributed_zero_first
 from utils.loggers.wandb.wandb_utils import check_wandb_resume
 from utils.metrics import fitness
 from utils.loggers import Loggers
@@ -255,6 +256,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     results = (0, 0, 0, 0, 0, 0, 0)  # P, R, mAP@.5, mAP@.5-.95, val_loss(box, obj, cls)
     scheduler.last_epoch = start_epoch - 1  # do not move
     scaler = amp.GradScaler(enabled=cuda)
+    stopper = EarlyStopping(patience=opt.patience)
     compute_loss = ComputeLoss(model)  # init loss class
     LOGGER.info(f'Image sizes {imgsz} train, {imgsz} val\n'
                 f'Using {train_loader.num_workers} dataloader workers\n'
@@ -389,6 +391,10 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 del ckpt
                 callbacks.on_model_save(last, epoch, final_epoch, best_fitness, fi)
 
+            # Stop
+            if stopper(epoch=epoch, fitness=fi):
+                break
+
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training -----------------------------------------------------------------------------------------------------
     if RANK in [-1, 0]:
@@ -454,6 +460,7 @@ def parse_opt(known=False):
     parser.add_argument('--artifact_alias', type=str, default="latest", help='version of dataset artifact to be used')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
     parser.add_argument('--freeze', type=int, default=0, help='Number of layers to freeze. backbone=10, all=24')
+    parser.add_argument('--patience', type=int, default=30, help='EarlyStopping patience (epochs)')
     opt = parser.parse_known_args()[0] if known else parser.parse_args()
     return opt
 

--- a/train.py
+++ b/train.py
@@ -391,16 +391,19 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 del ckpt
                 callbacks.on_model_save(last, epoch, final_epoch, best_fitness, fi)
 
-            # Stop
-            stop = stopper(epoch=epoch, fitness=fi)
-            if RANK == 0:
-                dist.broadcast_object_list([stop], 0)
-
-        # Stop
-        with torch_distributed_zero_first(RANK):
-            print(RANK, stop)
-            if stop:
+            # Stop Single-GPU
+            if stopper(epoch=epoch, fitness=fi):
                 break
+
+            # Stop DDP
+            # stop = stopper(epoch=epoch, fitness=fi)
+            # if RANK == 0:
+            #    dist.broadcast_object_list([stop], 0)  # broadcast 'stop' to all ranks
+
+        # Stop DPP
+        # with torch_distributed_zero_first(RANK):
+        # if stop:
+        #    break  # must break all DDP ranks
 
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training -----------------------------------------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -394,8 +394,8 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
             # Stop
             stop = stopper(epoch=epoch, fitness=fi)
-            if RANK == 0:
-                dist.broadcast_object_list([stop], 0)
+            #if RANK == 0:
+            #    dist.broadcast_object_list([stop], 0)
 
         # Stop
         #with torch_distributed_zero_first(RANK):

--- a/train.py
+++ b/train.py
@@ -398,10 +398,10 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 dist.broadcast_object_list([stop], 0)
 
         # Stop
-        with torch_distributed_zero_first(RANK):
-            print(RANK, stop)
-            if stop:
-                break
+        #with torch_distributed_zero_first(RANK):
+        print(RANK, stop)
+        if stop:
+            break
 
         # end epoch ----------------------------------------------------------------------------------------------------
     # end training -----------------------------------------------------------------------------------------------------

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -301,7 +301,7 @@ class EarlyStopping:
         self.patience = patience  # epochs to wait after fitness stops improving to stop
 
     def __call__(self, epoch, fitness):
-        if fitness >= self.best_fitness:  # >= 0 to allow for early zero-fitness stage of training
+        if fitness > self.best_fitness:  # >= 0 to allow for early zero-fitness stage of training
             self.best_epoch = epoch
             self.best_fitness = fitness
         stop = (epoch - self.best_epoch) >= self.patience  # stop training if patience exceeded

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -293,6 +293,23 @@ def copy_attr(a, b, include=(), exclude=()):
             setattr(a, k, v)
 
 
+class EarlyStopping:
+    # YOLOv5 simple early stopper
+    def __init__(self, patience=30):
+        self.best_fitness = 0  # i.e. mAP
+        self.best_epoch = 0
+        self.patience = patience
+
+    def __call__(self, epoch, fitness):
+        if fitness > self.best_fitness:
+            self.best_epoch = epoch
+            self.best_fitness = fitness
+        stop = (epoch - self.best_epoch) > self.patience  # stop training if patience exceeded
+        if stop:
+            LOGGER.info(f'EarlyStopping patience {self.patience} exceeded, stopping training.')
+        return stop
+
+
 class ModelEMA:
     """ Model Exponential Moving Average from https://github.com/rwightman/pytorch-image-models
     Keep a moving average of everything in the model state_dict (parameters and buffers).

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -301,7 +301,7 @@ class EarlyStopping:
         self.patience = patience  # epochs to wait after fitness stops improving to stop
 
     def __call__(self, epoch, fitness):
-        if fitness > self.best_fitness:
+        if fitness >= self.best_fitness:  # >= 0 to allow for early zero-fitness stage of training
             self.best_epoch = epoch
             self.best_fitness = fitness
         stop = (epoch - self.best_epoch) > self.patience  # stop training if patience exceeded

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -298,7 +298,7 @@ class EarlyStopping:
     def __init__(self, patience=30):
         self.best_fitness = 0  # i.e. mAP
         self.best_epoch = 0
-        self.patience = patience
+        self.patience = patience  # epochs to wait after fitness stops improving to stop
 
     def __call__(self, epoch, fitness):
         if fitness > self.best_fitness:

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -301,7 +301,7 @@ class EarlyStopping:
         self.patience = patience  # epochs to wait after fitness stops improving to stop
 
     def __call__(self, epoch, fitness):
-        if fitness > self.best_fitness:  # >= 0 to allow for early zero-fitness stage of training
+        if fitness >= self.best_fitness:  # >= 0 to allow for early zero-fitness stage of training
             self.best_epoch = epoch
             self.best_fitness = fitness
         stop = (epoch - self.best_epoch) >= self.patience  # stop training if patience exceeded

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -296,7 +296,7 @@ def copy_attr(a, b, include=(), exclude=()):
 class EarlyStopping:
     # YOLOv5 simple early stopper
     def __init__(self, patience=30):
-        self.best_fitness = 0  # i.e. mAP
+        self.best_fitness = 0.0  # i.e. mAP
         self.best_epoch = 0
         self.patience = patience  # epochs to wait after fitness stops improving to stop
 
@@ -304,7 +304,7 @@ class EarlyStopping:
         if fitness >= self.best_fitness:  # >= 0 to allow for early zero-fitness stage of training
             self.best_epoch = epoch
             self.best_fitness = fitness
-        stop = (epoch - self.best_epoch) > self.patience  # stop training if patience exceeded
+        stop = (epoch - self.best_epoch) >= self.patience  # stop training if patience exceeded
         if stop:
             LOGGER.info(f'EarlyStopping patience {self.patience} exceeded, stopping training.')
         return stop


### PR DESCRIPTION
PR adds EarlyStopping feature, defaults to 30 epochs of patience.

@SkalskiP @KalenMike 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Implementation of an EarlyStopping feature in YOLOv5 training pipeline

### 📊 Key Changes
- 🆕 Added `EarlyStopping` class to `utils/torch_utils.py`. 
- 🔧 Introduced `stopper` object in `train.py` that uses the new EarlyStopping feature.
- 💥 Included a `--patience` argument in training script to customize the EarlyStopping patience.

### 🎯 Purpose & Impact
- ⏱️ The purpose is to stop training early if the model's performance stops improving, saving time and resources.
- 📈 This could positively impact model training efficiency by preventing overfitting and reducing unnecessary computations.
- 👩‍💻 Users can set their preferred `patience` level, giving them control over when the training should halt based on their specific use-cases and constraints.