### PR TITLE
Fix `user_config_dir()` for GCP/AWS functions

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -105,9 +105,10 @@ def get_latest_run(search_dir='.'):
 
 def user_config_dir(dir='Ultralytics'):
     # Return path of user configuration directory (make if necessary)
+    system = platform.system()
     cfg = {'Windows': 'AppData/Roaming', 'Linux': '.config', 'Darwin': 'Library/Application Support'}
-    path = Path.home() / cfg.get(platform.system(), '') / dir
-    if not is_writeable(path):  # GCP functions and AWS lambda solution, only /tmp is writeable
+    path = Path.home() / cfg.get(system, '') / dir
+    if system == 'Linux' and not is_writeable(path):  # GCP functions and AWS lambda solution, only /tmp is writeable
         path = Path('/tmp') / dir
     if not path.is_dir():
         path.mkdir()  # make dir if required
@@ -115,7 +116,7 @@ def user_config_dir(dir='Ultralytics'):
 
 
 def is_writeable(path):
-    # Return True if path has write permissions
+    # Return True if path has write permissions (Warning: known issue on Windows)
     return os.access(path, os.R_OK)
 
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -105,11 +105,18 @@ def get_latest_run(search_dir='.'):
 
 def user_config_dir(dir='Ultralytics'):
     # Return path of user configuration directory (make if necessary)
-    settings = {'Windows': 'AppData/Roaming', 'Linux': '.config', 'Darwin': 'Library/Application Support'}
-    path = Path.home() / settings.get(platform.system(), '') / dir
+    cfg = {'Windows': 'AppData/Roaming', 'Linux': '.config', 'Darwin': 'Library/Application Support'}
+    path = Path.home() / cfg.get(platform.system(), '') / dir
+    if not is_writeable(path):  # GCP functions and AWS lambda solution, only /tmp is writeable
+        path = Path('/tmp') / dir
     if not path.is_dir():
         path.mkdir()  # make dir if required
     return path
+
+
+def is_writeable(path):
+    # Return True if path has write permissions
+    return os.access(path, os.R_OK)
 
 
 def is_docker():


### PR DESCRIPTION
Compatibility fix for GCP functions and AWS lambda for user config directory in https://github.com/ultralytics/yolov5/pull/4628

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced user configuration directory handling, including write permissions check.

### 📊 Key Changes
- Refactored the path settings in `user_config_dir` to improve readability.
- Implemented a check to identify if the path is writable, with a fallback to `/tmp` for Linux systems where only `/tmp` is writable.
- Added a new utility function `is_writeable` to verify write access to a given path.

### 🎯 Purpose & Impact
- **Enhanced Compatibility:** Ensures that the `user_config_dir` function works correctly in environments with restricted write access, such as Google Cloud Functions or AWS Lambda.
- **Improved Robustness:** The new writable check prevents errors that could occur when the application tries to write to a directory without the necessary permissions.
- **Potential Impact:** Users running YOLOv5 in severless environments should experience fewer permission-related issues, leading to a smoother operation and better user experience. 🚀