### PR TITLE
DDP `torch.jit.trace()` `--sync-bn` fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -333,7 +333,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 mem = f'{torch.cuda.memory_reserved() / 1E9 if torch.cuda.is_available() else 0:.3g}G'  # (GB)
                 pbar.set_description(('%10s' * 2 + '%10.4g' * 5) % (
                     f'{epoch}/{epochs - 1}', mem, *mloss, targets.shape[0], imgs.shape[-1]))
-                callbacks.on_train_batch_end(ni, model, imgs, targets, paths, plots, trace=not opt.sync)
+                callbacks.on_train_batch_end(ni, model, imgs, targets, paths, plots, trace=not opt.sync_bn)
             # end batch ------------------------------------------------------------------------------------------------
 
         # Scheduler

--- a/train.py
+++ b/train.py
@@ -333,7 +333,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 mem = f'{torch.cuda.memory_reserved() / 1E9 if torch.cuda.is_available() else 0:.3g}G'  # (GB)
                 pbar.set_description(('%10s' * 2 + '%10.4g' * 5) % (
                     f'{epoch}/{epochs - 1}', mem, *mloss, targets.shape[0], imgs.shape[-1]))
-                callbacks.on_train_batch_end(ni, model, imgs, targets, paths, plots, trace=not opt.sync_bn)
+                callbacks.on_train_batch_end(ni, model, imgs, targets, paths, plots, opt.sync_bn)
             # end batch ------------------------------------------------------------------------------------------------
 
         # Scheduler

--- a/train.py
+++ b/train.py
@@ -499,7 +499,6 @@ def main(opt):
         assert opt.batch_size % WORLD_SIZE == 0, '--batch-size must be multiple of CUDA device count'
         assert not opt.image_weights, '--image-weights argument is not compatible with DDP training'
         assert not opt.evolve, '--evolve argument is not compatible with DDP training'
-        assert not opt.sync_bn, '--sync-bn known training issue, see https://github.com/ultralytics/yolov5/issues/3998'
         torch.cuda.set_device(LOCAL_RANK)
         device = torch.device('cuda', LOCAL_RANK)
         dist.init_process_group(backend="nccl" if dist.is_nccl_available() else "gloo")

--- a/train.py
+++ b/train.py
@@ -333,7 +333,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 mem = f'{torch.cuda.memory_reserved() / 1E9 if torch.cuda.is_available() else 0:.3g}G'  # (GB)
                 pbar.set_description(('%10s' * 2 + '%10.4g' * 5) % (
                     f'{epoch}/{epochs - 1}', mem, *mloss, targets.shape[0], imgs.shape[-1]))
-                callbacks.on_train_batch_end(ni, model, imgs, targets, paths, plots)
+                callbacks.on_train_batch_end(ni, model, imgs, targets, paths, plots, trace=not opt.sync)
             # end batch ------------------------------------------------------------------------------------------------
 
         # Scheduler

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -75,7 +75,8 @@ class Loggers():
             if ni == 0:
                 with warnings.catch_warnings():
                     warnings.simplefilter('ignore')  # suppress jit trace warning
-                    self.tb.add_graph(torch.jit.trace(de_parallel(model), imgs[0:1], strict=False), [])
+                    with torch.no_grad():
+                        self.tb.add_graph(torch.jit.trace(de_parallel(model), imgs[0:1], strict=False), [])
             if ni < 3:
                 f = self.save_dir / f'train_batch{ni}.jpg'  # filename
                 Thread(target=plot_images, args=(imgs, targets, paths, f), daemon=True).start()

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -69,14 +69,13 @@ class Loggers():
         if self.wandb:
             self.wandb.log({"Labels": [wandb.Image(str(x), caption=x.name) for x in paths]})
 
-    def on_train_batch_end(self, ni, model, imgs, targets, paths, plots):
+    def on_train_batch_end(self, ni, model, imgs, targets, paths, plots, trace):
         # Callback runs on train batch end
         if plots:
-            if ni == 0:
+            if ni == 0 and trace:
                 with warnings.catch_warnings():
                     warnings.simplefilter('ignore')  # suppress jit trace warning
-                    with torch.no_grad():
-                        self.tb.add_graph(torch.jit.trace(de_parallel(model), imgs[0:1], strict=False), [])
+                    self.tb.add_graph(torch.jit.trace(de_parallel(model), imgs[0:1], strict=False), [])
             if ni < 3:
                 f = self.save_dir / f'train_batch{ni}.jpg'  # filename
                 Thread(target=plot_images, args=(imgs, targets, paths, f), daemon=True).start()

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -69,13 +69,14 @@ class Loggers():
         if self.wandb:
             self.wandb.log({"Labels": [wandb.Image(str(x), caption=x.name) for x in paths]})
 
-    def on_train_batch_end(self, ni, model, imgs, targets, paths, plots, trace):
+    def on_train_batch_end(self, ni, model, imgs, targets, paths, plots, sync_bn):
         # Callback runs on train batch end
         if plots:
-            if ni == 0 and trace:
-                with warnings.catch_warnings():
-                    warnings.simplefilter('ignore')  # suppress jit trace warning
-                    self.tb.add_graph(torch.jit.trace(de_parallel(model), imgs[0:1], strict=False), [])
+            if ni == 0:
+                if not sync_bn:  # tb.add_graph() --sync known issue https://github.com/ultralytics/yolov5/issues/3754
+                    with warnings.catch_warnings():
+                        warnings.simplefilter('ignore')  # suppress jit trace warning
+                        self.tb.add_graph(torch.jit.trace(de_parallel(model), imgs[0:1], strict=False), [])
             if ni < 3:
                 f = self.save_dir / f'train_batch{ni}.jpg'  # filename
                 Thread(target=plot_images, args=(imgs, targets, paths, f), daemon=True).start()


### PR DESCRIPTION
PR implements a workaround for DDP `--sync-bn` known issue https://github.com/ultralytics/yolov5/pull/4032.

Problem cause was discovered to be TensorBoard graph logging using torch.jit.trace(). Discovery made by @twotwoiscute.

I couldn't resolve the bug itself, so I simply skip TensorBoard add_graph() calls for DDP --sync-bn trainings. This means that DDP --sync-bn trainings will not have a YOLOv5 model visualizer in their TensorBoard results.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in training callbacks with enhanced synchronization batch normalization support.

### 📊 Key Changes
- Modified the `callbacks.on_train_batch_end` method to accept an additional `sync_bn` parameter.
- Removed a previous assertion that prevented the use of synchronized batch normalization during distributed data parallel (DDP) training.

### 🎯 Purpose & Impact
- The update allows for more flexible utilization of synchronized batch normalization, potentially improving model training consistency across multiple GPUs. 🤝
- The removal of the assertion means users can now experiment with `--sync-bn` during DDP training, which can lead to better model convergence and generalization when training on multiple devices. 🏋️‍♂️
- Potential increase in model training stability and performance across diverse hardware setups. 💪