### PR TITLE
Fix relative `ROOT` Pytorch Hub custom model bug

### DIFF
--- a/models/tf.py
+++ b/models/tf.py
@@ -20,7 +20,7 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[1]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
-ROOT = ROOT.relative_to(Path.cwd())  # relative
+# ROOT = ROOT.relative_to(Path.cwd())  # relative
 
 import numpy as np
 import tensorflow as tf

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -15,7 +15,7 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[1]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
-ROOT = ROOT.relative_to(Path.cwd())  # relative
+# ROOT = ROOT.relative_to(Path.cwd())  # relative
 
 from models.common import *
 from models.experimental import *


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of ROOT directory path handling in TensorFlow and YOLO model scripts.

### 📊 Key Changes
- Commented out the conversion of `ROOT` to a relative path in both `tf.py` and `yolo.py`.
- The `ROOT` directory variable now remains as an absolute path, as opposed to being converted to a relative path based on the current working directory.

### 🎯 Purpose & Impact
- This change could potentially resolve issues related to path handling, which can vary depending on the user's current working directory.
- Users may see improvements in the ease of importing and utilizing these models within different project structures.
- It simplifies the code by removing an operation that could cause confusion or path resolution errors in various environments. 🛠️🔍