### PR TITLE
Fix: add P2 layer 21 to yolov5-p2.yaml `Detect()` inputs

### DIFF
--- a/models/hub/yolov5-p2.yaml
+++ b/models/hub/yolov5-p2.yaml
@@ -50,5 +50,5 @@ head:
    [[-1, 10], 1, Concat, [1]],  # cat head P5
    [-1, 3, C3, [1024, False]],  # 30 (P5/32-large)
 
-   [[24, 27, 30], 1, Detect, [nc, anchors]],  # Detect(P3, P4, P5)
+   [[21, 24, 27, 30], 1, Detect, [nc, anchors]],  # Detect(P2, P3, P4, P5)
   ]


### PR DESCRIPTION
Layer 21 includes the information of xsmall objects

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement to YOLOv5's detection layers, including an additional layer for improved object detection.

### 📊 Key Changes
- The detection layer references in the YOLOv5 model configuration file have been updated.
- Layer index changed from [24, 27, 30] to [21, 24, 27, 30] within the `Detect` block.

### 🎯 Purpose & Impact
- The purpose of this change is to utilize an additional layer (P2) in the detection process for potentially enhanced performance and accuracy.
- Users could experience more precise object detection, especially for smaller objects, due to the added granularity from the extra layer.
- This change could impact model inference times and resource usage, potentially requiring a re-tuning of deployment settings for optimized performance. 🚀🔍