### PR TITLE
Fix `is_coco` on missing `data['val']` key

### DIFF
--- a/val.py
+++ b/val.py
@@ -134,7 +134,7 @@ def run(data,
 
     # Configure
     model.eval()
-    is_coco = type(data['val']) is str and data['val'].endswith('coco/val2017.txt')  # COCO dataset
+    is_coco = isinstance(data.get('val'), str) and data['val'].endswith('coco/val2017.txt')  # COCO dataset
     nc = 1 if single_cls else int(data['nc'])  # number of classes
     iouv = torch.linspace(0.5, 0.95, 10).to(device)  # iou vector for mAP@0.5:0.95
     niou = iouv.numel()


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved robustness in dataset type checking during validation.

### 📊 Key Changes
- Replaced type checking with `isinstance()` for 'val' in the dataset configuration.
- Utilized `data.get('val')` to safely access the 'val' key in the dataset dictionary.

### 🎯 Purpose & Impact
- **Enhanced Robustness**: Using `isinstance()` provides a more reliable type check and `data.get('val')` prevents potential `KeyError` exceptions if the 'val' key is missing.
- **User Experience**: This change minimally affects end users directly but improves the stability of the validation process when using the YOLOv5 model, leading to fewer crashes and more reliable model evaluation.