### PR TITLE
Fix 2 for Arial.ttf redownloads with hub inference

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,19 +1,19 @@
-import sys
-from pathlib import Path
-
-import torch
-from PIL import ImageFont
-
-FILE = Path(__file__).absolute()
-ROOT = FILE.parents[1]  # yolov5/ dir
-if str(ROOT) not in sys.path:
-    sys.path.append(str(ROOT))  # add ROOT to PATH
-
-# Check YOLOv5 Annotator font
-font = 'Arial.ttf'
-try:
-    ImageFont.truetype(font)
-except Exception as e:  # download if missing
-    url = "https://ultralytics.com/assets/" + font
-    print(f'Downloading {url} to {ROOT / font}...')
-    torch.hub.download_url_to_file(url, str(ROOT / font))
+# import sys
+# from pathlib import Path
+#
+# import torch
+# from PIL import ImageFont
+#
+# FILE = Path(__file__).absolute()
+# ROOT = FILE.parents[1]  # yolov5/ dir
+# if str(ROOT) not in sys.path:
+#     sys.path.append(str(ROOT))  # add ROOT to PATH
+#
+# # Check YOLOv5 Annotator font
+# font = 'Arial.ttf'
+# try:
+#     ImageFont.truetype(font)
+# except Exception as e:  # download if missing
+#     url = "https://ultralytics.com/assets/" + font
+#     print(f'Downloading {url} to {ROOT / font}...')
+#     torch.hub.download_url_to_file(url, str(ROOT / font))

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -23,6 +23,9 @@ from utils.metrics import fitness
 matplotlib.rc('font', **{'size': 11})
 matplotlib.use('Agg')  # for writing to files only
 
+FILE = Path(__file__).absolute()
+ROOT = FILE.parents[1]  # yolov5/ dir
+
 
 class Colors:
     # Ultralytics color palette https://ultralytics.com/
@@ -55,12 +58,14 @@ class Annotator:
             self.draw = ImageDraw.Draw(self.im)
             s = sum(self.im.size) / 2  # mean shape
             f = font_size or max(round(s * 0.035), 12)
+            font = Path(font)  # font handling
+            font = font if font.exists() else (ROOT / font.name)
             try:
-                self.font = ImageFont.truetype(font, size=f)
+                self.font = ImageFont.truetype(str(font) if font.exists() else font.name, size=f)
             except Exception as e:  # download if missing
-                url = "https://ultralytics.com/assets/" + font
+                url = "https://ultralytics.com/assets/" + font.name
                 print(f'Downloading {url} to {font}...')
-                torch.hub.download_url_to_file(url, font)
+                torch.hub.download_url_to_file(url, str(font))
                 self.font = ImageFont.truetype(font, size=f)
             self.fh = self.font.getsize('a')[1] - 3  # font height
         else:  # use cv2


### PR DESCRIPTION
Fix 2 for Arial.ttf redownloads with hub inference, follow-on to #4627.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of font management in the YOLOv5 codebase.

### 📊 Key Changes
- Removed unnecessary imports and path modifications in `utils/__init__.py`.
- Relocated the root directory (`ROOT`) definition to `utils/plots.py`.
- Improved font path handling to ensure compatibility regardless of font presence.

### 🎯 Purpose & Impact
- **Purpose:** To streamline font access in YOLOv5, avoiding errors when the default font is missing and making code maintenance simpler.
- **Impact:** Ensures a smoother experience for users when custom fonts are used or absent, and contributes to a cleaner, more maintainable codebase. 💻📈