### PR TITLE
Fix missing `opt.device` on `--task study`

### DIFF
--- a/val.py
+++ b/val.py
@@ -335,7 +335,7 @@ def main(opt):
     elif opt.task == 'speed':  # speed benchmarks
         for w in opt.weights if isinstance(opt.weights, list) else [opt.weights]:
             run(opt.data, weights=w, batch_size=opt.batch_size, imgsz=opt.imgsz, conf_thres=.25, iou_thres=.45,
-                save_json=False, plots=False)
+                device=opt.device, save_json=False, plots=False)
 
     elif opt.task == 'study':  # run over a range of settings and save/plot
         # python val.py --task study --data coco.yaml --iou 0.7 --weights yolov5s.pt yolov5m.pt yolov5l.pt yolov5x.pt


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Performance benchmarking now supports specifying device.

### 📊 Key Changes
- Device argument added to the speed benchmarking function in validation script (`val.py`).

### 🎯 Purpose & Impact
- ⚙️ Allows users to define the computing device (CPU, GPU) they want to use while conducting speed benchmarks.
- 🚀 Enables better control over benchmarking tests, potentially improving the utility of the tests for different hardware configurations.
- 🤖 This could help developers and researchers to better understand model performance across various devices.