### PR TITLE
Update wandb_utils.py

### DIFF
--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -45,7 +45,8 @@ def check_wandb_config_file(data_config_file):
 
 
 def check_wandb_dataset(data_file):
-    is_wandb_artifact = False
+    is_trainset_wandb_artifact = False
+    is_valset_wandb_artifact = False
     if check_file(data_file) and data_file.endswith('.yaml'):
         with open(data_file, errors='ignore') as f:
             data_dict = yaml.safe_load(f)


### PR DESCRIPTION
`is_valset_wandb_artifact` and `is_trainset_wandb_artifact` were referenced before assignment causing wandb to be unusable.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of Weights & Biases integration for dataset tracking.

### 📊 Key Changes
- Split a single flag `is_wandb_artifact` into two: `is_trainset_wandb_artifact` and `is_valset_wandb_artifact`.
- Improved clarity in distinguishing between training and validation dataset artifact status within Weights & Biases.

### 🎯 Purpose & Impact
- Provides better granularity by separately identifying the use of Weights & Biases artifacts for training and validation datasets.
- 🎉 Allows users to more accurately track and version their datasets, potentially improving experiment management and reproducibility.
- Minimal user impact in terms of usability, mostly affecting how data is logged and tracked in the backend.