### PR TITLE
Avoid out-of-image class labels

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -73,7 +73,6 @@ class Annotator:
             self.im = im if isinstance(im, Image.Image) else Image.fromarray(im)
             self.draw = ImageDraw.Draw(self.im)
             self.font = check_font(font, size=font_size or max(round(sum(self.im.size) / 2 * 0.035), 12))
-            self.fh = self.font.getsize('a')[1] - 3  # font height
         else:  # use cv2
             self.im = im
         self.lw = line_width or max(round(sum(im.shape) / 2 * 0.003), 2)  # line width
@@ -84,25 +83,24 @@ class Annotator:
             self.draw.rectangle(box, width=self.lw, outline=color)  # box
             if label:
                 w, h = self.font.getsize(label)  # text width
+                outside = box[1] - h >= 0  # label fits outside box
                 self.draw.rectangle([box[0],
-                                     box[1] - h if box[1] - h >= 0 else box[1],
+                                     box[1] - h if outside else box[1],
                                      box[0] + w + 1,
-                                     box[1] + 1 if box[1] - h >= 0 else box[1] + h + 1], fill=color)
+                                     box[1] + 1 if outside else box[1] + h + 1], fill=color)
                 # self.draw.text((box[0], box[1]), label, fill=txt_color, font=self.font, anchor='ls')  # for PIL>8.0
-                self.draw.text((box[0], box[1] - h if box[1] - h >= 0 else box[1]),
-                               label, fill=txt_color, font=self.font)
+                self.draw.text((box[0], box[1] - h if outside else box[1]), label, fill=txt_color, font=self.font)
         else:  # cv2
             c1, c2 = (int(box[0]), int(box[1])), (int(box[2]), int(box[3]))
             cv2.rectangle(self.im, c1, c2, color, thickness=self.lw, lineType=cv2.LINE_AA)
             if label:
                 tf = max(self.lw - 1, 1)  # font thickness
                 w, h = cv2.getTextSize(label, 0, fontScale=self.lw / 3, thickness=tf)[0]
-                c2 = c1[0] + w, c1[1] - h - 3 if c1[1] - h - 3 >= 0 else c1[1] + h + 3
+                outside = c1[1] - h - 3 >= 0  # label fits outside box
+                c2 = c1[0] + w, c1[1] - h - 3 if outside else c1[1] + h + 3
                 cv2.rectangle(self.im, c1, c2, color, -1, cv2.LINE_AA)  # filled
-                cv2.putText(self.im, label,
-                            (c1[0], c1[1] - 2 if c1[1] - h -3 >= 0 else c1[1] + h + 2),
-                                0, self.lw / 3, txt_color, thickness=tf,
-                            lineType=cv2.LINE_AA)
+                cv2.putText(self.im, label, (c1[0], c1[1] - 2 if outside else c1[1] + h + 2), 0, self.lw / 3, txt_color,
+                            thickness=tf, lineType=cv2.LINE_AA)
 
     def rectangle(self, xy, fill=None, outline=None, width=1):
         # Add rectangle to image (PIL-only)

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -84,18 +84,24 @@ class Annotator:
             self.draw.rectangle(box, width=self.lw, outline=color)  # box
             if label:
                 w, h = self.font.getsize(label)  # text width
-                self.draw.rectangle([box[0], box[1] - self.fh, box[0] + w + 1, box[1] + 1], fill=color)
+                self.draw.rectangle([box[0],
+                                     box[1] - h if box[1] - h >= 0 else box[1],
+                                     box[0] + w + 1,
+                                     box[1] + 1 if box[1] - h >= 0 else box[1] + h + 1], fill=color)
                 # self.draw.text((box[0], box[1]), label, fill=txt_color, font=self.font, anchor='ls')  # for PIL>8.0
-                self.draw.text((box[0], box[1] - h), label, fill=txt_color, font=self.font)
+                self.draw.text((box[0], box[1] - h if box[1] - h >= 0 else box[1]),
+                               label, fill=txt_color, font=self.font)
         else:  # cv2
             c1, c2 = (int(box[0]), int(box[1])), (int(box[2]), int(box[3]))
             cv2.rectangle(self.im, c1, c2, color, thickness=self.lw, lineType=cv2.LINE_AA)
             if label:
                 tf = max(self.lw - 1, 1)  # font thickness
                 w, h = cv2.getTextSize(label, 0, fontScale=self.lw / 3, thickness=tf)[0]
-                c2 = c1[0] + w, c1[1] - h - 3
+                c2 = c1[0] + w, c1[1] - h - 3 if c1[1] - h - 3 >= 0 else c1[1] + h + 3
                 cv2.rectangle(self.im, c1, c2, color, -1, cv2.LINE_AA)  # filled
-                cv2.putText(self.im, label, (c1[0], c1[1] - 2), 0, self.lw / 3, txt_color, thickness=tf,
+                cv2.putText(self.im, label,
+                            (c1[0], c1[1] - 2 if c1[1] - h -3 >= 0 else c1[1] + h + 2),
+                                0, self.lw / 3, txt_color, thickness=tf,
                             lineType=cv2.LINE_AA)
 
     def rectangle(self, xy, fill=None, outline=None, width=1):

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -82,7 +82,7 @@ class Annotator:
         if self.pil or not is_ascii(label):
             self.draw.rectangle(box, width=self.lw, outline=color)  # box
             if label:
-                w, h = self.font.getsize(label)  # text width
+                w, h = self.font.getsize(label)  # text width, height
                 outside = box[1] - h >= 0  # label fits outside box
                 self.draw.rectangle([box[0],
                                      box[1] - h if outside else box[1],
@@ -91,15 +91,15 @@ class Annotator:
                 # self.draw.text((box[0], box[1]), label, fill=txt_color, font=self.font, anchor='ls')  # for PIL>8.0
                 self.draw.text((box[0], box[1] - h if outside else box[1]), label, fill=txt_color, font=self.font)
         else:  # cv2
-            c1, c2 = (int(box[0]), int(box[1])), (int(box[2]), int(box[3]))
-            cv2.rectangle(self.im, c1, c2, color, thickness=self.lw, lineType=cv2.LINE_AA)
+            p1, p2 = (int(box[0]), int(box[1])), (int(box[2]), int(box[3]))
+            cv2.rectangle(self.im, p1, p2, color, thickness=self.lw, lineType=cv2.LINE_AA)
             if label:
                 tf = max(self.lw - 1, 1)  # font thickness
-                w, h = cv2.getTextSize(label, 0, fontScale=self.lw / 3, thickness=tf)[0]
-                outside = c1[1] - h - 3 >= 0  # label fits outside box
-                c2 = c1[0] + w, c1[1] - h - 3 if outside else c1[1] + h + 3
-                cv2.rectangle(self.im, c1, c2, color, -1, cv2.LINE_AA)  # filled
-                cv2.putText(self.im, label, (c1[0], c1[1] - 2 if outside else c1[1] + h + 2), 0, self.lw / 3, txt_color,
+                w, h = cv2.getTextSize(label, 0, fontScale=self.lw / 3, thickness=tf)[0]  # text width, height
+                outside = p1[1] - h - 3 >= 0  # label fits outside box
+                p2 = p1[0] + w, p1[1] - h - 3 if outside else p1[1] + h + 3
+                cv2.rectangle(self.im, p1, p2, color, -1, cv2.LINE_AA)  # filled
+                cv2.putText(self.im, label, (p1[0], p1[1] - 2 if outside else p1[1] + h + 2), 0, self.lw / 3, txt_color,
                             thickness=tf, lineType=cv2.LINE_AA)
 
     def rectangle(self, xy, fill=None, outline=None, width=1):


### PR DESCRIPTION
Avoid out-of-image class labels in detection.
Without this PR, labels may be out of the image.
![image](https://user-images.githubusercontent.com/3896992/134608892-7dee4696-f49d-47d1-9345-49aaac3ddc78.png)

In this PR, labels are contained within the image.
![image](https://user-images.githubusercontent.com/3896992/134608938-c9ccaa19-f05b-4125-ac17-6fe0ac3a60cd.png)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved label positioning for object detection annotations in Ultralytics' YOLOv5.

### 📊 Key Changes
- Removed redundant font height calculation for drawing text.
- Adjusted label positioning logic to allow labels to be drawn inside or outside of bounding boxes, depending on available space.
- Unified label positioning style across both PIL and OpenCV to enhance consistency.

### 🎯 Purpose & Impact
- **Enhanced Readability:** Better placement of labels ensures they do not overlap with other UI elements or go off-screen, enhancing readability.
- **Increased Robustness:** By checking if the label fits outside the box before deciding its position, the change provides smarter annotation that could minimize occlusion on small objects or images with limited space.
- **Visual Consistency Across Backends:** Whether using PIL or OpenCV for drawing, labels will now follow the same positioning rules, providing a consistent visual experience for end-users.