### PR TITLE
Add `crops = results.crop()` dictionary

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -365,6 +365,7 @@ class Detections:
         self.s = shape  # inference BCHW shape
 
     def display(self, pprint=False, show=False, save=False, crop=False, render=False, save_dir=Path('')):
+        crops = []
         for i, (im, pred) in enumerate(zip(self.imgs, self.pred)):
             str = f'image {i + 1}/{len(self.pred)}: {im.shape[0]}x{im.shape[1]} '
             if pred.shape[0]:
@@ -372,7 +373,7 @@ class Detections:
                     n = (pred[:, -1] == c).sum()  # detections per class
                     str += f"{n} {self.names[int(c)]}{'s' * (n > 1)}, "  # add to string
                 if show or save or render or crop:
-                    annotator, crops = Annotator(im, pil=not self.ascii), []
+                    annotator = Annotator(im, pil=not self.ascii)
                     for *box, conf, cls in reversed(pred):  # xyxy, confidence, class
                         label = f'{self.names[int(cls)]} {conf:.2f}'
                         if crop:
@@ -397,8 +398,10 @@ class Detections:
                     LOGGER.info(f"Saved {self.n} image{'s' * (self.n > 1)} to {colorstr('bold', save_dir)}")
             if render:
                 self.imgs[i] = np.asarray(im)
-            if crop:
-                return crops
+        if crop:
+            if save:
+                LOGGER.info(f'Saved results to {save_dir}\n')
+            return crops
 
     def print(self):
         self.display(pprint=True)  # print results
@@ -414,10 +417,7 @@ class Detections:
 
     def crop(self, save=True, save_dir='runs/detect/exp'):
         save_dir = increment_path(save_dir, exist_ok=save_dir != 'runs/detect/exp', mkdir=True) if save else None
-        crops = self.display(crop=True, save=save, save_dir=save_dir)  # crop results
-        if save:
-            LOGGER.info(f'Saved results to {save_dir}\n')
-        return crops
+        return self.display(crop=True, save=save, save_dir=save_dir)  # crop results
 
     def render(self):
         self.display(render=True)  # render results

--- a/models/common.py
+++ b/models/common.py
@@ -396,6 +396,35 @@ class Detections:
             if render:
                 self.imgs[i] = np.asarray(im)
 
+    def get_cropped(self): 
+        """
+        returns list of dicts containing cropped detections and their labels 
+        >>> result.get_cropped()
+            [
+                { 
+                    'label': <label> <accuracy> 
+                    'img': <cropped np image> 
+                }, 
+                { 
+                    'label': <label> <accuracy> 
+                    'img': <cropped np image> 
+                }, 
+                ...
+            ]
+        """
+        res = [] 
+        for i, (im, pred) in enumerate(zip(self.imgs, self.pred)):
+            assert pred != None, "prediction result is empty, no object detected"
+            for *box, conf, cls in pred:  # xyxy, confidence, class
+                label = f'{self.names[int(cls)]} {conf:.2f}'
+                cropped_img = save_one_box(box, im, save=False)
+                res.append({ 
+                    'label': label, 
+                    'img': cropped_img
+                })
+        return res 
+
+
     def print(self):
         self.display(pprint=True)  # print results
         LOGGER.info(f'Speed: %.1fms pre-process, %.1fms inference, %.1fms NMS per image at shape {tuple(self.s)}' %

--- a/models/common.py
+++ b/models/common.py
@@ -372,14 +372,12 @@ class Detections:
                     n = (pred[:, -1] == c).sum()  # detections per class
                     str += f"{n} {self.names[int(c)]}{'s' * (n > 1)}, "  # add to string
                 if show or save or render or crop:
-                    annotator = Annotator(im, pil=not self.ascii)
-                    cropped = [] 
+                    annotator, crops = Annotator(im, pil=not self.ascii), []
                     for *box, conf, cls in reversed(pred):  # xyxy, confidence, class
                         label = f'{self.names[int(cls)]} {conf:.2f}'
                         if crop:
-                            cropped_save_dir = save_dir / 'crops' / self.names[int(cls)] / self.files[i] if save else None
-                            cropped_box = save_one_box(box, im, file=cropped_save_dir, save=save)
-                            cropped.append({'label': label,'img': cropped_box})
+                            file = save_dir / 'crops' / self.names[int(cls)] / self.files[i] if save else None
+                            crops.append({'label': label, 'im': save_one_box(box, im, file=file, save=save)})
                         else:  # all others
                             annotator.box_label(box, label, color=colors(cls))
                     im = annotator.im
@@ -398,9 +396,8 @@ class Detections:
                     LOGGER.info(f"Saved {self.n} image{'s' * (self.n > 1)} to {colorstr('bold', save_dir)}")
             if render:
                 self.imgs[i] = np.asarray(im)
-            
-            if crop: 
-                return cropped
+            if crop:
+                return crops
 
     def print(self):
         self.display(pprint=True)  # print results
@@ -416,10 +413,10 @@ class Detections:
 
     def crop(self, save=True, save_dir='runs/detect/exp'):
         save_dir = increment_path(save_dir, exist_ok=save_dir != 'runs/detect/exp', mkdir=True) if save else None
-        cropped = self.display(crop=True, save=save, save_dir=save_dir)  # crop results
-        if save: 
+        crops = self.display(crop=True, save=save, save_dir=save_dir)  # crop results
+        if save:
             LOGGER.info(f'Saved results to {save_dir}\n')
-        return cropped 
+        return crops
 
     def render(self):
         self.display(render=True)  # render results

--- a/models/common.py
+++ b/models/common.py
@@ -377,7 +377,8 @@ class Detections:
                         label = f'{self.names[int(cls)]} {conf:.2f}'
                         if crop:
                             file = save_dir / 'crops' / self.names[int(cls)] / self.files[i] if save else None
-                            crops.append({'label': label, 'im': save_one_box(box, im, file=file, save=save)})
+                            crops.append({'box': box, 'conf': conf, 'cls': cls, 'label': label,
+                                          'im': save_one_box(box, im, file=file, save=save)})
                         else:  # all others
                             annotator.box_label(box, label, color=colors(cls))
                     im = annotator.im


### PR DESCRIPTION
Adding function that returns list of dicts containing cropped detections and their labels 
```
        >>> result.get_cropped()
            [
                { 
                    'label': <label> <accuracy> 
                    'img': <cropped np image> 
                }, 
                { 
                    'label': <label> <accuracy> 
                    'img': <cropped np image> 
                }, 
                ...
            ]
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to image cropping and results output in the YOLOv5 model's inference display method.

### 📊 Key Changes
- Added a `crops` list to gather crop data for images during inference.
- Updated the image cropping logic to support conditional saving and added the cropped image data to the `crops` list.
- Changed the `crop` method to return the `crops` list and support optional saving with a specified directory.

### 🎯 Purpose & Impact
- 🔍 **Clarity in Crop Outputs**: Users now get detailed information about each crop, improving transparency regarding inference results.
- 💾 **Flexible Saving Options**: The ability to choose whether to save cropped images or not adds flexibility for different user needs.
- 🔄 **Data Accessibility**: By returning the `crops` list, downstream applications can easily utilize the cropping results for further processing or analysis.