### PR TITLE
Re-open IP-camera videostream if disconnected

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -332,9 +332,9 @@ class LoadStreams:  # multiple IP or RTSP cameras
                 if success:
                     self.imgs[i] = im
                 else:
-                    print("Video stream doesn't respond. Check your IP camera availability")
-                    self.imgs[i] * 0
-                    cap.open(stream) # re-open stream if signal was lost                   
+                    print('WARNING: Video stream unresponsive, please check your IP camera connection.')
+                    self.imgs[i] *= 0
+                    cap.open(stream)  # re-open stream if signal was lost
             time.sleep(1 / self.fps[i])  # wait time
 
     def __iter__(self):

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -334,10 +334,7 @@ class LoadStreams:  # multiple IP or RTSP cameras
                 else:
                     print("Video stream doesn't respond. Check your IP camera availability")
                     self.imgs[i] * 0
-                    cap.open(stream) # re-open stream if signal was lost
-                    
-
-
+                    cap.open(stream) # re-open stream if signal was lost                   
             time.sleep(1 / self.fps[i])  # wait time
 
     def __iter__(self):


### PR DESCRIPTION
Streaming from IP-cameras via rtsp was freezing when signal lost. I added an option to re-open cv2.Videocapture in case of video-stream disconnection.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced error handling for unresponsive video streams in YOLOv5.

### 📊 Key Changes
- The `update` function in `utils/datasets.py` now takes an additional `stream` parameter.
- Improved error reporting with a warning message if a video stream is unresponsive.
- Added functionality to attempt to re-open the video stream automatically if the connection is lost.

### 🎯 Purpose & Impact
- Helps users to debug issues with IP camera connections by printing a warning when a video feed is lost.
- Increases robustness by trying to reconnect to the video stream, potentially reducing interruptions during stream processing.
- Facilitates continuity in video frame capture for YOLOv5, which is crucial for applications that rely on consistent real-time video analysis. 💪📹🔄