### PR TITLE
Evolution `--resume` fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -64,7 +64,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
     # Directories
     w = save_dir / 'weights'  # weights dir
-    w.mkdir(parents=True, exist_ok=True)  # make dir
+    (w.parent if evolve else w).mkdir(parents=True, exist_ok=True)  # make dir
     last, best = w / 'last.pt', w / 'best.pt'
 
     # Hyperparameters
@@ -489,7 +489,7 @@ def main(opt, callbacks=Callbacks()):
         assert len(opt.cfg) or len(opt.weights), 'either --cfg or --weights must be specified'
         if opt.evolve:
             opt.project = 'runs/evolve'
-            opt.exist_ok = opt.resume
+            opt.exist_ok, opt.resume = opt.resume, False  # pass resume to exist_ok and disable resume
         opt.save_dir = str(increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok))
 
     # DDP mode


### PR DESCRIPTION
Also disable `/weights` dir creation when evolving as no weights are saved and empty folder causes user expectations of weights.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved directory management and options handling during model training and evolution.

### 📊 Key Changes
- Modified weight directory creation to accommodate evolution runs.
- Tweaked command-line options to better manage the `--evolve` flag, ensuring separate runs do not overwrite each other.

### 🎯 Purpose & Impact
- 🧰 **Enhanced Evolve Feature**: The change in directory creation ensures that when evolutionary training is underway (`--evolve`), the script sets up directories correctly without clashes, leading to a more organized training process.
- 🛠️ **Improved Argument Handling**: Adjustments to the options fix potential issues where resuming training could conflict with existing saved models, streamlining user experience and script robustness.

This update should not affect normal training runs but will make evolving models more reliable and user-friendly.