### PR TITLE
Make CONFIG_DIR configurable per environment variable

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -4,6 +4,7 @@ Plotting utils
 """
 
 import math
+import os
 from copy import copy
 from pathlib import Path
 
@@ -20,7 +21,7 @@ from utils.general import user_config_dir, is_ascii, xywh2xyxy, xyxy2xywh
 from utils.metrics import fitness
 
 # Settings
-CONFIG_DIR = user_config_dir()  # Ultralytics settings dir
+CONFIG_DIR = Path(os.getenv('YOLOV5_CONFIG_DIR') or user_config_dir())  # Ultralytics settings dir
 matplotlib.rc('font', **{'size': 11})
 matplotlib.use('Agg')  # for writing to files only
 


### PR DESCRIPTION
# WHY

`CONFIG_DIR`, which is set to `general.user_config_dir()` is currently hardcoded to be prefixed with `Path.home()`.

This change breaks all calls to YOLOV5 in environments that don't allow disk writes to `/home/{...}`, such as AWS Lambda and Google Cloud Functions.

https://github.com/ultralytics/yolov5/blob/0d8a1842373e55f8f639adede0c3d378f1ffbea5/utils/plots.py#L23
https://github.com/ultralytics/yolov5/blob/0d8a1842373e55f8f639adede0c3d378f1ffbea5/utils/general.py#L106-L112

While the subdirectory takes into consideration the host OS defaults for configuration folders, there are systems in which `/home/{...}` is **not writable**.

This can happen in any system really, depending on how filesystem access is configured. However, this issue becomes more prevalent for Docker containers, especially in environments like **AWS Lambda** and **Google Cloud Functions**.

These kind of environments don't allow disk writes to any directory other than `/tmp`. Functions are executed in a protected sandbox environment in which all disk writes must happen within `/tmp`.

Any attempt to write to directories other than `/tmp`, will throw an exception like the following:

```python
Errno 30] Read-only file system: './.config/folder': OSError
Traceback (most recent call last):
...
```

# HOW

This Pull Request attempts to fix this hardcoding issue by introducing a configuration environment variable `YOLOV5_CONFIG_DIR` that can be set in the host environment or on a per execution basis.

This approach is similar to what [pytorch](https://github.com/pytorch/pytorch) does with `TORCH_HOME`.

[Matplotlib](https://matplotlib.org/stable/faq/environment_variables_faq.html#envvar-MPLCONFIGDIR) is another example with their environment variable `MPLCONFIGDIR`.

I'm happy to change the variable name as you see fit, or switch to a different approach we find a better one.

# CLOSING NOTES

I hope this small patch makes life easier for those who are running YOLOV5 in such an environment.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of configuration directory flexibility for YOLOv5. 

### 📊 Key Changes
- Imported the `os` module to the `plots.py` file.
- Modified `CONFIG_DIR` to prioritize the `YOLOV5_CONFIG_DIR` environment variable if set, over the default user configuration directory.

### 🎯 Purpose & Impact
- **Purpose:** This change allows users to specify a custom configuration directory through an environment variable (`YOLOV5_CONFIG_DIR`), providing greater flexibility and control in different environments or use cases.
- **Impact:** Users who need to customize where YOLOv5 settings are stored can now do so easily, which is especially useful for complex deployment scenarios or shared systems. This does not affect users who do not use this environment variable; for them, the default behavior remains unchanged.