### PR TITLE
W&B: fix dpp with wandb disabled

### DIFF
--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -5,6 +5,8 @@ Logging utils
 
 import warnings
 from threading import Thread
+import pkg_resources as pkg
+import os
 
 import torch
 from torch.utils.tensorboard import SummaryWriter
@@ -15,14 +17,18 @@ from utils.plots import plot_images, plot_results
 from utils.torch_utils import de_parallel
 
 LOGGERS = ('csv', 'tb', 'wandb')  # text-file, TensorBoard, Weights & Biases
+RANK = int(os.getenv('RANK', -1))
 
 try:
     import wandb
 
     assert hasattr(wandb, '__version__')  # verify package import not local dir
+    if pkg.parse_version(wandb.__version__) >= pkg.parse_version('0.12.2') and RANK in [0, -1]:
+        wandb_login_success = wandb.login(timeout=30)
+        if not wandb_login_success:
+            wandb = None
 except (ImportError, AssertionError):
     wandb = None
-
 
 class Loggers():
     # YOLOv5 Loggers class

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -3,11 +3,11 @@
 Logging utils
 """
 
+import os
 import warnings
 from threading import Thread
-import pkg_resources as pkg
-import os
 
+import pkg_resources as pkg
 import torch
 from torch.utils.tensorboard import SummaryWriter
 
@@ -29,6 +29,7 @@ try:
             wandb = None
 except (ImportError, AssertionError):
     wandb = None
+
 
 class Loggers():
     # YOLOv5 Loggers class

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -20,16 +20,6 @@ from utils.datasets import img2label_paths
 from utils.general import check_dataset, check_file
 
 RANK = int(os.getenv('RANK', -1))
-
-try:
-    import wandb
-
-    assert hasattr(wandb, '__version__')  # verify package import not local dir
-    if pkg.parse_version(wandb.__version__) >= pkg.parse_version('0.12.2') and RANK in [0, -1]:
-        wandb.login(timeout=30)
-except (ImportError, AssertionError):
-    wandb = None
-
 WANDB_ARTIFACT_PREFIX = 'wandb-artifact://'
 
 


### PR DESCRIPTION
Addresses https://github.com/ultralytics/yolov5/issues/5160

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Weights & Biases (wandb) logging integration in YOLOv5.

### 📊 Key Changes
- 📦 Added `pkg_resources` (as `pkg`) for version checking.
- 🚀 Modified wandb login process with version check and a login attempt within a conditional block.
- 💡 Moved wandb version check and login from `wandb_utils.py` to `__init__.py` within loggers.
- 🌐 Ensured wandb login only occurs on the main process (when `RANK` is 0 or -1).

### 🎯 Purpose & Impact
- 📈 Ensures better package version management for wandb, avoiding potential incompatibilities.
- 🔒 Improves overall stability with a more controlled wandb login flow.
- 🛠 Users will experience more reliable wandb integrations, especially in distributed training scenarios.
- ⏱ Adds a timeout to wandb login for better failure handling.