### PR TITLE
Validate `best.pt` on train end

### DIFF
--- a/train.py
+++ b/train.py
@@ -406,7 +406,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
             if f.exists():
                 strip_optimizer(f)  # strip optimizers
                 if f is best:
-                    LOGGER.info(f'Validating {f}...')
+                    LOGGER.info(f'\nValidating {f}...')
                     results, _, _ = val.run(data_dict,
                                             batch_size=batch_size // WORLD_SIZE * 2,
                                             imgsz=imgsz,

--- a/train.py
+++ b/train.py
@@ -356,9 +356,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                                            single_cls=single_cls,
                                            dataloader=val_loader,
                                            save_dir=save_dir,
-                                           save_json=is_coco and final_epoch,
-                                           verbose=nc < 50 and final_epoch,
-                                           plots=plots and final_epoch,
+                                           plots=False,
                                            callbacks=callbacks,
                                            compute_loss=compute_loss)
 
@@ -404,23 +402,22 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     # end training -----------------------------------------------------------------------------------------------------
     if RANK in [-1, 0]:
         LOGGER.info(f'\n{epoch - start_epoch + 1} epochs completed in {(time.time() - t0) / 3600:.3f} hours.')
-        if not evolve:
-            if is_coco:  # COCO dataset
-                for m in [last, best] if best.exists() else [last]:  # speed, mAP tests
+        for f in last, best:
+            if f.exists():
+                strip_optimizer(f)  # strip optimizers
+                if f is best:
                     results, _, _ = val.run(data_dict,
                                             batch_size=batch_size // WORLD_SIZE * 2,
                                             imgsz=imgsz,
-                                            model=attempt_load(m, device).half(),
+                                            model=attempt_load(f, device).half(),
                                             iou_thres=0.7,  # NMS IoU threshold for best pycocotools results
                                             single_cls=single_cls,
                                             dataloader=val_loader,
                                             save_dir=save_dir,
-                                            save_json=True,
-                                            plots=False)
-            # Strip optimizers
-            for f in last, best:
-                if f.exists():
-                    strip_optimizer(f)  # strip optimizers
+                                            save_json=is_coco,
+                                            verbose=True,
+                                            plots=True)  # val best model with plots
+
         callbacks.run('on_train_end', last, best, plots, epoch)
         LOGGER.info(f"Results saved to {colorstr('bold', save_dir)}")
 

--- a/train.py
+++ b/train.py
@@ -416,7 +416,8 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                                             save_dir=save_dir,
                                             save_json=is_coco,
                                             verbose=True,
-                                            plots=True)  # val best model with plots
+                                            plots=True,
+                                            callbacks=callbacks)  # val best model with plots
 
         callbacks.run('on_train_end', last, best, plots, epoch)
         LOGGER.info(f"Results saved to {colorstr('bold', save_dir)}")

--- a/train.py
+++ b/train.py
@@ -410,7 +410,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                                             batch_size=batch_size // WORLD_SIZE * 2,
                                             imgsz=imgsz,
                                             model=attempt_load(f, device).half(),
-                                            iou_thres=0.7,  # NMS IoU threshold for best pycocotools results
+                                            iou_thres=0.7 if is_coco else 0.6,  # best pycocotools results at 0.7
                                             single_cls=single_cls,
                                             dataloader=val_loader,
                                             save_dir=save_dir,

--- a/train.py
+++ b/train.py
@@ -406,6 +406,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
             if f.exists():
                 strip_optimizer(f)  # strip optimizers
                 if f is best:
+                    LOGGER.info(f'Validating {f}...')
                     results, _, _ = val.run(data_dict,
                                             batch_size=batch_size // WORLD_SIZE * 2,
                                             imgsz=imgsz,

--- a/val.py
+++ b/val.py
@@ -133,8 +133,7 @@ def run(data,
 
     # Half
     half &= device.type != 'cpu'  # half precision only supported on CUDA
-    if half:
-        model.half()
+    model.half() if half else model.float()
 
     # Configure
     model.eval()


### PR DESCRIPTION
Implements a final validation run (with plots) on best.pt after training completes. Resolves issues raised in #4858.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplification of validation logic and cleanup in training end routines.

### 📊 Key Changes
- Removed verbosity and JSON saving conditions tied to the COCO dataset and final epoch in `train.py`.
- Validation now always runs without plots unless the best model is being validated.
- Consolidated the optimizer stripping code for the last and best model files.
- In 'val.py', streamlined conditional model precision setting with a single line.

### 🎯 Purpose & Impact
- The update aims to reduce complexity within the training code by eliminating conditional statements related to verbose flags and JSON outputs.
- This change may lead to a slight performance improvement and better understandability of the code for developers.
- For users, these changes ensure a more consistent behavior at the end of training, regardless of dataset and epoch count.
- Streamlining the precision setting in `val.py` impacts how the model is run during validation, potentially affecting the speed and resource usage for this step.