### PR TITLE
Add `--save-frame` to `detect.py`

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -43,6 +43,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
         save_txt=False,  # save results to *.txt
         save_conf=False,  # save confidences in --save-txt labels
         save_crop=False,  # save cropped prediction boxes
+        save_frame=None, # save frame images per frequency
         nosave=False,  # do not save images/videos
         classes=None,  # filter by class: --class 0, or --class 0 2 3
         agnostic_nms=False,  # class-agnostic NMS
@@ -253,6 +254,8 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
                             save_path += '.mp4'
                         vid_writer[i] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
                     vid_writer[i].write(im0)
+                    if save_frame and frame % save_frame == 0:
+                        cv2.imwrite(str(save_dir / 'frames' / p.stem) + f'_{frame}.jpg', im0)
 
     # Print results
     t = tuple(x / seen * 1E3 for x in dt)  # speeds per image
@@ -277,6 +280,7 @@ def parse_opt():
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
     parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
     parser.add_argument('--save-crop', action='store_true', help='save cropped prediction boxes')
+    parser.add_argument('--save-frame', type=int, help='save frame images per frequency: --save-frame 30')
     parser.add_argument('--nosave', action='store_true', help='do not save images/videos')
     parser.add_argument('--classes', nargs='+', type=int, help='filter by class: --classes 0, or --classes 0 2 3')
     parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS')


### PR DESCRIPTION
Since the real-time video result from `--view-img` is too fast to check closely, sometimes it is very useful to save and check the inferred images of sparse frames.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing an option to periodically save frame images during video processing.

### 📊 Key Changes
- Added a new `--save-frame` argument to specify how often to save frames.
- Implemented saving of frame images at a specified frequency within the video processing loop.

### 🎯 Purpose & Impact
- **Purpose:** This feature allows users to save individual frames from processed videos at regular intervals, which can be useful for creating datasets or analyzing specific frames later.
- **Impact:** Users have more control over their video processing output, which can aid in better debugging and analysis of object detection performance. This could also save time and storage space as users can selectively store frames that are most relevant to their needs.
🖼️ Provides visual checkpoints during lengthy video analysis.