### PR TITLE
Fix 'PyTorch starting from' for URL weights

### DIFF
--- a/export.py
+++ b/export.py
@@ -272,7 +272,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
 
     for _ in range(2):
         y = model(im)  # dry runs
-    print(f"\n{colorstr('PyTorch:')} starting from {weights} ({file_size(weights):.1f} MB)")
+    print(f"\n{colorstr('PyTorch:')} starting from {file} ({file_size(file):.1f} MB)")
 
     # Exports
     if 'torchscript' in include:


### PR DESCRIPTION
Follows #4823

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement to logging output in the export script of the YOLOv5 repository.

### 📊 Key Changes
- The export script now references `file` instead of `weights` when printing the starting file size.

### 🎯 Purpose & Impact
- Clarifies the log message by printing the correct file name that is being processed.
- The update has a minor impact but improves the accuracy of the information provided to the user during the export process. 🧐
- Users will benefit from more accurate feedback when exporting their models, enhancing usability. 👍