### PR TITLE
Fix arg help string to match 'classes' arg name.

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -267,7 +267,7 @@ def parse_opt():
     parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
     parser.add_argument('--save-crop', action='store_true', help='save cropped prediction boxes')
     parser.add_argument('--nosave', action='store_true', help='do not save images/videos')
-    parser.add_argument('--classes', nargs='+', type=int, help='filter by class: --class 0, or --class 0 2 3')
+    parser.add_argument('--classes', nargs='+', type=int, help='filter by class: --classes 0, or --classes 0 2 3')
     parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS')
     parser.add_argument('--augment', action='store_true', help='augmented inference')
     parser.add_argument('--visualize', action='store_true', help='visualize features')


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Correction of the `--classes` argument help text in `detect.py`.

### 📊 Key Changes
- Fixed a typo in the command-line argument help text for `--classes`.

### 🎯 Purpose & Impact
- Clarifies how to use the `--classes` argument, improving the user experience.
- Ensures accurate documentation, preventing potential confusion among developers and users when filtering detections by class.