### PR TITLE
Close `matplotlib` plots after opening

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -178,6 +178,7 @@ class ConfusionMatrix:
             fig.axes[0].set_xlabel('True')
             fig.axes[0].set_ylabel('Predicted')
             fig.savefig(Path(save_dir) / 'confusion_matrix.png', dpi=250)
+            fig.close()
         except Exception as e:
             print(f'WARNING: ConfusionMatrix plot failure: {e}')
 
@@ -308,6 +309,7 @@ def plot_pr_curve(px, py, ap, save_dir='pr_curve.png', names=()):
     ax.set_ylim(0, 1)
     plt.legend(bbox_to_anchor=(1.04, 1), loc="upper left")
     fig.savefig(Path(save_dir), dpi=250)
+    fig.close()
 
 
 def plot_mc_curve(px, py, save_dir='mc_curve.png', names=(), xlabel='Confidence', ylabel='Metric'):
@@ -328,3 +330,4 @@ def plot_mc_curve(px, py, save_dir='mc_curve.png', names=(), xlabel='Confidence'
     ax.set_ylim(0, 1)
     plt.legend(bbox_to_anchor=(1.04, 1), loc="upper left")
     fig.savefig(Path(save_dir), dpi=250)
+    fig.close()

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -178,7 +178,7 @@ class ConfusionMatrix:
             fig.axes[0].set_xlabel('True')
             fig.axes[0].set_ylabel('Predicted')
             fig.savefig(Path(save_dir) / 'confusion_matrix.png', dpi=250)
-            fig.close()
+            plt.close()
         except Exception as e:
             print(f'WARNING: ConfusionMatrix plot failure: {e}')
 
@@ -309,7 +309,7 @@ def plot_pr_curve(px, py, ap, save_dir='pr_curve.png', names=()):
     ax.set_ylim(0, 1)
     plt.legend(bbox_to_anchor=(1.04, 1), loc="upper left")
     fig.savefig(Path(save_dir), dpi=250)
-    fig.close()
+    plt.close()
 
 
 def plot_mc_curve(px, py, save_dir='mc_curve.png', names=(), xlabel='Confidence', ylabel='Metric'):
@@ -330,4 +330,4 @@ def plot_mc_curve(px, py, save_dir='mc_curve.png', names=(), xlabel='Confidence'
     ax.set_ylim(0, 1)
     plt.legend(bbox_to_anchor=(1.04, 1), loc="upper left")
     fig.savefig(Path(save_dir), dpi=250)
-    fig.close()
+    plt.close()

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -345,7 +345,6 @@ def profile_idetection(start=0, stop=0, labels=(), save_dir=''):
                     a.remove()
         except Exception as e:
             print('Warning: Plotting error for %s; %s' % (f, e))
-
     ax[1].legend()
     plt.savefig(Path(save_dir) / 'idetection_profile.png', dpi=200)
 
@@ -371,6 +370,7 @@ def plot_evolve(evolve_csv=Path('path/to/evolve.csv')):  # from utils.plots impo
         print('%15s: %.3g' % (k, mu))
     f = evolve_csv.with_suffix('.png')  # filename
     plt.savefig(f, dpi=200)
+    plt.close()
     print(f'Saved {f}')
 
 
@@ -397,6 +397,7 @@ def plot_results(file='path/to/results.csv', dir=''):
             print(f'Warning: Plotting error for {f}: {e}')
     ax[1].legend()
     fig.savefig(save_dir / 'results.png', dpi=200)
+    fig.close()
 
 
 def feature_visualization(x, module_type, stage, n=32, save_dir=Path('runs/detect/exp')):
@@ -423,3 +424,4 @@ def feature_visualization(x, module_type, stage, n=32, save_dir=Path('runs/detec
 
             print(f'Saving {save_dir / f}... ({n}/{channels})')
             plt.savefig(save_dir / f, dpi=300, bbox_inches='tight')
+            plt.close()

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -397,7 +397,7 @@ def plot_results(file='path/to/results.csv', dir=''):
             print(f'Warning: Plotting error for {f}: {e}')
     ax[1].legend()
     fig.savefig(save_dir / 'results.png', dpi=200)
-    fig.close()
+    plt.close()
 
 
 def feature_visualization(x, module_type, stage, n=32, save_dir=Path('runs/detect/exp')):


### PR DESCRIPTION
Feature visualization produces a warning about too many open matplotlib plots, so I realized I need to actively close plots after opening them even though they are not rendered to screen.

```python
detect: weights=['yolov5s.pt'], source=data/images/zidane.jpg, imgsz=[640, 640], conf_thres=0.25, iou_thres=0.45, max_det=1000, device=, view_img=False, save_txt=False, save_conf=False, save_crop=False, nosave=False, classes=None, agnostic_nms=False, augment=False, visualize=True, update=False, project=runs/detect, name=exp, exist_ok=False, line_thickness=3, hide_labels=False, hide_conf=False, half=False
YOLOv5 🚀 v5.0-396-g35fe031 torch 1.9.0+cu102 CUDA:0 (Tesla T4, 15109.75MB)

Fusing layers... 
Model Summary: 224 layers, 7266973 parameters, 0 gradients
image 1/1 /content/yolov5/data/images/zidane.jpg: Saving runs/detect/exp4/zidane/stage0_Focus_features.png... (32/32)
Saving runs/detect/exp4/zidane/stage1_Conv_features.png... (32/64)
Saving runs/detect/exp4/zidane/stage2_C3_features.png... (32/64)
Saving runs/detect/exp4/zidane/stage3_Conv_features.png... (32/128)
Saving runs/detect/exp4/zidane/stage4_C3_features.png... (32/128)
Saving runs/detect/exp4/zidane/stage5_Conv_features.png... (32/256)
Saving runs/detect/exp4/zidane/stage6_C3_features.png... (32/256)
Saving runs/detect/exp4/zidane/stage7_Conv_features.png... (32/512)
Saving runs/detect/exp4/zidane/stage8_SPP_features.png... (32/512)
Saving runs/detect/exp4/zidane/stage9_C3_features.png... (32/512)
Saving runs/detect/exp4/zidane/stage10_Conv_features.png... (32/256)
Saving runs/detect/exp4/zidane/stage11_Upsample_features.png... (32/256)
Saving runs/detect/exp4/zidane/stage12_Concat_features.png... (32/512)
Saving runs/detect/exp4/zidane/stage13_C3_features.png... (32/256)
Saving runs/detect/exp4/zidane/stage14_Conv_features.png... (32/128)
Saving runs/detect/exp4/zidane/stage15_Upsample_features.png... (32/128)
Saving runs/detect/exp4/zidane/stage16_Concat_features.png... (32/256)
Saving runs/detect/exp4/zidane/stage17_C3_features.png... (32/128)
Saving runs/detect/exp4/zidane/stage18_Conv_features.png... (32/128)
Saving runs/detect/exp4/zidane/stage19_Concat_features.png... (32/256)
/content/yolov5/utils/plots.py:417: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).
  fig, ax = plt.subplots(math.ceil(n / 8), 8, tight_layout=True)  # 8 rows x n/8 cols
Saving runs/detect/exp4/zidane/stage20_C3_features.png... (32/256)
Saving runs/detect/exp4/zidane/stage21_Conv_features.png... (32/256)
Saving runs/detect/exp4/zidane/stage22_Concat_features.png... (32/512)
Saving runs/detect/exp4/zidane/stage23_C3_features.png... (32/512)
384x640 2 persons, 2 ties, Done. (29.299s)
Results saved to runs/detect/exp4
Done. (29.333s)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved memory management in plotting functions within Ultralytics YOLOv5.

### 📊 Key Changes
- Added `plt.close()` after saving plots in `utils/metrics.py` and `utils/plots.py`.
- Removed an unnecessary whitespace line from `utils/plots.py`.

### 🎯 Purpose & Impact
- **Reduces memory usage:** Adding `plt.close()` helps to free up memory that can be reused for other processes, avoiding potential memory leaks when generating multiple plots.
- **Cleaner codebase:** The removal of extra spaces aligns with good coding practices, contributing to a more maintainable and readable codebase.
- **User Experience:** Users will experience more efficient resource utilization, particularly when they are generating a large number of plots, leading to smoother and faster execution.