### PR TITLE
Fixed 'meta' and 'hyp' may out of order when using evolve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ sdist/
 var/
 wheels/
 *.egg-info/
-wandb/
+/wandb/
 .installed.cfg
 *.egg
 

--- a/train.py
+++ b/train.py
@@ -570,7 +570,7 @@ def main(opt):
                 mp, s = 0.8, 0.2  # mutation probability, sigma
                 npr = np.random
                 npr.seed(int(time.time()))
-                g = np.array([x[0] for x in meta.values()])  # gains 0-1
+                g = np.array([meta[k][0] for k in hyp.keys()])  # gains 0-1
                 ng = len(meta)
                 v = np.ones(ng)
                 while all(v == 1):  # mutate until a change occurs (prevent duplicates)


### PR DESCRIPTION
Hi, there.
Recently I have try to use the `evolve` feature of yolov5, and found out that the keys of `meta` and `hyp` maybe miss align in `train.py`. The reason is that, firstly, dictionary in python won't gurantee order. Secondly, the `anchors` hyper-parameter is possible add to the `hyp` dictionary in runtime (when it not be defined in hyp.yaml). And after that, all hyper-parameters after `anchors` will miss align between `meta` and `hyp`.

 So, I just use the `hyp` keys to get both `gain`, which will maintain the order.

We can validate this by set all `gain` of `meta` to 0 except one that after `anchors` key. Use `translate` key as an example (because `translate` and `scale` are initialized with non-zero value, if a hyper-parameter initialize with 0 and it won't get mutation), it will evolve on the `scale` key:

```python
python train.py --evolve 5 --epochs 2
```

```python
        # Hyperparameter evolution metadata (mutation scale 0-1, lower_limit, upper_limit)
        meta = {'lr0': (0, 1e-5, 1e-1),  # initial learning rate (SGD=1E-2, Adam=1E-3)
                'lrf': (0, 0.01, 1.0),  # final OneCycleLR learning rate (lr0 * lrf)
                'momentum': (0, 0.6, 0.98),  # SGD momentum/Adam beta1
                'weight_decay': (0, 0.0, 0.001),  # optimizer weight decay
                'warmup_epochs': (0, 0.0, 5.0),  # warmup epochs (fractions ok)
                'warmup_momentum': (0, 0.0, 0.95),  # warmup initial momentum
                'warmup_bias_lr': (0, 0.0, 0.2),  # warmup initial bias lr
                'box': (0, 0.02, 0.2),  # box loss gain
                'cls': (0, 0.2, 4.0),  # cls loss gain
                'cls_pw': (0, 0.5, 2.0),  # cls BCELoss positive_weight
                'obj': (0, 0.2, 4.0),  # obj loss gain (scale with pixels)
                'obj_pw': (0, 0.5, 2.0),  # obj BCELoss positive_weight
                'iou_t': (0, 0.1, 0.7),  # IoU training threshold
                'anchor_t': (0, 2.0, 8.0),  # anchor-multiple threshold
                'anchors': (0, 2.0, 10.0),  # anchors per output grid (0 to ignore)
                'fl_gamma': (0, 0.0, 2.0),  # focal loss gamma (efficientDet default gamma=1.5)
                'hsv_h': (0, 0.0, 0.1),  # image HSV-Hue augmentation (fraction)
                'hsv_s': (0, 0.0, 0.9),  # image HSV-Saturation augmentation (fraction)
                'hsv_v': (0, 0.0, 0.9),  # image HSV-Value augmentation (fraction)
                'degrees': (0, 0.0, 45.0),  # image rotation (+/- deg)
                'translate': (1, 0.0, 0.9),  # image translation (+/- fraction)
                'scale': (0, 0.0, 0.9),  # image scale (+/- gain)
                'shear': (0, 0.0, 10.0),  # image shear (+/- deg)
                'perspective': (0, 0.0, 0.001),  # image perspective (+/- fraction), range 0-0.001
                'flipud': (0, 0.0, 1.0),  # image flip up-down (probability)
                'fliplr': (0, 0.0, 1.0),  # image flip left-right (probability)
                'mosaic': (0, 0.0, 1.0),  # image mixup (probability)
                'mixup': (0, 0.0, 1.0),  # image mixup (probability)
                'copy_paste': (0, 0.0, 1.0)}  # segment copy-paste (probability)
```

```yaml
   metrics/precision,      metrics/recall,     metrics/mAP_0.5,metrics/mAP_0.5:0.95,        val/box_loss,        val/obj_loss,        val/cls_loss,                 lr0,                 lrf,            momentum,        weight_decay,       warmup_epochs,     warmup_momentum,      warmup_bias_lr,                 box,                 cls,              cls_pw,                 obj,              obj_pw,               iou_t,            anchor_t,            fl_gamma,               hsv_h,               hsv_s,               hsv_v,             degrees,           translate,               scale,               shear,         perspective,              flipud,              fliplr,              mosaic,               mixup,          copy_paste,             anchors
             0.29013,             0.38144,             0.27229,              0.1401,             0.08883,            0.043384,            0.016148,                0.01,                 0.2,               0.937,              0.0005,                   3,                 0.8,                 0.1,                0.05,                 0.5,                   1,                   1,                   1,                 0.2,                   4,                   0,               0.015,                 0.7,                 0.4,                   0,                 0.1,                 0.5,                   0,                   0,                   0,                 0.5,                   1,                   0,                   0,                   3
             0.28905,             0.38505,              0.2748,             0.14504,            0.088602,            0.043445,            0.016112,                0.01,                 0.2,               0.937,              0.0005,                   3,                 0.8,                 0.1,                0.05,                 0.5,                   1,                   1,                   1,                 0.2,                   4,                   0,               0.015,                 0.7,                 0.4,                   0,                 0.1,             0.62915,                   0,                   0,                   0,                 0.5,                   1,                   0,                   0,                   3
             0.28587,             0.38832,             0.27283,              0.1416,            0.088814,            0.043403,            0.016127,                0.01,                 0.2,               0.937,              0.0005,                   3,                 0.8,                 0.1,                0.05,                 0.5,                   1,                   1,                   1,                 0.2,                   4,                   0,               0.015,                 0.7,                 0.4,                   0,                 0.1,             0.59574,                   0,                   0,                   0,                 0.5,                   1,                   0,                   0,                   3
             0.29403,             0.36923,             0.27276,             0.14222,            0.089021,             0.04337,            0.016128,                0.01,                 0.2,               0.937,              0.0005,                   3,                 0.8,                 0.1,                0.05,                 0.5,                   1,                   1,                   1,                 0.2,                   4,                   0,               0.015,                 0.7,                 0.4,                   0,                 0.1,              0.5751,                   0,                   0,                   0,                 0.5,                   1,                   0,                   0,                   3
             0.28571,             0.38769,             0.27213,             0.14169,            0.088797,            0.043437,            0.016124,                0.01,                 0.2,               0.937,              0.0005,                   3,                 0.8,                 0.1,                0.05,                 0.5,                   1,                   1,                   1,                 0.2,                   4,                   0,               0.015,                 0.7,                 0.4,                   0,                 0.1,             0.61197,                   0,                   0,                   0,                 0.5,                   1,                   0,                   0,                   3
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving the `.gitignore` and genetic algorithm in YOLOv5.

### 📊 Key Changes
- Modified the `.gitignore` to explicitly ignore the `wandb/` directory.
- Updated the genetic algorithm within `train.py` to ensure hyp keys align with meta values during mutation.

### 🎯 Purpose & Impact
- Ensuring that the Weights & Biases (wandb) folder, used for experiment tracking, is properly excluded from version control. This helps prevent accidental commits of potentially large and unneeded `wandb` directories.
- Refining the genetic algorithm that fine-tunes hyperparameters to prevent errors and ensure only valid mutations are considered. This should lead to more efficient and potentially more effective model training.
  
The changes will make collaborating on YOLOv5 codebase cleaner and may lead to improved performance of models trained with YOLOv5 thanks to the more robust hyperparameter tuning process. 🧬✨