### PR TITLE
Add `callbacks` to train function in W&B sweep

### DIFF
--- a/utils/loggers/wandb/sweep.py
+++ b/utils/loggers/wandb/sweep.py
@@ -9,6 +9,7 @@ sys.path.append(FILE.parents[3].as_posix())  # add utils/ to path
 from train import train, parse_opt
 from utils.general import increment_path
 from utils.torch_utils import select_device
+from utils.callbacks import Callbacks
 
 
 def sweep():
@@ -26,7 +27,8 @@ def sweep():
     device = select_device(opt.device, batch_size=opt.batch_size)
 
     # train
-    train(hyp_dict, opt, device)
+    callbacks = Callbacks()
+    train(hyp_dict, opt, device, callbacks)
 
 
 if __name__ == "__main__":

--- a/utils/loggers/wandb/sweep.py
+++ b/utils/loggers/wandb/sweep.py
@@ -27,8 +27,7 @@ def sweep():
     device = select_device(opt.device, batch_size=opt.batch_size)
 
     # train
-    callbacks = Callbacks()
-    train(hyp_dict, opt, device, callbacks)
+    train(hyp_dict, opt, device, callbacks=Callbacks())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix following https://github.com/ultralytics/yolov5/pull/4688 which modified the function signature to `train`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to the Weights & Biases (WandB) Sweep Functionality in YOLOv5.

### 📊 Key Changes
- Added an import of the `Callbacks` class in the WandB sweep script.
- Modified the `train()` function call to include a new `callbacks` parameter.

### 🎯 Purpose & Impact
- The inclusion of `Callbacks` allows for more customizable training processes by triggering functions at specific stages.
- This update empowers users to integrate advanced training behaviors and custom actions without modifying the core training logic.
- Users leveraging WandB sweeps can now benefit from callbacks, potentially leading to better hyperparameter tuning and more robust model training. 🚀