### PR TITLE
Scope `onnx-simplifier` requirements check

### DIFF
--- a/export.py
+++ b/export.py
@@ -44,7 +44,7 @@ def export_onnx(model, img, file, opset, train, dynamic, simplify):
     # ONNX model export
     prefix = colorstr('ONNX:')
     try:
-        check_requirements(('onnx', 'onnx-simplifier'))
+        check_requirements(('onnx'))
         import onnx
 
         print(f'\n{prefix} starting export with onnx {onnx.__version__}...')
@@ -66,6 +66,7 @@ def export_onnx(model, img, file, opset, train, dynamic, simplify):
         # Simplify
         if simplify:
             try:
+                check_requirements(('onnx-simplifier'))
                 import onnxsim
 
                 print(f'{prefix} simplifying with onnx-simplifier {onnxsim.__version__}...')

--- a/export.py
+++ b/export.py
@@ -44,7 +44,7 @@ def export_onnx(model, img, file, opset, train, dynamic, simplify):
     # ONNX model export
     prefix = colorstr('ONNX:')
     try:
-        check_requirements(('onnx'))
+        check_requirements(('onnx',))
         import onnx
 
         print(f'\n{prefix} starting export with onnx {onnx.__version__}...')
@@ -66,7 +66,7 @@ def export_onnx(model, img, file, opset, train, dynamic, simplify):
         # Simplify
         if simplify:
             try:
-                check_requirements(('onnx-simplifier'))
+                check_requirements(('onnx-simplifier',))
                 import onnxsim
 
                 print(f'{prefix} simplifying with onnx-simplifier {onnxsim.__version__}...')


### PR DESCRIPTION
Export.py has been updated to check for onnx-simplifier requirement only when the --simplify argument is added.
Allows for better flexibility and one less requirement if simplify is not needed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to ONNX export dependencies management in YOLOv5.

### 📊 Key Changes
- Removed `onnx-simplifier` from the immediate dependency check during ONNX export.
- Added a separate dependency check for `onnx-simplifier` only when simplification is required.

### 🎯 Purpose & Impact
- **Purpose:** To streamline the export process by only requiring necessary dependencies, avoiding the loading of extra packages unless needed.
- **Impact:** Users who export to ONNX without the need for simplification will experience a faster setup as the simplifier package won't be checked or loaded initially. This change could reduce the initial overhead, making the export process slightly quicker and more efficient for those not using simplification. 🚀