### PR TITLE
Auto-download Arial.ttf on init

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import torch
+from PIL import ImageFont
+
+FILE = Path(__file__).absolute()
+ROOT = FILE.parents[0]  # yolov5/ dir
+
+# Check YOLOv5 Annotator font
+font = 'Arial.ttf'
+try:
+    ImageFont.truetype(font)
+except Exception as e:  # download if missing
+    url = "https://ultralytics.com/assets/" + font
+    print(f'Downloading {url} to {ROOT / font}...')
+    torch.hub.download_url_to_file(url, str(ROOT / font))

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,7 +4,7 @@ import torch
 from PIL import ImageFont
 
 FILE = Path(__file__).absolute()
-ROOT = FILE.parents[0]  # yolov5/ dir
+ROOT = FILE.parents[1]  # yolov5/ dir
 
 # Check YOLOv5 Annotator font
 font = 'Arial.ttf'

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -48,7 +48,7 @@ colors = Colors()  # create instance for 'from utils.plots import colors'
 class Annotator:
     # YOLOv5 Annotator for train/val mosaics and jpgs and detect/hub inference annotations
     def __init__(self, im, line_width=None, font_size=None, font='Arial.ttf', pil=True):
-        assert im.data.contiguous, 'Image not contiguous. Apply np.ascontiguousarray(im) to plot_on_box() input image.'
+        assert im.data.contiguous, 'Image not contiguous. Apply np.ascontiguousarray(im) to Annotator() input images.'
         self.pil = pil
         if self.pil:  # use PIL
             self.im = im if isinstance(im, Image.Image) else Image.fromarray(im)
@@ -57,11 +57,10 @@ class Annotator:
             f = font_size or max(round(s * 0.035), 12)
             try:
                 self.font = ImageFont.truetype(font, size=f)
-            except Exception as e:  # download TTF if missing
-                print(f'WARNING: Annotator font {font} not found: {e}')
-                url = "https://github.com/ultralytics/yolov5/releases/download/v1.0/" + font
+            except Exception as e:  # download if missing
+                url = "https://ultralytics.com/assets/" + font
+                print(f'Downloading {url} to {font}...')
                 torch.hub.download_url_to_file(url, font)
-                print(f'Annotator font successfully downloaded from {url} to {font}')
                 self.font = ImageFont.truetype(font, size=f)
             self.fh = self.font.getsize('a')[1] - 3  # font height
         else:  # use cv2


### PR DESCRIPTION
Auto-download Arial.ttf from https://ultralytics.com/assets/ if PIL can't find the font on the user's system.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced font management and error messages in YOLOv5 annotator utility.

### 📊 Key Changes
- Implemented automatic font downloading in `utils/__init__.py` if `Arial.ttf` is missing.
- Refined assertion error message in `utils/plots.py` for non-contiguous image input.
- Simplified font handling in `Annotator` class by removing redundant download messages.

### 🎯 Purpose & Impact
- **Easier Setup:** Users no longer need to manually download the `Arial.ttf` font; it's downloaded automatically, which streamlines the setup process.
- **Improved User Experience:** Clearer error message helps users understand and fix issues with image input formats.
- **Smoother Operation:** Simplified font error handling in the `Annotator` class results in a more straightforward and less error-prone user experience.