### PR TITLE
Update default Albumentations

### DIFF
--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -23,9 +23,13 @@ class Albumentations:
             check_version(A.__version__, '1.0.3')  # version requirement
 
             self.transform = A.Compose([
-                A.Blur(p=0.1),
-                A.MedianBlur(p=0.1),
-                A.ToGray(p=0.01)],
+                A.Blur(p=0.01),
+                A.MedianBlur(p=0.01),
+                A.ToGray(p=0.01),
+                A.CLAHE(p=0.01),
+                A.RandomBrightnessContrast(p=0.0),
+                A.RandomGamma(p=0.0),
+                A.ImageCompression(quality_lower=75, p=0.0)],
                 bbox_params=A.BboxParams(format='yolo', label_fields=['class_labels']))
 
             logging.info(colorstr('albumentations: ') + ', '.join(f'{x}' for x in self.transform.transforms if x.p))


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimized image augmentation probabilities in the YOLOv5 model.

### 📊 Key Changes
- Reduced the probability of applying the Blur and MedianBlur effects from 0.1 to 0.01.
- Added new augmentations with a probability of 0.01 for CLAHE (Contrast Limited Adaptive Histogram Equalization).
- Introduced RandomBrightnessContrast and RandomGamma augmentations with a disabled state (probability set to 0.0).
- Included ImageCompression with a default quality setting of 75 but disabled it (probability set to 0.0).

### 🎯 Purpose & Impact
- 🎨 **Enhanced Data Augmentation:** Adding new transformations like CLAHE enriches the data augmentation pipeline and can potentially improve model robustness to various lighting conditions.
- 🔍 **Fine-Tuning Probabilities:** Adjusting the probabilities of existing augmentations aims to create a more balanced augmentation strategy that may lead to better generalization and prevent overfitting.
- 🚀 **Experimentation Ready:** Including new augmentations with a zero probability allows for quick experimentation. Developers can easily enable these augmentations in the future for further research and testing.
- 📈 **Potential Impact:** These changes could lead to more effective training and possibly improved accuracy without changing the current model behavior since new augmentations are initially set to not apply.