### PR TITLE
Fix `isascii()` method calls for python 3.6

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -161,7 +161,7 @@ def is_pip():
     return 'site-packages' in Path(__file__).resolve().parts
 
 def is_ascii(s=''):
-    # Is string composed of all ASCII (no UTF) characters?
+    # Is string composed of all ASCII (no UTF) characters? (note str().isascii() introduced in python 3.7)
     s = str(s)  # convert list, tuple, None, etc. to str
     return len(s.encode().decode('ascii', 'ignore')) == len(s)
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -160,6 +160,11 @@ def is_pip():
     # Is file in a pip package?
     return 'site-packages' in Path(__file__).resolve().parts
 
+def is_ascii(s=''):
+    # Is string composed of all ASCII (no UTF) characters?
+    s = str(s)  # convert list, tuple, None, etc. to str
+    return len(s.encode().decode('ascii', 'ignore')) == len(s)
+
 
 def is_chinese(s='人工智能'):
     # Is string composed of any Chinese characters?

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -17,7 +17,7 @@ import seaborn as sn
 import torch
 from PIL import Image, ImageDraw, ImageFont
 
-from utils.general import user_config_dir, is_chinese, xywh2xyxy, xyxy2xywh
+from utils.general import user_config_dir, is_ascii, is_chinese, xywh2xyxy, xyxy2xywh
 from utils.metrics import fitness
 
 # Settings
@@ -68,7 +68,7 @@ class Annotator:
     # YOLOv5 Annotator for train/val mosaics and jpgs and detect/hub inference annotations
     def __init__(self, im, line_width=None, font_size=None, font='Arial.ttf', pil=False, example='abc'):
         assert im.data.contiguous, 'Image not contiguous. Apply np.ascontiguousarray(im) to Annotator() input images.'
-        self.pil = pil or not example.isascii() or is_chinese(example)
+        self.pil = pil or not is_ascii(example) or is_chinese(example)
         if self.pil:  # use PIL
             self.im = im if isinstance(im, Image.Image) else Image.fromarray(im)
             self.draw = ImageDraw.Draw(self.im)
@@ -80,7 +80,7 @@ class Annotator:
 
     def box_label(self, box, label='', color=(128, 128, 128), txt_color=(255, 255, 255)):
         # Add one xyxy box to image with label
-        if self.pil or not label.isascii():
+        if self.pil or not is_ascii(label):
             self.draw.rectangle(box, width=self.lw, outline=color)  # box
             if label:
                 w, h = self.font.getsize(label)  # text width, height


### PR DESCRIPTION
The `str.isascii()` method was introduced in python3.7, so this changes it back to using the utils function `is_ascii` to continue supporting python3.6.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement in string character encoding checks and annotations in YOLOv5.

### 📊 Key Changes
- Implemented a new function `is_ascii` to check if a string is composed only of ASCII characters.
- Replaced the direct `.isascii()` string method with the new `is_ascii` function within the annotation class `Annotator`.

### 🎯 Purpose & Impact
- **Purpose:** The introduction of `is_ascii` aims to provide compatibility for Python versions older than 3.7, which do not have the `.isascii()` method for strings.
- **Impact:** Users working on environments with older Python versions will benefit from this update, ensuring that character encoding issues are handled seamlessly across different Python versions. Visual annotations on images will work correctly regardless of the character set being used in the labels.