### PR TITLE
Shuffle all 4(or 9) images in mosaic augmentation

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -661,6 +661,7 @@ def load_mosaic(self, index):
     s = self.img_size
     yc, xc = [int(random.uniform(-x, 2 * s + x)) for x in self.mosaic_border]  # mosaic center x, y
     indices = [index] + random.choices(self.indices, k=3)  # 3 additional image indices
+    random.shuffle(indices)
     for i, index in enumerate(indices):
         # Load image
         img, _, (h, w) = load_image(self, index)
@@ -717,6 +718,7 @@ def load_mosaic9(self, index):
     labels9, segments9 = [], []
     s = self.img_size
     indices = [index] + random.choices(self.indices, k=8)  # 8 additional image indices
+    random.shuffle(indices)
     for i, index in enumerate(indices):
         # Load image
         img, _, (h, w) = load_image(self, index)


### PR DESCRIPTION
Thank you for sharing nice open-source codes 👍

This PR is. for shuffling the order of all 4(or 9) images in mosaic augmentation

Currently, the order of images in mosaic augmentation is not completely random.
The remaining images except the first are randomly arranged. Apply shuffle all to increase the diversity of data composition.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image indexing for data augmentation in YOLOv5 🖼️✨

### 📊 Key Changes
- Added `random.shuffle(indices)` in the `load_mosaic` and `load_mosaic9` methods.

### 🎯 Purpose & Impact
- **Purpose:** To introduce more randomness in selecting images for mosaic data augmentation, which stitches together multiple images to create a new training sample.
- **Impact:** This change likely leads to better model generalization due to increased variability in training data, potentially improving the performance of YOLOv5 object detection models. 🚀