### PR TITLE
Add `autobatch` feature for best `batch-size` estimation

### DIFF
--- a/train.py
+++ b/train.py
@@ -36,6 +36,7 @@ import val  # for end-of-epoch mAP
 from models.experimental import attempt_load
 from models.yolo import Model
 from utils.autoanchor import check_anchors
+from utils.autobatch import check_batch_size
 from utils.datasets import create_dataloader
 from utils.general import labels_to_class_weights, increment_path, labels_to_image_weights, init_seeds, \
     strip_optimizer, get_latest_run, check_dataset, check_git_status, check_img_size, check_requirements, \
@@ -131,6 +132,14 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
             print(f'freezing {k}')
             v.requires_grad = False
 
+    # Image size
+    gs = max(int(model.stride.max()), 32)  # grid size (max stride)
+    imgsz = check_img_size(opt.imgsz, gs, floor=gs * 2)  # verify imgsz is gs-multiple
+
+    # Batch size
+    if cuda and RANK == -1:  # single-GPU only
+        batch_size = check_batch_size(model, batch_size, imgsz)
+
     # Optimizer
     nbs = 64  # nominal batch size
     accumulate = max(round(nbs / batch_size), 1)  # accumulate loss before optimizing
@@ -190,11 +199,6 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
         del ckpt, csd
 
-    # Image sizes
-    gs = max(int(model.stride.max()), 32)  # grid size (max stride)
-    nl = model.model[-1].nl  # number of detection layers (used for scaling hyp['obj'])
-    imgsz = check_img_size(opt.imgsz, gs, floor=gs * 2)  # verify imgsz is gs-multiple
-
     # DP mode
     if cuda and RANK == -1 and torch.cuda.device_count() > 1:
         logging.warning('DP not recommended, instead use torch.distributed.run for best DDP Multi-GPU results.\n'
@@ -242,6 +246,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         model = DDP(model, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK)
 
     # Model parameters
+    nl = model.model[-1].nl  # number of detection layers (to scale hyps)
     hyp['box'] *= 3. / nl  # scale to layers
     hyp['cls'] *= nc / 80. * 3. / nl  # scale to classes and layers
     hyp['obj'] *= (imgsz / 640) ** 2 * 3. / nl  # scale to image size and layers

--- a/train.py
+++ b/train.py
@@ -138,7 +138,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
     # Batch size
     if cuda and RANK == -1:  # single-GPU only
-        batch_size = check_batch_size(model, batch_size, imgsz)
+        batch_size = check_batch_size(model, imgsz, batch_size)
 
     # Optimizer
     nbs = 64  # nominal batch size

--- a/train.py
+++ b/train.py
@@ -138,7 +138,8 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
     # Batch size
     if cuda and RANK == -1:  # single-GPU only
-        batch_size = check_batch_size(model, imgsz, batch_size)
+        with amp.autocast():
+            batch_size = check_batch_size(model, imgsz, batch_size)
 
     # Optimizer
     nbs = 64  # nominal batch size

--- a/train.py
+++ b/train.py
@@ -139,7 +139,8 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     # Batch size
     if cuda and RANK == -1:  # single-GPU only
         with amp.autocast():
-            batch_size = check_batch_size(model, imgsz, batch_size)
+            batch_size = check_batch_size(deepcopy(model).eval(), imgsz, batch_size)
+            batch_size = check_batch_size(deepcopy(model).train(), imgsz, batch_size)
 
     # Optimizer
     nbs = 64  # nominal batch size

--- a/train.py
+++ b/train.py
@@ -138,14 +138,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
     # Batch size
     if cuda and RANK == -1:  # single-GPU only
-
-        model2 = deepcopy(model).eval()
-        for k, v in model2.named_parameters():
-            v.requires_grad = True  # train all layers
-        check_batch_size(model2.eval(), imgsz, batch_size)
-
         with amp.autocast():
-            check_batch_size(model2.eval(), imgsz, batch_size)
             batch_size = check_batch_size(deepcopy(model).train(), imgsz, batch_size)
 
     # Optimizer

--- a/train.py
+++ b/train.py
@@ -138,8 +138,14 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
     # Batch size
     if cuda and RANK == -1:  # single-GPU only
+
+        model2 = deepcopy(model).eval()
+        for k, v in model2.named_parameters():
+            v.requires_grad = True  # train all layers
+        check_batch_size(model2.eval(), imgsz, batch_size)
+
         with amp.autocast():
-            check_batch_size(deepcopy(model).eval(), imgsz, batch_size)
+            check_batch_size(model2.eval(), imgsz, batch_size)
             batch_size = check_batch_size(deepcopy(model).train(), imgsz, batch_size)
 
     # Optimizer

--- a/train.py
+++ b/train.py
@@ -139,7 +139,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     # Batch size
     if cuda and RANK == -1:  # single-GPU only
         with amp.autocast():
-            batch_size = check_batch_size(deepcopy(model).eval(), imgsz, batch_size)
+            check_batch_size(deepcopy(model).eval(), imgsz, batch_size)
             batch_size = check_batch_size(deepcopy(model).train(), imgsz, batch_size)
 
     # Optimizer

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -25,7 +25,7 @@ def autobatch(model, imgsz=640, fraction=0.9):
     # f = 15.8
     print(f'{prefix}{t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
 
-    batch_sizes = [1, 2, 4, 8, 16, 32]
+    batch_sizes = [1, 2, 4, 8, 16, 64]
     model = deepcopy(de_parallel(model)).train()
     try:
         img = [torch.zeros(b, 3, imgsz, imgsz) for b in batch_sizes]
@@ -34,11 +34,12 @@ def autobatch(model, imgsz=640, fraction=0.9):
     except Exception as e:
         print()
 
-    for i in range(2, 7):
+
+    print(y)
+    for i in range(2, len(batch_sizes)):
         p = np.polyfit(batch_sizes[:i], y[:i], deg=1)  # first degree polynomial fit
         f_intercept = int((f * fraction - p[1]) / p[0])  # optimal batch size
         print(f_intercept)
-
 
     return f_intercept
 

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -25,7 +25,7 @@ def autobatch(model, imgsz=640, fraction=0.9):
     # f = 15.8
     print(f'{prefix}{t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
 
-    batch_sizes = [1, 2, 4, 8, 16]
+    batch_sizes = [1, 2, 4, 8, 16, 32, 64]
     model = deepcopy(de_parallel(model)).train()
     try:
         img = [torch.zeros(b, 3, imgsz, imgsz) for b in batch_sizes]

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -34,7 +34,7 @@ def autobatch(model, imgsz=640, fraction=0.9):
     except Exception as e:
         print()
 
-    p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
+    p = np.polyfit(batch_sizes, y, w=batch_sizes, deg=1)  # first degree polynomial fit
     print(batch_sizes, y, p)
     f_intercept = int((f * fraction - p[0]) / p[1])  # optimal batch size
     return f_intercept

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -34,10 +34,12 @@ def autobatch(model, imgsz=640, fraction=0.9):
     except Exception as e:
         print()
 
-    p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
-    print(batch_sizes, y, p)
-    print(np.polyval(p, batch_sizes))
-    f_intercept = int((f * fraction - p[1]) / p[0])  # optimal batch size
+    for i in range(2, 7):
+        p = np.polyfit(batch_sizes[:i], y[:i], deg=1)  # first degree polynomial fit
+        f_intercept = int((f * fraction - p[1]) / p[0])  # optimal batch size
+        print(f_intercept)
+
+
     return f_intercept
 
 # autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -13,14 +13,14 @@ from tqdm import tqdm
 from utils.general import colorstr
 
 
-def autobatch(model, imgsz=640, fraction=0.8):
+def autobatch(model, imgsz=640, fraction=0.8, device=0):
     # Automatically compute optimal batch size to use `fraction` of available CUDA memory
     prefix = colorstr('autobatch: ')
     print(f'\n{prefix} Computing optimal batch size')
 
-    t = torch.cuda.get_device_properties(0).total_memory / 1E9  # (GB)
-    r = torch.cuda.memory_reserved(0) / 1E9  # (GB)
-    a = torch.cuda.memory_allocated(0) / 1E9  # (GB)
+    t = torch.cuda.get_device_properties(device).total_memory / 1024 ** 3  # (GB)
+    r = torch.cuda.memory_reserved(device) / 1024 ** 3  # (GB)
+    a = torch.cuda.memory_allocated(device) / 1024 ** 3  # (GB)
     f = r - a  # free inside reserved
 
     try:

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -36,6 +36,7 @@ def autobatch(model, imgsz=640, fraction=0.9):
 
     p = np.polyfit(batch_sizes, y, w=batch_sizes, deg=1)  # first degree polynomial fit
     print(batch_sizes, y, p)
+    print(np.polyval(p, batch_sizes))
     f_intercept = int((f * fraction - p[0]) / p[1])  # optimal batch size
     return f_intercept
 

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -21,17 +21,16 @@ def autobatch(model, imgsz=640, fraction=0.8, device=0):
     t = torch.cuda.get_device_properties(device).total_memory / 1024 ** 3  # (GB)
     r = torch.cuda.memory_reserved(device) / 1024 ** 3  # (GB)
     a = torch.cuda.memory_allocated(device) / 1024 ** 3  # (GB)
-    f = r - a  # free inside reserved
+    f = t - (r + a)  # free inside reserved
 
+    batch_sizes = [1, 2, 4, 8]
+    x = []
     try:
-        batch_sizes = [1, 2, 4, 8]
         print(f'\n{prefix} {t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
     except Exception as e:
         print()
 
-
-    #x, y = zip(*x)
-    #p = np.polyfit(x, y)
-
+    # x, y = zip(*x)
+    # p = np.polyfit(x, y)
 
     return None

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -32,7 +32,7 @@ def autobatch(model, imgsz=640, fraction=0.9):
         y = profile(img, model, n=3, device=device)
         y = [x[2] for x in y if y]  # memory [2]
     except Exception as e:
-        print((f'{prefix}{e})
+        print(f'{prefix}{e}')
 
     batch_sizes = batch_sizes[:len(y)]
     print(y)

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -12,11 +12,12 @@ from utils.general import colorstr
 from utils.torch_utils import de_parallel, profile
 
 
-def autobatch(model, imgsz=64, fraction=0.8, device='cpu'):
+def autobatch(model, imgsz=64, fraction=0.9):
     # Automatically compute optimal batch size to use `fraction` of available CUDA memory
     prefix = colorstr('autobatch: ')
     print(f'\n{prefix} Computing optimal batch size')
 
+    device = next(model.parameters()).device  # get model device
     t = torch.cuda.get_device_properties(device).total_memory / 1024 ** 3  # (GB)
     r = torch.cuda.memory_reserved(device) / 1024 ** 3  # (GB)
     a = torch.cuda.memory_allocated(device) / 1024 ** 3  # (GB)
@@ -34,7 +35,7 @@ def autobatch(model, imgsz=64, fraction=0.8, device='cpu'):
         print()
 
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
-    f_intercept = int((f - p[0]) / p[1])  # optimal batch size
+    f_intercept = int((f * fraction - p[0]) / p[1])  # optimal batch size
     return f_intercept
 
 

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -30,11 +30,11 @@ def autobatch(model, imgsz=640, fraction=0.9):
     try:
         img = [torch.zeros(b, 3, imgsz, imgsz) for b in batch_sizes]
         y = profile(img, model, n=3, device=device)
-        y = [x[2] for x in y]  # memory [2]
+        y = [x[2] for x in y if y]  # memory [2]
     except Exception as e:
-        print()
+        print((f'{prefix}{e})
 
-
+    batch_sizes = batch_sizes[:len(y)]
     print(y)
     for i in range(2, len(batch_sizes)):
         p = np.polyfit(batch_sizes[:i], y[:i], deg=1)  # first degree polynomial fit

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -16,7 +16,7 @@ def autobatch(model, imgsz=640, fraction=0.95):
     # Automatically compute optimal batch size to use `fraction` of available CUDA memory
     prefix = colorstr('autobatch: ')
     print(f'{prefix}Computing optimal batch size for --imgsz {imgsz}')
-
+    model = deepcopy(de_parallel(model)).train()
     device = next(model.parameters()).device  # get model device
     t = torch.cuda.get_device_properties(device).total_memory / 1024 ** 3  # (GB)
     r = torch.cuda.memory_reserved(device) / 1024 ** 3  # (GB)
@@ -25,7 +25,6 @@ def autobatch(model, imgsz=640, fraction=0.95):
     print(f'{prefix}{t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
 
     batch_sizes = [1, 2, 4, 8, 16]
-    model = deepcopy(de_parallel(model)).train()
     try:
         img = [torch.zeros(b, 3, imgsz, imgsz) for b in batch_sizes]
         y = profile(img, model, n=3, device=device)

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -3,17 +3,16 @@
 Auto-batch utils
 """
 
-import random
+from copy import deepcopy
 
 import numpy as np
 import torch
-import yaml
-from tqdm import tqdm
 
 from utils.general import colorstr
+from utils.torch_utils import de_parallel, profile
 
 
-def autobatch(model, imgsz=640, fraction=0.8, device=0):
+def autobatch(model, imgsz=64, fraction=0.8, device='cpu'):
     # Automatically compute optimal batch size to use `fraction` of available CUDA memory
     prefix = colorstr('autobatch: ')
     print(f'\n{prefix} Computing optimal batch size')
@@ -22,15 +21,23 @@ def autobatch(model, imgsz=640, fraction=0.8, device=0):
     r = torch.cuda.memory_reserved(device) / 1024 ** 3  # (GB)
     a = torch.cuda.memory_allocated(device) / 1024 ** 3  # (GB)
     f = t - (r + a)  # free inside reserved
+    # f = 15.8
+    print(f'\n{prefix} {t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
 
     batch_sizes = [1, 2, 4, 8]
-    x = []
+    model = deepcopy(de_parallel(model)).train()
     try:
-        print(f'\n{prefix} {t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
+        img = [torch.zeros(b, 3, imgsz, imgsz) for b in batch_sizes]
+        y = profile(img, model, n=3, device=device)
+        y = [x[2] for x in y]  # memory [2]
     except Exception as e:
         print()
 
-    # x, y = zip(*x)
-    # p = np.polyfit(x, y)
+    p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
+    f_intercept = int((f - p[0]) / p[1])  # optimal batch size
+    return f_intercept
 
-    return None
+
+model = torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False)
+
+autobatch(model)

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -25,7 +25,7 @@ def autobatch(model, imgsz=640, fraction=0.9):
     # f = 15.8
     print(f'{prefix}{t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
 
-    batch_sizes = [1, 2, 4, 8, 16, 32, 64]
+    batch_sizes = [1, 2, 4, 8, 16, 32]
     model = deepcopy(de_parallel(model)).train()
     try:
         img = [torch.zeros(b, 3, imgsz, imgsz) for b in batch_sizes]

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -12,6 +12,14 @@ from utils.general import colorstr
 from utils.torch_utils import de_parallel, profile
 
 
+def check_batch_size(model, imgsz=640, b=16):
+    # Check YOLOv5 batch size
+    assert isinstance(b, int), f'batch-size {b} must be integer'
+    if b < 1:
+        b = autobatch(model, imgsz)  # compute optimal batch size
+    return b
+
+
 def autobatch(model, imgsz=640, fraction=0.95):
     # Automatically compute optimal batch size to use `fraction` of available CUDA memory
     # Usage:

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -37,7 +37,7 @@ def autobatch(model, imgsz=640, fraction=0.9):
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
     print(batch_sizes, y, p)
     print(np.polyval(p, batch_sizes))
-    f_intercept = int((f * fraction - p[0]) / p[1])  # optimal batch size
+    f_intercept = int((f * fraction - p[1]) / p[0])  # optimal batch size
     return f_intercept
 
 # autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -12,7 +12,7 @@ from utils.general import colorstr
 from utils.torch_utils import de_parallel, profile
 
 
-def autobatch(model, imgsz=640, fraction=0.9):
+def autobatch(model, imgsz=640, fraction=0.95):
     # Automatically compute optimal batch size to use `fraction` of available CUDA memory
     prefix = colorstr('autobatch: ')
     print(f'{prefix}Computing optimal batch size for --imgsz {imgsz}')
@@ -22,10 +22,9 @@ def autobatch(model, imgsz=640, fraction=0.9):
     r = torch.cuda.memory_reserved(device) / 1024 ** 3  # (GB)
     a = torch.cuda.memory_allocated(device) / 1024 ** 3  # (GB)
     f = t - (r + a)  # free inside reserved
-    # f = 15.8
     print(f'{prefix}{t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
 
-    batch_sizes = [1, 2, 4, 8, 16, 64]
+    batch_sizes = [1, 2, 4, 8, 16]
     model = deepcopy(de_parallel(model)).train()
     try:
         img = [torch.zeros(b, 3, imgsz, imgsz) for b in batch_sizes]
@@ -35,11 +34,8 @@ def autobatch(model, imgsz=640, fraction=0.9):
 
     y = [x[2] for x in y if x]  # memory [2]
     batch_sizes = batch_sizes[:len(y)]
-    for i in range(2, len(batch_sizes)):
-        p = np.polyfit(batch_sizes[:i], y[:i], deg=1)  # first degree polynomial fit
-        f_intercept = int((f * fraction - p[1]) / p[0])  # optimal batch size
-        print(f_intercept)
-
+    p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
+    f_intercept = int((f * fraction - p[1]) / p[0])  # optimal batch size
     return f_intercept
 
 # autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -33,9 +33,8 @@ def autobatch(model, imgsz=640, fraction=0.9):
     except Exception as e:
         print(f'{prefix}{e}')
 
-    y = [x[2] for x in y if y]  # memory [2]
+    y = [x[2] for x in y if x]  # memory [2]
     batch_sizes = batch_sizes[:len(y)]
-    print(y)
     for i in range(2, len(batch_sizes)):
         p = np.polyfit(batch_sizes[:i], y[:i], deg=1)  # first degree polynomial fit
         f_intercept = int((f * fraction - p[1]) / p[0])  # optimal batch size

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -34,7 +34,7 @@ def autobatch(model, imgsz=640, fraction=0.9):
     except Exception as e:
         print()
 
-    p = np.polyfit(batch_sizes, y, w=batch_sizes, deg=1)  # first degree polynomial fit
+    p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
     print(batch_sizes, y, p)
     print(np.polyval(p, batch_sizes))
     f_intercept = int((f * fraction - p[0]) / p[1])  # optimal batch size

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -1,0 +1,37 @@
+# YOLOv5 🚀 by Ultralytics, GPL-3.0 license
+"""
+Auto-batch utils
+"""
+
+import random
+
+import numpy as np
+import torch
+import yaml
+from tqdm import tqdm
+
+from utils.general import colorstr
+
+
+def autobatch(model, imgsz=640, fraction=0.8):
+    # Automatically compute optimal batch size to use `fraction` of available CUDA memory
+    prefix = colorstr('autobatch: ')
+    print(f'\n{prefix} Computing optimal batch size')
+
+    t = torch.cuda.get_device_properties(0).total_memory / 1E9  # (GB)
+    r = torch.cuda.memory_reserved(0) / 1E9  # (GB)
+    a = torch.cuda.memory_allocated(0) / 1E9  # (GB)
+    f = r - a  # free inside reserved
+
+    try:
+        batch_sizes = [1, 2, 4, 8]
+        print(f'\n{prefix} {t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
+    except Exception as e:
+        print()
+
+
+    #x, y = zip(*x)
+    #p = np.polyfit(x, y)
+
+
+    return None

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -30,10 +30,10 @@ def autobatch(model, imgsz=640, fraction=0.9):
     try:
         img = [torch.zeros(b, 3, imgsz, imgsz) for b in batch_sizes]
         y = profile(img, model, n=3, device=device)
-        y = [x[2] for x in y if y]  # memory [2]
     except Exception as e:
         print(f'{prefix}{e}')
 
+    y = [x[2] for x in y if y]  # memory [2]
     batch_sizes = batch_sizes[:len(y)]
     print(y)
     for i in range(2, len(batch_sizes)):

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -25,7 +25,7 @@ def autobatch(model, imgsz=640, fraction=0.9):
     # f = 15.8
     print(f'{prefix}{t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
 
-    batch_sizes = [1, 2, 4, 8]
+    batch_sizes = [1, 2, 4, 8, 16]
     model = deepcopy(de_parallel(model)).train()
     try:
         img = [torch.zeros(b, 3, imgsz, imgsz) for b in batch_sizes]

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -14,6 +14,12 @@ from utils.torch_utils import de_parallel, profile
 
 def autobatch(model, imgsz=640, fraction=0.95):
     # Automatically compute optimal batch size to use `fraction` of available CUDA memory
+    # Usage:
+    #     import torch
+    #     from utils.autobatch import autobatch
+    #     model = torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False)
+    #     print(autobatch(model))
+
     prefix = colorstr('autobatch: ')
     print(f'{prefix}Computing optimal batch size for --imgsz {imgsz}')
     model = deepcopy(de_parallel(model)).train()

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -15,7 +15,7 @@ from utils.torch_utils import de_parallel, profile
 def autobatch(model, imgsz=640, fraction=0.9):
     # Automatically compute optimal batch size to use `fraction` of available CUDA memory
     prefix = colorstr('autobatch: ')
-    print(f'\n{prefix} Computing optimal batch size for --imgsz {imgsz}')
+    print(f'{prefix}Computing optimal batch size for --imgsz {imgsz}')
 
     device = next(model.parameters()).device  # get model device
     t = torch.cuda.get_device_properties(device).total_memory / 1024 ** 3  # (GB)
@@ -23,7 +23,7 @@ def autobatch(model, imgsz=640, fraction=0.9):
     a = torch.cuda.memory_allocated(device) / 1024 ** 3  # (GB)
     f = t - (r + a)  # free inside reserved
     # f = 15.8
-    print(f'\n{prefix} {t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
+    print(f'{prefix}{t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
 
     batch_sizes = [1, 2, 4, 8]
     model = deepcopy(de_parallel(model)).train()
@@ -35,6 +35,7 @@ def autobatch(model, imgsz=640, fraction=0.9):
         print()
 
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
+    print(batch_sizes, y, p)
     f_intercept = int((f * fraction - p[0]) / p[1])  # optimal batch size
     return f_intercept
 

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -12,10 +12,10 @@ from utils.general import colorstr
 from utils.torch_utils import de_parallel, profile
 
 
-def autobatch(model, imgsz=64, fraction=0.9):
+def autobatch(model, imgsz=640, fraction=0.9):
     # Automatically compute optimal batch size to use `fraction` of available CUDA memory
     prefix = colorstr('autobatch: ')
-    print(f'\n{prefix} Computing optimal batch size')
+    print(f'\n{prefix} Computing optimal batch size for --imgsz {imgsz}')
 
     device = next(model.parameters()).device  # get model device
     t = torch.cuda.get_device_properties(device).total_memory / 1024 ** 3  # (GB)
@@ -38,7 +38,4 @@ def autobatch(model, imgsz=64, fraction=0.9):
     f_intercept = int((f * fraction - p[0]) / p[1])  # optimal batch size
     return f_intercept
 
-
-model = torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False)
-
-autobatch(model)
+# autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -48,6 +48,7 @@ def autobatch(model, imgsz=640, fraction=0.95):
     batch_sizes = batch_sizes[:len(y)]
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
     f_intercept = int((f * fraction - p[1]) / p[0])  # optimal batch size
+    print(f'{prefix} batch-size {f_intercept} estimated to use f{fraction * 100}%% of CUDA device {device} memory')
     return f_intercept
 
 # autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -48,7 +48,7 @@ def autobatch(model, imgsz=640, fraction=0.95):
     batch_sizes = batch_sizes[:len(y)]
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
     f_intercept = int((t * fraction - p[1]) / p[0])  # optimal batch size
-    print(f'{prefix}batch-size {f_intercept} estimated to utilize {t * fraction:3}G of '
+    print(f'{prefix}batch-size {f_intercept} estimated to utilize {t * fraction:.3g}G of '
           f'{str(device).upper()} {t:.3g}G ({fraction * 100:.0f}%)')
     return f_intercept
 

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -48,8 +48,8 @@ def autobatch(model, imgsz=640, fraction=0.95):
     batch_sizes = batch_sizes[:len(y)]
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
     f_intercept = int((t * fraction - p[1]) / p[0])  # optimal batch size
-    print(f'{prefix}batch-size {f_intercept} estimated to utilize {t * fraction:.3g}G of '
-          f'{str(device).upper()} {t:.3g}G ({fraction * 100:.0f}%)')
+    print(f'{prefix}batch-size {f_intercept} estimated to utilize '
+          f'{str(device).upper()} {t * fraction:.3g}G/{t:.3g}G ({fraction * 100:.0f}%)')
     return f_intercept
 
 # autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -47,8 +47,9 @@ def autobatch(model, imgsz=640, fraction=0.95):
     y = [x[2] for x in y if x]  # memory [2]
     batch_sizes = batch_sizes[:len(y)]
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
-    f_intercept = int((f * fraction - p[1]) / p[0])  # optimal batch size
-    print(f'{prefix}batch-size {f_intercept} estimated to utilize {fraction * 100}% of {str(device).upper()} memory')
+    f_intercept = int((t * fraction - p[1]) / p[0])  # optimal batch size
+    print(f'{prefix}batch-size {f_intercept} estimated to utilize {f_intercept:3}G of '
+          f'{str(device).upper()} {t:.3g}G ({fraction * 100:.0g})')
     return f_intercept
 
 # autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -36,7 +36,7 @@ def autobatch(model, imgsz=640, fraction=0.95):
     f = t - (r + a)  # free inside reserved
     print(f'{prefix}{t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
 
-    batch_sizes = [1, 2, 4, 8, 16, 32, 64]
+    batch_sizes = [1, 2, 4, 8, 16, 32]
     try:
         img = [torch.zeros(b, 3, imgsz, imgsz) for b in batch_sizes]
         y = profile(img, model, n=3, device=device)

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -37,7 +37,7 @@ def autobatch(model, imgsz=640, fraction=0.95):
     f = t - (r + a)  # free inside reserved
     print(f'{prefix}{t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
 
-    batch_sizes = [1, 2, 4, 8, 16]
+    batch_sizes = [1, 2, 4, 8, 16, 32, 64]
     try:
         img = [torch.zeros(b, 3, imgsz, imgsz) for b in batch_sizes]
         y = profile(img, model, n=3, device=device)

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -36,7 +36,7 @@ def autobatch(model, imgsz=640, fraction=0.9):
     f = t - (r + a)  # free inside reserved
     print(f'{prefix}{t:.3g}G total, {r:.3g}G reserved, {a:.3g}G allocated, {f:.3g}G free')
 
-    batch_sizes = [1, 2, 4, 8, 16, 32]
+    batch_sizes = [1, 2, 4, 8, 16]
     try:
         img = [torch.zeros(b, 3, imgsz, imgsz) for b in batch_sizes]
         y = profile(img, model, n=3, device=device)

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -19,7 +19,7 @@ def check_batch_size(model, imgsz=640, b=16):
     return b
 
 
-def autobatch(model, imgsz=640, fraction=0.95):
+def autobatch(model, imgsz=640, fraction=0.9):
     # Automatically compute optimal batch size to use `fraction` of available CUDA memory
     # Usage:
     #     import torch

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -47,7 +47,7 @@ def autobatch(model, imgsz=640, fraction=0.95):
     y = [x[2] for x in y if x]  # memory [2]
     batch_sizes = batch_sizes[:len(y)]
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
-    f_intercept = int((t * fraction - p[1]) / p[0])  # optimal batch size
+    f_intercept = int((f * fraction - p[1]) / p[0])  # optimal batch size
     print(f'{prefix}batch-size {f_intercept} estimated to utilize '
           f'{str(device).upper()} {t * fraction:.3g}G/{t:.3g}G ({fraction * 100:.0f}%)')
     return f_intercept

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -14,8 +14,7 @@ from utils.torch_utils import de_parallel, profile
 
 def check_batch_size(model, imgsz=640, b=16):
     # Check YOLOv5 batch size
-    assert isinstance(b, int), f'batch-size {b} must be integer'
-    if b < 1:
+    if b < 1 or b == 'auto':
         b = autobatch(model, imgsz)  # compute optimal batch size
     return b
 

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -29,7 +29,6 @@ def autobatch(model, imgsz=640, fraction=0.95):
 
     prefix = colorstr('autobatch: ')
     print(f'{prefix}Computing optimal batch size for --imgsz {imgsz}')
-    model = deepcopy(de_parallel(model)).train()
     device = next(model.parameters()).device  # get model device
     t = torch.cuda.get_device_properties(device).total_memory / 1024 ** 3  # (GB)
     r = torch.cuda.memory_reserved(device) / 1024 ** 3  # (GB)

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -48,7 +48,7 @@ def autobatch(model, imgsz=640, fraction=0.95):
     batch_sizes = batch_sizes[:len(y)]
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
     f_intercept = int((f * fraction - p[1]) / p[0])  # optimal batch size
-    print(f'{prefix}batch-size {f_intercept} estimated to utilize {fraction * 100}% of CUDA:{device} memory')
+    print(f'{prefix}batch-size {f_intercept} estimated to utilize {fraction * 100}% of {str(device).upper()} memory')
     return f_intercept
 
 # autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -48,8 +48,8 @@ def autobatch(model, imgsz=640, fraction=0.95):
     batch_sizes = batch_sizes[:len(y)]
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
     f_intercept = int((t * fraction - p[1]) / p[0])  # optimal batch size
-    print(f'{prefix}batch-size {f_intercept} estimated to utilize {f_intercept:3}G of '
-          f'{str(device).upper()} {t:.3g}G ({fraction * 100:.0g})')
+    print(f'{prefix}batch-size {f_intercept} estimated to utilize {t * fraction:3}G of '
+          f'{str(device).upper()} {t:.3g}G ({fraction * 100:.0f}%)')
     return f_intercept
 
 # autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -48,7 +48,7 @@ def autobatch(model, imgsz=640, fraction=0.95):
     batch_sizes = batch_sizes[:len(y)]
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
     f_intercept = int((f * fraction - p[1]) / p[0])  # optimal batch size
-    print(f'{prefix} batch-size {f_intercept} estimated to use f{fraction * 100}%% of CUDA device {device} memory')
+    print(f'{prefix}batch-size {f_intercept} estimated to utilize {fraction * 100}% of CUDA:{device} memory')
     return f_intercept
 
 # autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -52,7 +52,7 @@ def autobatch(model, imgsz=640, fraction=0.9, batch_size=16):
     batch_sizes = batch_sizes[:len(y)]
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
     b = int((f * fraction - p[1]) / p[0])  # y intercept (optimal batch size)
-    print(f'{prefix}Using batch-size {b} for {d} {t * fraction:.3g}G/{t:.3g}G, {fraction * 100:.0f}% utilization')
+    print(f'{prefix}Using batch-size {b} for {d} {t * fraction:.3g}G/{t:.3g}G ({fraction * 100:.0f}%)')
     return b
 
 # autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -52,7 +52,7 @@ def autobatch(model, imgsz=640, fraction=0.9, batch_size=16):
     batch_sizes = batch_sizes[:len(y)]
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
     b = int((f * fraction - p[1]) / p[0])  # y intercept (optimal batch size)
-    print(f'{prefix}batch-size {b} estimated to utilize {d} {t * fraction:.3g}G/{t:.3g}G ({fraction * 100:.0f}%)')
+    print(f'Using {prefix}batch-size {b} for {fraction * 100:.0f}% estimated {d} utilization {t * fraction:.3g}G/{t:.3g}G')
     return b
 
 # autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -52,7 +52,5 @@ def autobatch(model, imgsz=640, fraction=0.9, batch_size=16):
     batch_sizes = batch_sizes[:len(y)]
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
     b = int((f * fraction - p[1]) / p[0])  # y intercept (optimal batch size)
-    print(f'{prefix}Using batch-size {b} for {d} {t * fraction:.3g}G/{t:.3g}G ({fraction * 100:.0f}%)')
+    print(f'{prefix}Using colorstr(batch-size {b}) for {d} {t * fraction:.3g}G/{t:.3g}G ({fraction * 100:.0f}%)')
     return b
-
-# autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -52,7 +52,7 @@ def autobatch(model, imgsz=640, fraction=0.9, batch_size=16):
     batch_sizes = batch_sizes[:len(y)]
     p = np.polyfit(batch_sizes, y, deg=1)  # first degree polynomial fit
     b = int((f * fraction - p[1]) / p[0])  # y intercept (optimal batch size)
-    print(f'Using {prefix}batch-size {b} for {fraction * 100:.0f}% estimated {d} utilization {t * fraction:.3g}G/{t:.3g}G')
+    print(f'{prefix}Using batch-size {b} for {d} {t * fraction:.3g}G/{t:.3g}G, {fraction * 100:.0f}% utilization')
     return b
 
 # autobatch(torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False))

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -126,7 +126,7 @@ def profile(input, ops, n=10, device=None):
                         _ = (sum([yi.sum() for yi in y]) if isinstance(y, list) else y).sum().backward()
                         t[2] = time_sync()
                     except Exception as e:  # no backward method
-                        print(e)
+                        # print(e)  # for debug
                         t[2] = float('nan')
                     tf += (t[1] - t[0]) * 1000 / n  # ms per op forward
                     tb += (t[2] - t[1]) * 1000 / n  # ms per op backward


### PR DESCRIPTION
Adds YOLOv5 autobatch feature to solve for best batch size on CUDA devices by passing `--batch-size -1` to train.py:
```bash
$ python train.py --batch-size -1

YOLOv5 🚀 v6.0-67-g60e42e1 torch 1.9.0+cu111 CUDA:0 (A100-SXM4-40GB, 40536MiB)
...
autobatch: Computing optimal batch size for --imgsz 640
autobatch: CUDA:0 39.6G total, 0.0996G reserved, 0.0813G allocated, 39.4G free
      Params      GFLOPs  GPU_mem (GB)  forward (ms) backward (ms)                   input                  output
     7235389       16.53         0.296            22         19.57        (1, 3, 640, 640)                    list
     7235389       33.06         0.568         21.47         16.62        (2, 3, 640, 640)                    list
     7235389       66.13         1.007         21.79         16.77        (4, 3, 640, 640)                    list
     7235389       132.3         1.797         21.46         18.54        (8, 3, 640, 640)                    list
     7235389       264.5         3.280         22.64         23.45       (16, 3, 640, 640)                    list
autobatch: Using batch-size 179 for CUDA:0 35.6G/39.6G (90%)
```

<img width="1746" alt="Screenshot 2021-11-06 at 12 31 10" src="https://user-images.githubusercontent.com/26833433/140608439-9d38512d-1272-4a53-a83e-c245a83693c2.png">

### Limitations

- Only works for Single-GPU trainings with `train.py`
- Experimental and still under development
- Auto-batch size does not get saved to opt.yaml for use with --resume.py (autobatch will run again on --resume)
- NOT RECOMMENDED FOR PRODUCTION USE

@kalenmike @stefani-kovachevska @AyushExel 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introduced automatic batch size estimation for YOLOv5 training on single GPU setups.

### 📊 Key Changes
- Added a new utility function `check_train_batch_size` to estimate the optimal training batch size.
- Modified `train.py` to enable batch size auto-tuning when a batch size of `-1` is specified for single-GPU training.
- Introduced a new file `utils/autobatch.py` which contains the `autobatch` function to facilitate batch size estimation based on available GPU memory.
- Minor refinement to error handling in `utils/torch_utils.py` by commenting out a debug print statement.

### 🎯 Purpose & Impact
- 🚀 **Enhanced Usability**: The new feature allows users with less technical knowledge to efficiently utilize their GPU for training without manually experimenting with batch sizes.
- 💡 **Optimized Resource Usage**: Helps avoid out-of-memory errors by automating the selection of the largest possible batch size that fits in the GPU memory, ensuring better GPU utilization.
- ✨ **Streamlined Training**: Simplifies the training setup process, potentially making YOLOv5 more accessible to a broader audience.
- 🐞 **Reduced Debug Noise**: Adjusted the error output for smoother debugging and user experience.