### PR TITLE
Multiple TF export improvements

### DIFF
--- a/export.py
+++ b/export.py
@@ -194,6 +194,7 @@ def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('Te
             dataset = LoadImages(check_dataset(data)['train'], img_size=imgsz, auto=False)  # representative data
             converter.representative_dataset = lambda: representative_dataset_gen(dataset, ncalib)
             converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
+            converter.target_spec.supported_types = []
             converter.inference_input_type = tf.uint8  # or tf.int8
             converter.inference_output_type = tf.uint8  # or tf.int8
             converter.experimental_new_quantizer = False

--- a/export.py
+++ b/export.py
@@ -188,6 +188,7 @@ def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('Te
 
         converter = tf.lite.TFLiteConverter.from_keras_model(keras_model)
         converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS]
+        converter.target_spec.supported_types = [tf.float16]
         converter.optimizations = [tf.lite.Optimize.DEFAULT]
         if int8:
             dataset = LoadImages(check_dataset(data)['train'], img_size=imgsz, auto=False)  # representative data

--- a/export.py
+++ b/export.py
@@ -145,6 +145,7 @@ def export_saved_model(model, im, file, dynamic,
         inputs = keras.Input(shape=(*imgsz, 3), batch_size=None if dynamic else batch_size)
         outputs = tf_model.predict(inputs, tf_nms, agnostic_nms, topk_per_class, topk_all, iou_thres, conf_thres)
         keras_model = keras.Model(inputs=inputs, outputs=outputs)
+        keras_model.trainable = False
         keras_model.summary()
         keras_model.save(f, save_format='tf')
 

--- a/export.py
+++ b/export.py
@@ -183,7 +183,7 @@ def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('Te
 
         print(f'\n{prefix} starting export with tensorflow {tf.__version__}...')
         batch_size, ch, *imgsz = list(im.shape)  # BCHW
-        f = file.with_suffix('.tflite')
+        f = str(file).replace('.pt', '-fp16.tflite')
 
         converter = tf.lite.TFLiteConverter.from_keras_model(keras_model)
         converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS]
@@ -249,7 +249,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
     # Load PyTorch model
     device = select_device(device)
     assert not (device.type == 'cpu' and half), '--half only compatible with GPU export, i.e. use --device 0'
-    model = attempt_load(weights, map_location=device, inplace=True, fuse=not any(tf_exports))  # load FP32 model
+    model = attempt_load(weights, map_location=device, inplace=True, fuse=True)  # load FP32 model
     nc, names = model.nc, model.names  # number of classes, class names
 
     # Input

--- a/models/tf.py
+++ b/models/tf.py
@@ -70,8 +70,9 @@ class TFConv(keras.layers.Layer):
         # see https://stackoverflow.com/questions/52975843/comparing-conv2d-with-padding-between-tensorflow-and-pytorch
 
         conv = keras.layers.Conv2D(
-            c2, k, s, 'SAME' if s == 1 else 'VALID', use_bias=False,
-            kernel_initializer=keras.initializers.Constant(w.conv.weight.permute(2, 3, 1, 0).numpy()))
+            c2, k, s, 'SAME' if s == 1 else 'VALID', use_bias=False if hasattr(w, 'bn') else True,
+            kernel_initializer=keras.initializers.Constant(w.conv.weight.permute(2, 3, 1, 0).numpy()),
+            bias_initializer='zeros' if hasattr(w, 'bn') else keras.initializers.Constant(w.conv.bias.numpy()))
         self.conv = conv if s == 1 else keras.Sequential([TFPad(autopad(k, p)), conv])
         self.bn = TFBN(w.bn) if hasattr(w, 'bn') else tf.identity
 


### PR DESCRIPTION
* Fusing YOLOv5 models before TF export.
* Set params to non trainable during the export process.
* Fix TFLite fp16 model export.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved support for TensorFlow Lite (TFLite) export and Keras model conversion 🚀

### 📊 Key Changes
- Set `keras_model.trainable` to `False` to freeze the model weights during export.
- Changed the TFLite file naming convention to include the floating-point precision (`-fp16`) in the filename.
- Added support for exporting to TensorFlow Lite with float16 quantization.
- Updated Conv2D initialization in TensorFlow models to consider if layer has batch normalization or not, and add bias accordingly.
- Enforced fusing of model layers during loading for all TensorFlow export formats.

### 🎯 Purpose & Impact
- Freezing the Keras model weights during export ensures the model remains unchanged for inference, improving reliability.
- New naming convention for TFLite files clarifies the precision level of the exported model, aiding in user understanding.
- Float16 support in TFLite can reduce model size, potentially leading to faster inference on compatible hardware while maintaining good accuracy.
- Correct handling of biases in Conv2D layers during TensorFlow model conversion improves model equivalence between PyTorch and TensorFlow implementations.
- Enforcing layer fusing aligns PyTorch model loading with TensorFlow's optimization practices, leading to potentially faster and more efficient inference operations.

Overall, these changes aim to enhance the user experience by providing more efficient and understandable model export options, ensuring more consistent cross-platform model performance. 📈🔒