### PR TITLE
update `detect.py` in order to support torch script

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -77,7 +77,15 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
     pt, onnx, tflite, pb, saved_model = (suffix == x for x in suffixes)  # backend booleans
     stride, names = 64, [f'class{i}' for i in range(1000)]  # assign defaults
     if pt:
-        model = attempt_load(weights, map_location=device)  # load FP32 model
+        if 'torchscript' in w:
+            # this is torchscript saved not a pickle that can be loaded with th.load
+            # we assume the file exist in the target folder
+            if Path(w).is_file():
+                model = torch.jit.load(w)
+            else:
+                raise ValueError('Cannot find torchscript file {}'.format(Path(w))
+        else:
+            model = attempt_load(weights, map_location=device)  # load FP32 model
         stride = int(model.stride.max())  # model stride
         names = model.module.names if hasattr(model, 'module') else model.names  # get class names
         if half:

--- a/detect.py
+++ b/detect.py
@@ -79,12 +79,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
     pt, onnx, tflite, pb, saved_model = (suffix == x for x in suffixes)  # backend booleans
     stride, names = 64, [f'class{i}' for i in range(1000)]  # assign defaults
     if pt:
-        if 'torchscript' in w:
-            # this is torchscript saved not a pickle that can be loaded with th.load
-            # we assume the file exist in the target folder
-            model = torch.jit.load(w)
-        else:
-            model = attempt_load(weights, map_location=device)  # load FP32 model
+        model = torch.jit.load(w) if 'torchscript' in w else attempt_load(weights, map_location=device)
         stride = int(model.stride.max())  # model stride
         names = model.module.names if hasattr(model, 'module') else model.names  # get class names
         if half:

--- a/detect.py
+++ b/detect.py
@@ -80,10 +80,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
         if 'torchscript' in w:
             # this is torchscript saved not a pickle that can be loaded with th.load
             # we assume the file exist in the target folder
-            if Path(w).is_file():
-                model = torch.jit.load(w)
-            else:
-                raise ValueError('Cannot find torchscript file {}'.format(Path(w))
+            model = torch.jit.load(w)
         else:
             model = attempt_load(weights, map_location=device)  # load FP32 model
         stride = int(model.stride.max())  # model stride


### PR DESCRIPTION
This change assumes the torchscrip file was previously saved with `export.py`.
Based on the issue #5070 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added TorchScript compatibility to model loading in `detect.py`.

### 📊 Key Changes
- `detect.py` now includes a conditional to check for 'torchscript' in the model file name.
- If 'torchscript' is found, the script uses `torch.jit.load()` to load the model; otherwise, it uses the existing `attempt_load()` method.

### 🎯 Purpose & Impact
- **Purpose**: This change enables the use of TorchScript models, which can offer better performance and easier deployments to different platforms.
- **Impact**: Users can now run inference with YOLOv5 using TorchScript format models, potentially increasing the use cases and environments where YOLOv5 can be applied. 🚀