### PR TITLE
Fixed 'meta' and 'hyp' may out of order when using evolve

### DIFF
--- a/train.py
+++ b/train.py
@@ -573,9 +573,10 @@ def main(opt):
                 g = np.array([x[0] for x in meta.values()])  # gains 0-1
                 ng = len(meta)
                 v = np.ones(ng)
+                assert len(hyp) == len(meta), (hyp, meta)
                 while all(v == 1):  # mutate until a change occurs (prevent duplicates)
                     v = (g * (npr.random(ng) < mp) * npr.randn(ng) * npr.random() * s + 1).clip(0.3, 3.0)
-                for i, k in enumerate(hyp.keys()):  # plt.hist(v.ravel(), 300)
+                for i, k in enumerate(meta.keys()):  # plt.hist(v.ravel(), 300)
                     hyp[k] = float(x[i + 7] * v[i])  # mutate
 
             # Constrain to limits


### PR DESCRIPTION
Hi, there.
Recently I have try to use the `evolve` feature of yolov5, and found out that the keys of `meta` and `hyp` maybe miss align in `train.py`. The reason is that, firstly, dictionary in python won't gurantee order. Secondly, the `anchors` hyper-parameter is highly possible add to the `hyp` dictionary in runtime (when it not be defined in hyp.yaml). And after that, all hyper-parameters after `anchors` will miss align between `meta` and `hyp`.

 So, I just use the `meta` dictionary to get both `value` and `key`, which will maintain the order.

You can validate this by set all `gain` of `meta` to 0 except one that after `anchors` key. Use `degrees` key as example, it will evolve on the `translate` key:

```python
        # Hyperparameter evolution metadata (mutation scale 0-1, lower_limit, upper_limit)
        meta = {'lr0': (0, 1e-5, 1e-1),  # initial learning rate (SGD=1E-2, Adam=1E-3)
                'lrf': (0, 0.01, 1.0),  # final OneCycleLR learning rate (lr0 * lrf)
                'momentum': (0, 0.6, 0.98),  # SGD momentum/Adam beta1
                'weight_decay': (0, 0.0, 0.001),  # optimizer weight decay
                'warmup_epochs': (0, 0.0, 5.0),  # warmup epochs (fractions ok)
                'warmup_momentum': (0, 0.0, 0.95),  # warmup initial momentum
                'warmup_bias_lr': (0, 0.0, 0.2),  # warmup initial bias lr
                'box': (0, 0.02, 0.2),  # box loss gain
                'cls': (0, 0.2, 4.0),  # cls loss gain
                'cls_pw': (0, 0.5, 2.0),  # cls BCELoss positive_weight
                'obj': (0, 0.2, 4.0),  # obj loss gain (scale with pixels)
                'obj_pw': (0, 0.5, 2.0),  # obj BCELoss positive_weight
                'iou_t': (0, 0.1, 0.7),  # IoU training threshold
                'anchor_t': (0, 2.0, 8.0),  # anchor-multiple threshold
                'anchors': (0, 2.0, 10.0),  # anchors per output grid (0 to ignore)
                'fl_gamma': (0, 0.0, 2.0),  # focal loss gamma (efficientDet default gamma=1.5)
                'hsv_h': (0, 0.0, 0.1),  # image HSV-Hue augmentation (fraction)
                'hsv_s': (0, 0.0, 0.9),  # image HSV-Saturation augmentation (fraction)
                'hsv_v': (0, 0.0, 0.9),  # image HSV-Value augmentation (fraction)
                'degrees': (1, 0.0, 45.0),  # image rotation (+/- deg)
                'translate': (0, 0.0, 0.9),  # image translation (+/- fraction)
                'scale': (0, 0.0, 0.9),  # image scale (+/- gain)
                'shear': (0, 0.0, 10.0),  # image shear (+/- deg)
                'perspective': (0, 0.0, 0.001),  # image perspective (+/- fraction), range 0-0.001
                'flipud': (0, 0.0, 1.0),  # image flip up-down (probability)
                'fliplr': (0, 0.0, 1.0),  # image flip left-right (probability)
                'mosaic': (0, 0.0, 1.0),  # image mixup (probability)
                'mixup': (0, 0.0, 1.0),  # image mixup (probability)
                'copy_paste': (0, 0.0, 1.0)}  # segment copy-paste (probability)
```

```yaml
   metrics/precision,      metrics/recall,     metrics/mAP_0.5,metrics/mAP_0.5:0.95,        val/box_loss,        val/obj_loss,        val/cls_loss,                 lr0,                 lrf,            momentum,        weight_decay,       warmup_epochs,     warmup_momentum,      warmup_bias_lr,                 box,                 cls,              cls_pw,                 obj,              obj_pw,               iou_t,            anchor_t,            fl_gamma,               hsv_h,               hsv_s,               hsv_v,             degrees,           translate,               scale,               shear,         perspective,              flipud,              fliplr,              mosaic,               mixup,          copy_paste,             anchors
             0.28791,             0.37835,             0.26652,             0.13908,            0.088833,            0.043384,            0.016149,                0.01,                 0.2,               0.937,              0.0005,                   3,                 0.8,                 0.1,                0.05,                 0.5,                   1,                   1,                   1,                 0.2,                   4,                   0,               0.015,                 0.7,                 0.4,                   0,                 0.1,                 0.5,                   0,                   0,                   0,                 0.5,                   1,                   0,                   0,                   3
             0.29136,             0.37709,             0.26546,             0.13878,            0.088909,            0.043359,            0.016147,                0.01,                 0.2,               0.937,              0.0005,                   3,                 0.8,                 0.1,                0.05,                 0.5,                   1,                   1,                   1,                 0.2,                   4,                   0,               0.015,                 0.7,                 0.4,                   0,             0.10431,                 0.5,                   0,                   0,                   0,                 0.5,                   1,                   0,                   0,                   3
               0.287,             0.37366,             0.26618,              0.1379,            0.089098,            0.043362,            0.016173,                0.01,                 0.2,               0.937,              0.0005,                   3,                 0.8,                 0.1,                0.05,                 0.5,                   1,                   1,                   1,                 0.2,                   4,                   0,               0.015,                 0.7,                 0.4,                   0,             0.11631,                 0.5,                   0,                   0,                   0,                 0.5,                   1,                   0,                   0,                   3
             0.29075,             0.37408,             0.27109,             0.14146,            0.089018,            0.043297,            0.016147,                0.01,                 0.2,               0.937,              0.0005,                   3,                 0.8,                 0.1,                0.05,                 0.5,                   1,                   1,                   1,                 0.2,                   4,                   0,               0.015,                 0.7,                 0.4,                   0,             0.07318,                 0.5,                   0,                   0,                   0,                 0.5,                   1,                   0,                   0,                   3
             0.28586,             0.38375,             0.26586,             0.13868,            0.088914,            0.043362,             0.01615,                0.01,                 0.2,               0.937,              0.0005,                   3,                 0.8,                 0.1,                0.05,                 0.5,                   1,                   1,                   1,                 0.2,                   4,                   0,               0.015,                 0.7,                 0.4,                   0,             0.10432,                 0.5,                   0,                   0,                   0,                 0.5,                   1,                   0,                   0,                   3

```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced mutation logic in hyperparameter optimization during training.

### 📊 Key Changes
- Added an assertion to ensure `hyp` (hyperparameters) and `meta` (metadata) have the same length.
- Changed the mutation loop to reference `meta.keys()` instead of `hyp.keys()`.

### 🎯 Purpose & Impact
- The assertion prevents potential mismatches between hyperparameters and metadata, which improves code robustness. 🛠️
- Updating the reference in the mutation loop ensures that the correct keys are used for mutating hyperparameters, leading to more effective training sessions. 📈
- These changes are likely to prevent silent errors during hyperparameter optimization, resulting in better model performance and stability. 🚀