### PR TITLE
Fix different devices bug when moving model from GPU to CPU

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -290,6 +290,7 @@ class AutoShape(nn.Module):
         return self
 
     def _apply(self, fn):
+        # Apply to(), cpu(), cuda(), half() to model tensors that are not parameters or registered buffers
         self = super()._apply(fn)
         m = self.model.model[-1]  # Detect()
         m.stride = fn(m.stride)

--- a/models/common.py
+++ b/models/common.py
@@ -289,6 +289,13 @@ class AutoShape(nn.Module):
         LOGGER.info('AutoShape already enabled, skipping... ')  # model already converted to model.autoshape()
         return self
 
+    def to(self, *args, **kwargs):
+        self = super().to(*args, **kwargs)
+        m = self.model.model[-1]  # Detect()
+        m.stride = m.stride.to(*args, **kwargs)
+        m.grid = [grid.to(*args, **kwargs) for grid in m.grid]
+        return self
+
     @torch.no_grad()
     def forward(self, imgs, size=640, augment=False, profile=False):
         # Inference from various sources. For height=640, width=1280, RGB images example inputs are:

--- a/models/common.py
+++ b/models/common.py
@@ -289,11 +289,11 @@ class AutoShape(nn.Module):
         LOGGER.info('AutoShape already enabled, skipping... ')  # model already converted to model.autoshape()
         return self
 
-    def to(self, *args, **kwargs):
-        self = super().to(*args, **kwargs)
+    def _apply(self, fn):
+        self = super()._apply(fn)
         m = self.model.model[-1]  # Detect()
-        m.stride = m.stride.to(*args, **kwargs)
-        m.grid = [grid.to(*args, **kwargs) for grid in m.grid]
+        m.stride = fn(m.stride)
+        m.grid = list(map(fn, m.grid))
         return self
 
     @torch.no_grad()

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -233,6 +233,7 @@ class Model(nn.Module):
         model_info(self, verbose, img_size)
 
     def _apply(self, fn):
+        # Apply to(), cpu(), cuda(), half() to model tensors that are not parameters or registered buffers
         self = super()._apply(fn)
         m = self.model[-1]  # Detect()
         if isinstance(m, Detect):

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -232,6 +232,13 @@ class Model(nn.Module):
     def info(self, verbose=False, img_size=640):  # print model information
         model_info(self, verbose, img_size)
 
+    def to(self, *args, **kwargs):
+        self = super().to(*args, **kwargs)
+        m = self.model[-1]  # Detect()
+        m.stride = m.stride.to(*args, **kwargs)
+        m.grid = [grid.to(*args, **kwargs) for grid in m.grid]
+        return self
+
 
 def parse_model(d, ch):  # model_dict, input_channels(3)
     LOGGER.info('\n%3s%18s%3s%10s  %-40s%-30s' % ('', 'from', 'n', 'params', 'module', 'arguments'))

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -235,6 +235,7 @@ class Model(nn.Module):
     def _apply(self, fn):
         self = super()._apply(fn)
         m = self.model[-1]  # Detect()
+        if isinstance(m, Detect):
         m.stride = fn(m.stride)
         m.grid = list(map(fn, m.grid))
         return self

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -232,11 +232,11 @@ class Model(nn.Module):
     def info(self, verbose=False, img_size=640):  # print model information
         model_info(self, verbose, img_size)
 
-    def to(self, *args, **kwargs):
-        self = super().to(*args, **kwargs)
+    def _apply(self, fn):
+        self = super()._apply(fn)
         m = self.model[-1]  # Detect()
-        m.stride = m.stride.to(*args, **kwargs)
-        m.grid = [grid.to(*args, **kwargs) for grid in m.grid]
+        m.stride = fn(m.stride)
+        m.grid = list(map(fn, m.grid))
         return self
 
 

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -236,8 +236,8 @@ class Model(nn.Module):
         self = super()._apply(fn)
         m = self.model[-1]  # Detect()
         if isinstance(m, Detect):
-        m.stride = fn(m.stride)
-        m.grid = list(map(fn, m.grid))
+            m.stride = fn(m.stride)
+            m.grid = list(map(fn, m.grid))
         return self
 
 


### PR DESCRIPTION
Discovered by @glenn-jocher https://github.com/ultralytics/yolov5/pull/4833#issuecomment-935201586

Simple reproducer:
```python
import torch

img = 'https://ultralytics.com/images/zidane.jpg'
model = torch.hub.load('ultralytics/yolov5', 'yolov5s', device='cuda:0')
results = model(img)
results.print()

model.to('cpu')
results = model(img)
results.print()
```
```python
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and CPU!
```
---
Problem :
* In Detect() module, `stride` and `grid` are not moved to the correct device. Only tensors that are registered using `register_buffer` move to the correct device. 

Possible solutions :
* Declare `stride` and `grid` as a nn.Parameter() and nn.ParameterList() respectively. 
* Save `stride` and `grid` using register_buffer(). But `grid` is a list of tensors and register_buffer() only accepts tensors as inputs, so not an ideal solution.
* Override the `to()` function of `Model` and `AutoShape` class to manually move `stride` and `grid`. This seems to be an easy and straightforward solution.

Similar discussion - https://discuss.pytorch.org/t/why-model-to-device-wouldnt-put-tensors-on-a-custom-layer-to-the-same-device/17964

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced YOLOv5 model flexibility with improved tensor operation support.

### 📊 Key Changes
- Added `_apply` method in `models/common.py` and `models/yolo.py`.
- The method accommodates model tensor operations such as `.to()`, `.cpu()`, `.cuda()`, and `.half()`.
- Adjustments made specifically to the last layer `Detect()` within the model to correctly handle `stride` and `grid`.

### 🎯 Purpose & Impact
- These changes ensure that when you move the model between devices and data types (e.g., CPU to GPU, or full precision to half precision), it carries over seamlessly.
- This functionality is crucial for deployment flexibility, allowing users to easily optimize models for different hardware environments 🔄.
- End-users might experience more stable performance and a smoother experience when switching their models across different computational setups 🖥️⚡.
- Developers gain a simplified codebase for managing device and data type transitions, making future maintenance and upgrades smoother 💻🔧.