### PR TITLE
Remove redundant `ComputeLoss` code

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -91,7 +91,6 @@ class QFocalLoss(nn.Module):
 class ComputeLoss:
     # Compute losses
     def __init__(self, model, autobalance=False):
-        super(ComputeLoss, self).__init__()
         self.sort_obj_iou = False
         device = next(model.parameters()).device  # get model device
         h = model.hyp  # hyperparameters


### PR DESCRIPTION
Because `ComputeLoss` does not inherit from other classes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in loss computation in Ultralytics' YOLOv5 model.

### 📊 Key Changes
- Removed the unnecessary `super()` call from the `ComputeLoss` class constructor.

### 🎯 Purpose & Impact
- **Purpose**: The PR seems to streamline the loss class by eliminating a redundant superclass initialization, which wasn't required.
- **Impact**: This change might slightly improve the initialization performance of the `ComputeLoss` class and reduce potential confusion about inheritance hierarchy for developers working with the codebase. 
- **User Benefit**: Users of YOLOv5 will likely not notice any direct changes, but developers can experience a cleaner and potentially less error-prone codebase. 🛠️✨