### PR TITLE
Add `Profile()` profiler

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -48,8 +48,8 @@ class Profile(contextlib.ContextDecorator):
         print(f'Profile results: {time.time() - self.start:.5f}s')
 
 
-class timeout(contextlib.ContextDecorator):
-    # Usage: @timeout(seconds) decorator or 'with timeout(seconds):' context manager
+class Timeout(contextlib.ContextDecorator):
+    # Usage: @Timeout(seconds) decorator or 'with Timeout(seconds):' context manager
     def __init__(self, seconds, *, timeout_msg='', suppress_timeout_errors=True):
         self.seconds = int(seconds)
         self.timeout_message = timeout_msg

--- a/utils/general.py
+++ b/utils/general.py
@@ -39,6 +39,15 @@ cv2.setNumThreads(0)  # prevent OpenCV from multithreading (incompatible with Py
 os.environ['NUMEXPR_MAX_THREADS'] = str(min(os.cpu_count(), 8))  # NumExpr max threads
 
 
+class Profile(contextlib.ContextDecorator):
+    # Usage: @Profile() decorator or 'with Profile():' context manager
+    def __enter__(self):
+        self.start = time.time()
+
+    def __exit__(self, type, value, traceback):
+        print(f'Profile results: {time.time() - self.start:.5f}s')
+
+
 class timeout(contextlib.ContextDecorator):
     # Usage: @timeout(seconds) decorator or 'with timeout(seconds):' context manager
     def __init__(self, seconds, *, timeout_msg='', suppress_timeout_errors=True):


### PR DESCRIPTION
Usage example:

```python
import contextlib
import time


class Profile(contextlib.ContextDecorator):
    # Usage: @Profile() decorator or 'with Profile():' context manager
    def __enter__(self):
        self.start = time.time()

    def __exit__(self, type, value, traceback):
        print(f'Profile results: {time.time() - self.start:.5f}s')


def get_number():
    for x in range(5000000):
        yield x


@Profile()
def expensive_function():
    for x in get_number():
        i = x ^ x ^ x
    return 'some result!'


# "Profile results: 0.68269s"
result = expensive_function()

# "Profile results: 0.00000s"
with Profile():
    get_number()

```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Implementation of a new `Profile` class and renaming the `timeout` class to `Timeout` in `utils/general.py`.

### 📊 Key Changes
- Added a new class called `Profile` for timing blocks of code or functions.
- Renamed the existing `timeout` class to `Timeout` to adhere to Python naming conventions.

### 🎯 Purpose & Impact
- The `Profile` class allows developers and users to measure the execution time of code sections, which can help in identifying performance bottlenecks.
- The renaming to `Timeout` improves code readability and follows the convention of class names starting with a capital letter, which can make the codebase more consistent and easier to understand for new users.
- These changes should not affect the functionality of existing code using the old `timeout` class, but will offer additional utility for performance profiling.