### PR TITLE
Single `cache_version` definition

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -365,6 +365,8 @@ def img2label_paths(img_paths):
 
 
 class LoadImagesAndLabels(Dataset):  # for training/testing
+    cache_version = 0.5  # dataset labels *.cache version
+
     def __init__(self, path, img_size=640, batch_size=16, augment=False, hyp=None, rect=False, image_weights=False,
                  cache_images=False, single_cls=False, stride=32, pad=0.0, prefix=''):
         self.img_size = img_size
@@ -404,7 +406,8 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         cache_path = (p if p.is_file() else Path(self.label_files[0]).parent).with_suffix('.cache')
         try:
             cache, exists = np.load(cache_path, allow_pickle=True).item(), True  # load dict
-            assert cache['version'] == 0.4 and cache['hash'] == get_hash(self.label_files + self.img_files)
+            assert cache['version'] == self.cache_version  # same version
+            assert cache['hash'] == get_hash(self.label_files + self.img_files)  # same hash
         except:
             cache, exists = self.cache_labels(cache_path, prefix), False  # cache
 
@@ -508,7 +511,7 @@ class LoadImagesAndLabels(Dataset):  # for training/testing
         x['hash'] = get_hash(self.label_files + self.img_files)
         x['results'] = nf, nm, ne, nc, len(self.img_files)
         x['msgs'] = msgs  # warnings
-        x['version'] = 0.5  # cache version
+        x['version'] = self.cache_version  # cache version
         try:
             np.save(path, x)  # save cache for next time
             path.with_suffix('.cache.npy').rename(path)  # remove .npy suffix


### PR DESCRIPTION
Defines dataset labels *.cache version in a single place, fixing a bug introduced in #4845.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated dataset caching logic in YOLOv5 for improved consistency and maintainability.

### 📊 Key Changes
- Introduced `cache_version` variable in `LoadImagesAndLabels` class.
- Updated cache validation to check against the `cache_version` variable.
- Ensured cache version and file hash checks match current dataset.

### 🎯 Purpose & Impact
- **Purpose:** The changes simplify the process of ensuring the cache format remains consistent across versions, making maintenance easier and reducing potential errors caused by format discrepancies.
- **Impact:** Users will benefit from more consistent cache behavior when training or evaluating models. It will minimize issues related to outdated or mismatched cache data, leading to a smoother user experience. 🔄💾