### PR TITLE
close PR

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -661,6 +661,7 @@ def load_mosaic(self, index):
     s = self.img_size
     yc, xc = [int(random.uniform(-x, 2 * s + x)) for x in self.mosaic_border]  # mosaic center x, y
     indices = [index] + random.choices(self.indices, k=3)  # 3 additional image indices
+    random.shuffle(indices)
     for i, index in enumerate(indices):
         # Load image
         img, _, (h, w) = load_image(self, index)
@@ -717,6 +718,7 @@ def load_mosaic9(self, index):
     labels9, segments9 = [], []
     s = self.img_size
     indices = [index] + random.choices(self.indices, k=8)  # 8 additional image indices
+    random.shuffle(indices)
     for i, index in enumerate(indices):
         # Load image
         img, _, (h, w) = load_image(self, index)


### PR DESCRIPTION
Thank you for sharing nice open-source codes 👍

I applied to shuffle the order of all 4(or 9) images in mosaic augmentation

Currently, the order of images in mosaic augmentation is not completely random. 
The remaining images except the first are randomly arranged. Apply shuffle all to increase the diversity of data composition.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced data augmentation for object detection with shuffled mosaic image inputs.

### 📊 Key Changes
- Shuffle image indices when creating mosaic images for training.
- Applied to both `load_mosaic` and `load_mosaic9` methods in `datasets.py`.

### 🎯 Purpose & Impact
- 👍 Ensures a more diverse combination of images in mosaics, preventing the model from overfitting.
- 🔄 May lead to better generalization and improved detection performance on varied data.
- 🔍 Users could see an uptick in model robustness from this seemingly small change.