### PR TITLE
Replace `path.absolute()` with `path.resolve()`

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -15,7 +15,7 @@ import numpy as np
 import torch
 import torch.backends.cudnn as cudnn
 
-FILE = Path(__file__).absolute()
+FILE = Path(__file__).resolve()
 sys.path.append(FILE.parents[0].as_posix())  # add yolov5/ to path
 
 from models.experimental import attempt_load

--- a/export.py
+++ b/export.py
@@ -15,7 +15,7 @@ import torch
 import torch.nn as nn
 from torch.utils.mobile_optimizer import optimize_for_mobile
 
-FILE = Path(__file__).absolute()
+FILE = Path(__file__).resolve()
 sys.path.append(FILE.parents[0].as_posix())  # add yolov5/ to path
 
 from models.common import Conv

--- a/hubconf.py
+++ b/hubconf.py
@@ -33,7 +33,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
     from utils.downloads import attempt_download
     from utils.torch_utils import select_device
 
-    file = Path(__file__).absolute()
+    file = Path(__file__).resolve()
     check_requirements(requirements=file.parent / 'requirements.txt', exclude=('tensorboard', 'thop', 'opencv-python'))
     set_logging(verbose=verbose)
 

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -11,7 +11,7 @@ import sys
 from copy import deepcopy
 from pathlib import Path
 
-FILE = Path(__file__).absolute()
+FILE = Path(__file__).resolve()
 sys.path.append(FILE.parents[1].as_posix())  # add yolov5/ to path
 
 from models.common import *

--- a/train.py
+++ b/train.py
@@ -26,7 +26,7 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim import Adam, SGD, lr_scheduler
 from tqdm import tqdm
 
-FILE = Path(__file__).absolute()
+FILE = Path(__file__).resolve()
 sys.path.append(FILE.parents[0].as_posix())  # add yolov5/ to path
 
 import val  # for end-of-epoch mAP

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,7 +4,7 @@
 # import torch
 # from PIL import ImageFont
 #
-# FILE = Path(__file__).absolute()
+# FILE = Path(__file__).resolve()
 # ROOT = FILE.parents[1]  # yolov5/ dir
 # if str(ROOT) not in sys.path:
 #     sys.path.append(str(ROOT))  # add ROOT to PATH

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -156,7 +156,7 @@ class _RepeatSampler(object):
 
 class LoadImages:  # for inference
     def __init__(self, path, img_size=640, stride=32, auto=True):
-        p = str(Path(path).absolute())  # os-agnostic absolute path
+        p = str(Path(path).resolve())  # os-agnostic absolute path
         if '*' in p:
             files = sorted(glob.glob(p, recursive=True))  # glob
         elif os.path.isdir(p):

--- a/utils/general.py
+++ b/utils/general.py
@@ -147,7 +147,7 @@ def is_colab():
 
 def is_pip():
     # Is file in a pip package?
-    return 'site-packages' in Path(__file__).absolute().parts
+    return 'site-packages' in Path(__file__).resolve().parts
 
 
 def is_ascii(s=''):

--- a/utils/loggers/wandb/sweep.py
+++ b/utils/loggers/wandb/sweep.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import wandb
 
-FILE = Path(__file__).absolute()
+FILE = Path(__file__).resolve()
 sys.path.append(FILE.parents[3].as_posix())  # add utils/ to path
 
 from train import train, parse_opt

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import yaml
 from tqdm import tqdm
 
-FILE = Path(__file__).absolute()
+FILE = Path(__file__).resolve()
 sys.path.append(FILE.parents[3].as_posix())  # add yolov5/ to path
 
 from utils.datasets import LoadImagesAndLabels

--- a/val.py
+++ b/val.py
@@ -17,7 +17,7 @@ import numpy as np
 import torch
 from tqdm import tqdm
 
-FILE = Path(__file__).absolute()
+FILE = Path(__file__).resolve()
 sys.path.append(FILE.parents[0].as_posix())  # add yolov5/ to path
 
 from models.experimental import attempt_load


### PR DESCRIPTION
Per https://docs.python.org/3/library/pathlib.html

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR updates the file path resolution method across various Python scripts.

### 📊 Key Changes
- Replaced `Path(__file__).absolute()` with `Path(__file__).resolve()` in multiple files including `detect.py`, `export.py`, `hubconf.py`, `models/yolo.py`, `train.py`, `utils/__init__.py`, `utils/datasets.py`, `utils/general.py`, `utils/loggers/wandb/sweep.py`, `utils/loggers/wandb/wandb_utils.py`, and `val.py`.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To ensure that file paths are resolved consistently and correctly, especially in environments where symbolic links may exist.
- 🚀 **Impact**: This should prevent potential issues related to file path resolution for users running YOLOv5 in different environments, leading to smoother execution and deployment.