### PR TITLE
fix zipfile name for coco128-segments

### DIFF
--- a/data/scripts/get_coco128.sh
+++ b/data/scripts/get_coco128.sh
@@ -10,7 +10,7 @@
 # Download/unzip images and labels
 d='../datasets' # unzip directory
 url=https://github.com/ultralytics/yolov5/releases/download/v1.0/
-f='coco128.zip' # or 'coco2017labels-segments.zip', 68 MB
+f='coco128.zip' # or 'coco128-segments.zip', 68 MB
 echo 'Downloading' $url$f ' ...'
 curl -L $url$f -o $f && unzip -q $f -d $d && rm $f &
 


### PR DESCRIPTION
Incorrect zip-file name in the comment which downloads the coco2017 dataset instead of coco128.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to COCO128 dataset download script in YOLOv5.

### 📊 Key Changes
- Changed the associated zip file name in the dataset download script from 'coco2017labels-segments.zip' to 'coco128-segments.zip'.

### 🎯 Purpose & Impact
- Ensures users download the correct segmentation data for the COCO128 dataset.
- Prevents confusion and potential errors that could arise from downloading mismatched dataset files.
- Impacts users who use the download script to acquire data for model training and evaluation; they'll now get the appropriate dataset more reliably. 🔄