### PR TITLE
Fix `check_suffix()`

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -244,7 +244,7 @@ def check_imshow():
 
 def check_suffix(file='yolov5s.pt', suffix=('.pt',), msg=''):
     # Check file(s) for acceptable suffixes
-    if any(suffix):
+    if file and suffix:
         if isinstance(suffix, str):
             suffix = [suffix]
         for f in file if isinstance(file, (list, tuple)) else [file]:
@@ -258,7 +258,7 @@ def check_yaml(file, suffix=('.yaml', '.yml')):
 
 def check_file(file, suffix=''):
     # Search/download file (if necessary) and return path
-    check_suffix(file, suffix)
+    check_suffix(file, suffix)  # optional
     file = str(file)  # convert to str()
     if Path(file).is_file() or file == '':  # exists
         return file


### PR DESCRIPTION
Fix a bug in #4711 when `file=''`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved file suffix checking in utility functions.

### 📊 Key Changes
- Modified `check_suffix` logic to require a non-empty `file` parameter.
- Made `check_suffix` call in `check_file` optional.

### 🎯 Purpose & Impact
- These changes ensure that file checks only proceed if a file name is provided, preventing unnecessary checks on empty strings or `None`.
- The update will result in cleaner code and potentially avoid errors where incorrect file paths might have been accepted.
- Users should experience more robust file handling, especially when dealing with model weights and configuration files. 🛠️📁