### PR TITLE
Fix `root` referenced before assignment

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -352,11 +352,11 @@ def check_dataset(data, autodownload=True):
         if not all(x.exists() for x in val):
             print('\nWARNING: Dataset not found, nonexistent paths: %s' % [str(x) for x in val if not x.exists()])
             if s and autodownload:  # download script
+                root = path.parent if 'path' in data else '..'  # unzip directory i.e. '../'
                 if s.startswith('http') and s.endswith('.zip'):  # URL
                     f = Path(s).name  # filename
                     print(f'Downloading {s} to {f}...')
                     torch.hub.download_url_to_file(s, f)
-                    root = path.parent if 'path' in data else '..'  # unzip directory i.e. '../'
                     Path(root).mkdir(parents=True, exist_ok=True)  # create root
                     ZipFile(f).extractall(path=root)  # unzip
                     Path(f).unlink()  # remove zip

--- a/utils/general.py
+++ b/utils/general.py
@@ -366,7 +366,7 @@ def check_dataset(data, autodownload=True):
                     r = os.system(s)
                 else:  # python script
                     r = exec(s, {'yaml': data})  # return None
-                print(f"Dataset autodownload {f'success, saved to {root}' if r in (0, None) else 'failure'}")
+                print(f"Dataset autodownload {f'success, saved to {root}' if r in (0, None) else 'failure'}\n")
             else:
                 raise Exception('Dataset not found.')
 


### PR DESCRIPTION
Fix for bug introduced by #4919 discovered on VOC autodownload:
```
python train.py --data VOC.yaml
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated dataset autodownload and extraction process in `check_dataset` function.

### 📊 Key Changes
- Ensured the root directory for unzipping datasets is defined before downloading the `.zip` file.
- Improved user feedback by adding a newline character to the dataset autodownload success/failure message.

### 🎯 Purpose & Impact
- These changes aim to make the dataset downloading process more robust and user-friendly.
- Users will experience a smoother autodownload process with clearer communication on success or failure status. This can be particularly helpful when setting up datasets for the first time or in automated scripts. 🔄