### PR TITLE
Fix for `plot_evolve()` string argument

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -358,8 +358,9 @@ def profile_idetection(start=0, stop=0, labels=(), save_dir=''):
     plt.savefig(Path(save_dir) / 'idetection_profile.png', dpi=200)
 
 
-def plot_evolve(evolve_csv=Path('path/to/evolve.csv')):  # from utils.plots import *; plot_evolve()
+def plot_evolve(evolve_csv='path/to/evolve.csv'):  # from utils.plots import *; plot_evolve()
     # Plot evolve.csv hyp evolution results
+    evolve_csv = Path(evolve_csv)
     data = pd.read_csv(evolve_csv)
     keys = [x.strip() for x in data.columns]
     x = data.values


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplified the interface of the `plot_evolve` function for ease of use.

### 📊 Key Changes
- Changed the default parameter value of `evolve_csv` from a `Path` object to a plain string.
- Within the `plot_evolve` function, the string is converted back into a `Path` object.

### 🎯 Purpose & Impact
- **Usability Improvement**: By accepting a string path by default, the function becomes more intuitive for users to call, as they can now pass in a simple file path string directly.
- **Code Clarity**: Internally converting the string to a `Path` ensures that the function still benefits from the advantages of using the `pathlib` library, without exposing this detail to the user.
- 🚀 The change should have minimal impact on existing code since it maintains the function's behavior while simplifying the interface for new users.