### PR TITLE
Improved `detect.py` timing

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -213,7 +213,7 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
                         if save_crop:
                             save_one_box(xyxy, imc, file=save_dir / 'crops' / names[c] / f'{p.stem}.jpg', BGR=True)
 
-            # Print time (inference only)
+            # Print time (inference-only)
             print(f'{s}Done. ({t3 - t2:.3f}s)')
 
             # Stream results

--- a/detect.py
+++ b/detect.py
@@ -213,7 +213,7 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
                         if save_crop:
                             save_one_box(xyxy, imc, file=save_dir / 'crops' / names[c] / f'{p.stem}.jpg', BGR=True)
 
-            # Print time (inference + NMS)
+            # Print time (inference only)
             print(f'{s}Done. ({t3 - t2:.3f}s)')
 
             # Stream results

--- a/detect.py
+++ b/detect.py
@@ -245,10 +245,10 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
     t = tuple(x / seen * 1E3 for x in dt)  # speeds per image
     print(f'Speed: %.1fms pre-process, %.1fms inference, %.1fms NMS per image at shape {(1, 3, *imgsz)}' % t)
 
+    # Save
     if save_txt or save_img:
         s = f"\n{len(list(save_dir.glob('labels/*.txt')))} labels saved to {save_dir / 'labels'}" if save_txt else ''
         print(f"Results saved to {colorstr('bold', save_dir)}{s}")
-
     if update:
         strip_optimizer(weights)  # update model (to fix SourceChangeWarning)
 

--- a/detect.py
+++ b/detect.py
@@ -8,7 +8,6 @@ Usage:
 
 import argparse
 import sys
-import time
 from pathlib import Path
 
 import cv2
@@ -123,8 +122,9 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
     # Run inference
     if pt and device.type != 'cpu':
         model(torch.zeros(1, 3, *imgsz).to(device).type_as(next(model.parameters())))  # run once
-    t0 = time.time()
+    dt, seen = [0.0, 0.0, 0.0], 0
     for path, img, im0s, vid_cap in dataset:
+        t1 = time_sync()
         if onnx:
             img = img.astype('float32')
         else:
@@ -133,9 +133,10 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
         img = img / 255.0  # 0 - 255 to 0.0 - 1.0
         if len(img.shape) == 3:
             img = img[None]  # expand for batch dim
+        t2 = time_sync()
+        dt[0] += t2 - t1
 
         # Inference
-        t1 = time_sync()
         if pt:
             visualize = increment_path(save_dir / Path(path).stem, mkdir=True) if visualize else False
             pred = model(img, augment=augment, visualize=visualize)[0]
@@ -162,17 +163,20 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
             pred[..., 2] *= imgsz[1]  # w
             pred[..., 3] *= imgsz[0]  # h
             pred = torch.tensor(pred)
+        dt[1] += time_sync() - t2
 
         # NMS
+        t3 = time_sync()
         pred = non_max_suppression(pred, conf_thres, iou_thres, classes, agnostic_nms, max_det=max_det)
-        t2 = time_sync()
+        dt[2] += time_sync() - t3
 
         # Second-stage classifier (optional)
         if classify:
             pred = apply_classifier(pred, modelc, img, im0s)
 
         # Process predictions
-        for i, det in enumerate(pred):  # detections per image
+        for i, det in enumerate(pred):  # per image
+            seen += 1
             if webcam:  # batch_size >= 1
                 p, s, im0, frame = path[i], f'{i}: ', im0s[i].copy(), dataset.count
             else:
@@ -210,7 +214,7 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
                             save_one_box(xyxy, imc, file=save_dir / 'crops' / names[c] / f'{p.stem}.jpg', BGR=True)
 
             # Print time (inference + NMS)
-            print(f'{s}Done. ({t2 - t1:.3f}s)')
+            print(f'{s}Done. ({t3 - t2:.3f}s)')
 
             # Stream results
             im0 = annotator.result()
@@ -237,14 +241,16 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
                         vid_writer[i] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
                     vid_writer[i].write(im0)
 
+    # Print speeds
+    t = tuple(x / seen * 1E3 for x in dt)  # speeds per image
+    print(f'Speed: %.1fms pre-process, %.1fms inference, %.1fms NMS per image at shape {(1, 3, *imgsz)}' % t)
+
     if save_txt or save_img:
         s = f"\n{len(list(save_dir.glob('labels/*.txt')))} labels saved to {save_dir / 'labels'}" if save_txt else ''
         print(f"Results saved to {colorstr('bold', save_dir)}{s}")
 
     if update:
         strip_optimizer(weights)  # update model (to fix SourceChangeWarning)
-
-    print(f'Done. ({time.time() - t0:.3f}s)')
 
 
 def parse_opt():

--- a/detect.py
+++ b/detect.py
@@ -163,10 +163,10 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
             pred[..., 2] *= imgsz[1]  # w
             pred[..., 3] *= imgsz[0]  # h
             pred = torch.tensor(pred)
-        dt[1] += time_sync() - t2
+        t3 = time_sync()
+        dt[1] += t3 - t2
 
         # NMS
-        t3 = time_sync()
         pred = non_max_suppression(pred, conf_thres, iou_thres, classes, agnostic_nms, max_det=max_det)
         dt[2] += time_sync() - t3
 

--- a/detect.py
+++ b/detect.py
@@ -241,11 +241,9 @@ def run(weights='yolov5s.pt',  # model.pt path(s)
                         vid_writer[i] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
                     vid_writer[i].write(im0)
 
-    # Print speeds
+    # Print results
     t = tuple(x / seen * 1E3 for x in dt)  # speeds per image
     print(f'Speed: %.1fms pre-process, %.1fms inference, %.1fms NMS per image at shape {(1, 3, *imgsz)}' % t)
-
-    # Save
     if save_txt or save_img:
         s = f"\n{len(list(save_dir.glob('labels/*.txt')))} labels saved to {save_dir / 'labels'}" if save_txt else ''
         print(f"Results saved to {colorstr('bold', save_dir)}{s}")


### PR DESCRIPTION
Updated detect.py timing to match hub and val.py formats. Allows for simpler FPS calculation for students, i.e. https://github.com/ultralytics/yolov5/issues/4737



```shell
$ python detect.py
YOLOv5 🚀 v5.0-419-gc5360f6 torch 1.9.0 CPU

Fusing layers... 
Model Summary: 224 layers, 7266973 parameters, 0 gradients
image 1/2 /Users/glennjocher/PycharmProjects/yolov5/data/images/bus.jpg: 640x480 4 persons, 1 bus, 1 fire hydrant, Done. (0.240s)
image 2/2 /Users/glennjocher/PycharmProjects/yolov5/data/images/zidane.jpg: 384x640 2 persons, 2 ties, Done. (0.191s)
Speed: 1.1ms pre-process, 215.5ms inference, 1.1ms NMS per image at shape (1, 3, 640, 640)  <------- NEW
Results saved to runs/detect/exp12
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Significant refactor of timing logic in inference scripts for enhanced transparency and clarity.

### 📊 Key Changes
- Removed the global import of the `time` module in `detect.py`.
- Introduced a local, more granular timing system that tracks three distinct stages.
- Changed timing print statements to reflect only the time spent on the inference process, excluding pre- and post-processing times.
- Standardized and cleaned up timing across both `detect.py` and `val.py` for consistency.

### 🎯 Purpose & Impact
- The purpose of these changes is to provide users with more accurate and detailed insights into the model's inference performance 🚀.
- Users will benefit from a clear understanding of where time is spent during model operation, allowing for better optimization and evaluation 🕒.
- This level of detail is especially important for use cases where inference speed is critical, such as real-time applications 📈.