### PR TITLE
Revert `torch.hub.load()` test

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -83,7 +83,8 @@ jobs:
           # Python
           python - <<EOF
           import torch
-          model = torch.hub.load('ultralytics/yolov5', 'custom', path='runs/train/exp/weights/last.pt')
+          # Known issue, urllib.error.HTTPError: HTTP Error 403: rate limit exceeded, will be resolved in torch==1.10.0 
+          # model = torch.hub.load('ultralytics/yolov5', 'custom', path='runs/train/exp/weights/last.pt')
           EOF
 
         shell: bash


### PR DESCRIPTION
Temporarily reverts https://github.com/ultralytics/yolov5/pull/4978 until torch 1.10 is released, which should resolve `urllib.error.HTTPError: HTTP Error 403: rate limit exceeded` errors generated by torch hub from GitHub actions runners that is currently causing CI failures.

See https://github.com/pytorch/vision/issues/4156 for details.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving CI workflow robustness by noting a known HTTP 403 error. 🛠️

### 📊 Key Changes
- Commented out the line in CI testing that loads a model from Ultralytics's GitHub to avoid a known `urllib.error.HTTPError: HTTP Error 403: rate limit exceeded`.
- Added a comment explaining the issue and indicating it will be resolved in the upcoming `torch==1.10.0` release.

### 🎯 Purpose & Impact
- 🔗 The change prevents CI from failing due to GitHub rate limiting, which is important for maintaining a smooth continuous integration process.
- 🛡️ This is a temporary workaround until the issue is resolved in PyTorch's future release, ensuring developers are aware of the limitation and the CI testing does not get obstructed by external HTTP errors.
- 🚀 For users, this means better reliability in the project's development workflow, potentially leading to quicker releases and bug fixes since CI plays a crucial role in the quality control process.