### PR TITLE
Add `python train.py --weights ''` to CI tests

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -69,6 +69,7 @@ jobs:
 
           # Train
           python train.py --img 64 --batch 32 --weights ${{ matrix.model }}.pt --cfg ${{ matrix.model }}.yaml --epochs 1 --device $di
+          python train.py --img 64 --batch 32 --weights '' --cfg ${{ matrix.model }}.yaml --epochs 1 --device $di
           # Val
           python val.py --img 64 --batch 32 --weights ${{ matrix.model }}.pt --device $di
           python val.py --img 64 --batch 32 --weights runs/train/exp/weights/last.pt --device $di

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -69,7 +69,7 @@ jobs:
 
           # Train
           python train.py --img 64 --batch 32 --weights ${{ matrix.model }}.pt --cfg ${{ matrix.model }}.yaml --epochs 1 --device $di
-          python train.py --img 64 --batch 32 --weights '' --cfg ${{ matrix.model }}.yaml --epochs 1 --device $di
+          python train.py --img 64 --batch 32 --weights "" --cfg ${{ matrix.model }}.yaml --epochs 1 --device $di
           # Val
           python val.py --img 64 --batch 32 --weights ${{ matrix.model }}.pt --device $di
           python val.py --img 64 --batch 32 --weights runs/train/exp/weights/last.pt --device $di


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved CI Testing for YOLOv5 Models 🛠️

### 📊 Key Changes
- Added a new line in CI workflow to train models without preloaded weights.

### 🎯 Purpose & Impact
- **Ensure Robustness:** Assures that model training can start from scratch, not just from pre-trained weights. 🌱
- **Test Model Integrity:** Validates that the training process is stable and works with randomly initialized weights. 👍
- **Potential Impact:** Increases user confidence in training YOLOv5 models from the ground up. 🔝