### PR TITLE
Fix SKU-110K HUB: `OSError`

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -943,12 +943,22 @@ def dataset_stats(path='coco128.yaml', autodownload=False, verbose=False, profil
             return False, None, path
 
     def hub_ops(f, max_dim=1920):
-        # HUB ops for 1 image 'f'
-        im = Image.open(f)
-        r = max_dim / max(im.height, im.width)  # ratio
-        if r < 1.0:  # image too large
-            im = im.resize((int(im.width * r), int(im.height * r)))
-        im.save(im_dir / Path(f).name, quality=75)  # save
+        # HUB ops for 1 image 'f': resize and save at reduced quality in /dataset-hub for web/app viewing
+        f_new = im_dir / Path(f).name  # dataset-hub image filename
+        try:  # use PIL
+            im = Image.open(f)
+            r = max_dim / max(im.height, im.width)  # ratio
+            if r < 1.0:  # image too large
+                im = im.resize((int(im.width * r), int(im.height * r)))
+            im.save(f_new, quality=75)  # save
+        except Exception as e:  # use OpenCV
+            print(f'WARNING: HUB ops PIL failure {f}: {e}')
+            im = cv2.imread(f)
+            im_height, im_width = im.shape[:2]
+            r = max_dim / max(im_height, im_width)  # ratio
+            if r < 1.0:  # image too large
+                im = cv2.resize(im, (int(im_width * r), int(im_height * r)), interpolation=cv2.INTER_LINEAR)
+            cv2.imwrite(str(f_new), im)
 
     zipped, data_dir, yaml_path = unzip(Path(path))
     with open(check_yaml(yaml_path), errors='ignore') as f:


### PR DESCRIPTION
Fix for #5105, verified working on SKU-110K hub ops.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image resizing and saving mechanism for large images in the YOLOv5 dataset hub.

### 📊 Key Changes
- Added a fallback using OpenCV for image resizing and saving when the PIL library fails.
- Maintained the functionality for resizing large images to a maximum dimension while reducing the quality for optimized web or app display.
- Exception handling introduced for robustness against PIL-related errors, logging a warning message when necessary.

### 🎯 Purpose & Impact
- 🎨 **Enhanced Compatibility**: Provides an alternative library (OpenCV) for image operations, ensuring more consistent behavior across different environments.
- 🔍 **Improved Robustness**: Helps avoid crashes or failures when processing images due to potential PIL limitations or issues.
- 📉 **Reduced Load Times**: Resized images will load faster on websites and apps due to their smaller sizes, improving user experience.
- ⚠️ **Increased Feedback**: Warning messages help in debugging and alert users to any issues encountered during image processing.