### PR TITLE
W&B: Don't log models in evolve operation

### DIFF
--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -138,7 +138,11 @@ class Loggers():
         if self.wandb:
             self.wandb.log({"Results": [wandb.Image(str(f), caption=f.name) for f in files]})
             # Calling wandb.log. TODO: Refactor this into WandbLogger.log_model
-            wandb.log_artifact(str(best if best.exists() else last), type='model',
-                               name='run_' + self.wandb.wandb_run.id + '_model',
-                               aliases=['latest', 'best', 'stripped'])
-            self.wandb.finish_run()
+            if not self.opt.evolve:
+                wandb.log_artifact(str(best if best.exists() else last), type='model',
+                                   name='run_' + self.wandb.wandb_run.id + '_model',
+                                   aliases=['latest', 'best', 'stripped'])
+                self.wandb.finish_run()
+            else:
+                self.wandb.finish_run()
+                self.wandb = WandbLogger(self.opt)

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -112,7 +112,7 @@ class WandbLogger():
     https://docs.wandb.com/guides/integrations/yolov5
     """
 
-    def __init__(self, opt, run_id, job_type='Training'):
+    def __init__(self, opt, run_id=None, job_type='Training'):
         """
         - Initialize WandbLogger instance
         - Upload dataset if opt.upload_dataset is True


### PR DESCRIPTION
Fix for https://github.com/ultralytics/yolov5/issues/4604

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to WandbLogger for better handling of evolutionary training in YOLOv5.

### 📊 Key Changes
- The WandbLogger `__init__` method now accepts a `run_id` as an optional parameter.
- Conditional logging of artifacts in `on_train_end` function to avoid logging during evolutionary training.

### 🎯 Purpose & Impact
- 🎨 **Flexibility for Advanced Users:** The optional `run_id` allows users to better integrate with existing W&B runs, aiding those involved in more complex experiments.
- 🔍 **Streamlined Evolutionary Training:** The change prevents unnecessary logging of models during evolution, reducing clutter and potential confusion during the hyperparameter tuning process.
- 💾 **Improved Run Management:** The update ensures that runs are finished appropriately, which is crucial for correct experiment tracking and resource management within W&B.