### PR TITLE
Update val.py `pad = 0.0 if task == 'speed' else 0.5`

### DIFF
--- a/val.py
+++ b/val.py
@@ -147,10 +147,10 @@ def run(data,
     if not training:
         if device.type != 'cpu':
             model(torch.zeros(1, 3, imgsz, imgsz).to(device).type_as(next(model.parameters())))  # run once
+        pad = 0.0 if task == 'speed' else 0.5
         task = task if task in ('train', 'val', 'test') else 'val'  # path to train/val/test images
-        dataloader = create_dataloader(data[task], imgsz, batch_size, gs, single_cls, pad=0.5, rect=True,
+        dataloader = create_dataloader(data[task], imgsz, batch_size, gs, single_cls, pad=pad, rect=True,
                                        prefix=colorstr(f'{task}: '))[0]
-
     seen = 0
     confusion_matrix = ConfusionMatrix(nc=nc)
     names = {k: v for k, v in enumerate(model.names if hasattr(model, 'names') else model.module.names)}

--- a/val.py
+++ b/val.py
@@ -151,6 +151,7 @@ def run(data,
         task = task if task in ('train', 'val', 'test') else 'val'  # path to train/val/test images
         dataloader = create_dataloader(data[task], imgsz, batch_size, gs, single_cls, pad=pad, rect=True,
                                        prefix=colorstr(f'{task}: '))[0]
+
     seen = 0
     confusion_matrix = ConfusionMatrix(nc=nc)
     names = {k: v for k, v in enumerate(model.names if hasattr(model, 'names') else model.module.names)}


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved dataloader padding configuration for speed tests in the YOLOv5 validation script.

### 📊 Key Changes
- Added a conditional statement to set padding to 0.0 specifically when the task is 'speed'.
- Ensured padding remains 0.5 for other tasks ('train', 'val', 'test') in the dataloader creation.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: The change is designed to optimize the dataloader configuration for speed testing by reducing unnecessary padding that can affect performance measurements.
- 💡 **Impact**: This update will lead to more accurate speed benchmarks for users testing their YOLOv5 models, as it minimizes the computational load by eliminating excess padding during the speed test task. 

Model developers and users performing speed tests can expect more streamlined and precise performance metrics, aiding in the fine-tuning and evaluation of models.