### PR TITLE
Pass `LOCAL_RANK` to `torch_distributed_zero_first()`

### DIFF
--- a/train.py
+++ b/train.py
@@ -99,7 +99,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     plots = not evolve  # create plots
     cuda = device.type != 'cpu'
     init_seeds(1 + RANK)
-    with torch_distributed_zero_first(RANK):
+    with torch_distributed_zero_first(LOCAL_RANK):
         data_dict = data_dict or check_dataset(data)  # check if None
     train_path, val_path = data_dict['train'], data_dict['val']
     nc = 1 if single_cls else int(data_dict['nc'])  # number of classes
@@ -111,7 +111,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     check_suffix(weights, '.pt')  # check weights
     pretrained = weights.endswith('.pt')
     if pretrained:
-        with torch_distributed_zero_first(RANK):
+        with torch_distributed_zero_first(LOCAL_RANK):
             weights = attempt_download(weights)  # download if not found locally
         ckpt = torch.load(weights, map_location=device)  # load checkpoint
         model = Model(cfg or ckpt['model'].yaml, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
@@ -208,7 +208,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
     # Trainloader
     train_loader, dataset = create_dataloader(train_path, imgsz, batch_size // WORLD_SIZE, gs, single_cls,
-                                              hyp=hyp, augment=True, cache=opt.cache, rect=opt.rect, rank=RANK,
+                                              hyp=hyp, augment=True, cache=opt.cache, rect=opt.rect, rank=LOCAL_RANK,
                                               workers=workers, image_weights=opt.image_weights, quad=opt.quad,
                                               prefix=colorstr('train: '))
     mlc = int(np.concatenate(dataset.labels, 0)[:, 0].max())  # max label class


### PR DESCRIPTION
resolve #5111 

The change proposed in this pull request:

- passing `local_rank` to `torch_distributed_zero_first`, to avoid CUDA device index error

Details of the issue are listed in the issue description and follow-up comment. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of multi-GPU training support in YOLOv5.

### 📊 Key Changes
- Replaced `RANK` with `LOCAL_RANK` to better support distributed training on multiple GPUs.

### 🎯 Purpose & Impact
- 🤝 **Improved Compatibility:** These changes enhance the compatibility with distributed training frameworks, allowing for more efficient utilization of multiple GPUs.
- ⚡ **Increased Efficiency:** Better support for local GPU rank handling potentially leads to improved parallel processing performance and reduced training times.
- 👨‍💻 **Developer Experience:** For developers using YOLOv5 for training on multiple GPUs, this update simplifies processes and could help avoid common issues related to device ranking in distributed environments.