### PR TITLE
Fix `ROOT` as relative path

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -7,7 +7,7 @@ Usage:
 """
 
 import argparse
-import os.path
+import os
 import sys
 from pathlib import Path
 

--- a/detect.py
+++ b/detect.py
@@ -7,6 +7,7 @@ Usage:
 """
 
 import argparse
+import os.path
 import sys
 from pathlib import Path
 
@@ -19,7 +20,7 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
-ROOT = ROOT.relative_to(Path.cwd())  # relative
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.experimental import attempt_load
 from utils.datasets import LoadImages, LoadStreams

--- a/export.py
+++ b/export.py
@@ -21,6 +21,7 @@ TensorFlow.js:
 """
 
 import argparse
+import os.path
 import subprocess
 import sys
 import time
@@ -34,7 +35,7 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
-ROOT = ROOT.relative_to(Path.cwd())  # relative
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.common import Conv
 from models.experimental import attempt_load

--- a/export.py
+++ b/export.py
@@ -21,7 +21,7 @@ TensorFlow.js:
 """
 
 import argparse
-import os.path
+import os
 import subprocess
 import sys
 import time

--- a/train.py
+++ b/train.py
@@ -10,7 +10,6 @@ import argparse
 import logging
 import math
 import os
-import os.path
 import random
 import sys
 import time

--- a/train.py
+++ b/train.py
@@ -10,6 +10,7 @@ import argparse
 import logging
 import math
 import os
+import os.path
 import random
 import sys
 import time
@@ -30,7 +31,7 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
-ROOT = ROOT.relative_to(Path.cwd())  # relative
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 import val  # for end-of-epoch mAP
 from models.experimental import attempt_load

--- a/val.py
+++ b/val.py
@@ -9,6 +9,7 @@ Usage:
 import argparse
 import json
 import os
+import os.path
 import sys
 from pathlib import Path
 from threading import Thread
@@ -21,7 +22,7 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
-ROOT = ROOT.relative_to(Path.cwd())  # relative
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.experimental import attempt_load
 from utils.datasets import create_dataloader

--- a/val.py
+++ b/val.py
@@ -9,7 +9,6 @@ Usage:
 import argparse
 import json
 import os
-import os.path
 import sys
 from pathlib import Path
 from threading import Thread


### PR DESCRIPTION
Make it possible again to run yolo code from outside the yolo root directory.

Closes #5065 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in path handling across YOLOv5 scripts.

### 📊 Key Changes
- Added the `os` module import for enhanced path operations.
- Modified the way the `ROOT` directory is determined to be relative to the current working directory by using `os.path.relpath` instead of the previously used `Path.relative_to`.

### 🎯 Purpose & Impact
- **Consistency:** This change ensures a consistent and robust way of identifying relative paths across different environments and operating systems. 🧭
- **Portability:** By using `os.path.relpath`, there is an increased likelihood of cross-platform compatibility, preventing potential path-related issues when running on different systems. 💻🌍
- **Code Reliability:** These changes aim to minimize the risks of path errors that users might face when setting up YOLOv5, leading to a smoother user experience. 👌

This update is mainly behind-the-scenes and should be seamless to users, but it will contribute to making the software more stable and dependable.