### PR TITLE
Sorted datasets update to `cache_labels()`

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -487,7 +487,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         nm, nf, ne, nc, msgs = 0, 0, 0, 0, []  # number missing, found, empty, corrupt, messages
         desc = f"{prefix}Scanning '{path.parent / path.stem}' images and labels..."
         with Pool(NUM_THREADS) as pool:
-            pbar = tqdm(pool.imap_unordered(verify_image_label, zip(self.img_files, self.label_files, repeat(prefix))),
+            pbar = tqdm(pool.imap(verify_image_label, zip(self.img_files, self.label_files, repeat(prefix))),
                         desc=desc, total=len(self.img_files))
             for im_file, l, shape, segments, nm_f, nf_f, ne_f, nc_f, msg in pbar:
                 nm += nm_f
@@ -508,7 +508,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         x['hash'] = get_hash(self.label_files + self.img_files)
         x['results'] = nf, nm, ne, nc, len(self.img_files)
         x['msgs'] = msgs  # warnings
-        x['version'] = 0.4  # cache version
+        x['version'] = 0.5  # cache version
         try:
             np.save(path, x)  # save cache for next time
             path.with_suffix('.cache.npy').rename(path)  # remove .npy suffix


### PR DESCRIPTION
PR should produce datasets sorted alphabetically by filename. Cache version incremented to 0.5. 

Note: will force a one-time re-caching of existing datasets on first-use.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image and label scanning process in YOLOv5 dataset caching.

### 📊 Key Changes
- Replaced `imap_unordered` with `imap` function in the dataset labeling process.
- Updated cache version from 0.4 to 0.5.

### 🎯 Purpose & Impact
- 🎯 The switch to `imap` enforces the order during multiprocessing, which can help in maintaining consistency.
- 📈 By incrementing the cache version, users are informed of an update that possibly includes new features or bug fixes. Users can expect a slight change in how the dataset caching system works, potentially improving their experience with data processing.