### PR TITLE
Fix bug in `plot_one_box` when label is `None`

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -72,7 +72,7 @@ def plot_one_box(box, im, color=(128, 128, 128), txt_color=(255, 255, 255), labe
     assert im.data.contiguous, 'Image not contiguous. Apply np.ascontiguousarray(im) to plot_on_box() input image.'
     lw = line_width or max(int(min(im.size) / 200), 2)  # line width
 
-    if use_pil or not is_ascii(label):  # use PIL
+    if use_pil or (label is not None and not is_ascii(label)):  # use PIL
         im = Image.fromarray(im)
         draw = ImageDraw.Draw(im)
         draw.rectangle(box, width=lw + 1, outline=color)  # plot


### PR DESCRIPTION
Although the 'label' defaults to None in plot_one_box(), the func does not support the case in that label is None. 

```python
In [1]: import numpy as np

In [2]: from utils.plots import plot_one_box

In [3]: im = np.zeros((360, 640, 3), dtype=np.uint8)

In [4]: xywh = [0.3, 0.4, 0.1, 0.1]

In [5]: plot_one_box(xywh, im)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-5-d7ddfe3655a8> in <module>
----> 1 plot_one_box(xywh, im)

yolov5/utils/plots.py in plot_one_box(box, im, color, txt_color, label, line_width, use_pil)
     73     lw = line_width or max(int(min(im.size) / 200), 2)  # line width
     74
---> 75     if use_pil or not is_ascii(label):  # use PIL
     76         im = Image.fromarray(im)
     77         draw = ImageDraw.Draw(im)

yolov5/utils/general.py in is_ascii(str)
    116 def is_ascii(str=''):
    117     # Is string composed of all ASCII (no UTF) characters?
--> 118     return len(str.encode().decode('ascii', 'ignore')) == len(str)
    119
    120

AttributeError: 'NoneType' object has no attribute 'encode'
```


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced label handling in bounding box plotting functionality.

### 📊 Key Changes
- Modified the condition to check for non-ASCII labels before using PIL (Python Imaging Library) for drawing.

### 🎯 Purpose & Impact
- 🛠️ **Improved Robustness**: Ensures that plotting uses PIL only when the label is not None and contains non-ASCII characters, preventing errors.
- 💻 **User Experience**: Guarantees that boxes are plotted correctly on images, even if the labels are not provided, enhancing the overall functionality for end-users.