### PR TITLE
EarlyStopper updates

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -298,13 +298,16 @@ class EarlyStopping:
     def __init__(self, patience=30):
         self.best_fitness = 0.0  # i.e. mAP
         self.best_epoch = 0
-        self.patience = patience  # epochs to wait after fitness stops improving to stop
+        self.patience = patience or float('inf')  # epochs to wait after fitness stops improving to stop
+        self.possible_stop = False  # possible stop may occur next epoch
 
     def __call__(self, epoch, fitness):
         if fitness >= self.best_fitness:  # >= 0 to allow for early zero-fitness stage of training
             self.best_epoch = epoch
             self.best_fitness = fitness
-        stop = (epoch - self.best_epoch) >= self.patience  # stop training if patience exceeded
+        delta = epoch - self.best_epoch  # epochs without improvement
+        self.possible_stop = delta >= (self.patience - 1)  # possible stop may occur next epoch
+        stop = delta >= self.patience  # stop training if patience exceeded
         if stop:
             LOGGER.info(f'EarlyStopping patience {self.patience} exceeded, stopping training.')
         return stop


### PR DESCRIPTION
Updates to EarlyStopping PR https://github.com/ultralytics/yolov5/pull/4576 to address concerns in https://github.com/ultralytics/yolov5/issues/4653:

- Default increased from 30 epochs to 100 epochs to minimize impact to existing workflows.
- Added `stopper.possible_stop` attribute to indicate possibility of stop next epoch, utilized to create plots and save checkpoints in case epoch is actually final epoch: `final_epoch = (epoch + 1 == epochs) or stopper.possible_stop`
- Fixed Multi-GPU bug (EarlyStopping completely disabled in Multi-GPU now, existing TODO inlined in README).



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving early stopping logic in YOLOv5 training.

### 📊 Key Changes
- Modified the final epoch check to consider a possible stop signal from the `EarlyStopping` class.
- Refined the early stopping check to apply only to single-GPU training (RANK == -1 condition).
- Increased the default early stopping patience from 30 to 100 epochs.
- Added a `possible_stop` attribute to the `EarlyStopping` class for better anticipation of training completion.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To provide a more robust and clear early stopping mechanism, allowing training to stop earlier when no improvements are observed, and to help users anticipate the end of training.
- 🎉 **Impact**: Users benefit from faster training times when no further improvements are made, potentially saving resources. The clarity in training stopping conditions can also help in better managing long training sessions.