### PR TITLE
Add class filtering to `LoadImagesAndLabels()` dataloader

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -437,16 +437,26 @@ class LoadImagesAndLabels(Dataset):
         self.shapes = np.array(shapes, dtype=np.float64)
         self.img_files = list(cache.keys())  # update
         self.label_files = img2label_paths(cache.keys())  # update
-        if single_cls:
-            for x in self.labels:
-                x[:, 0] = 0
-
         n = len(shapes)  # number of images
         bi = np.floor(np.arange(n) / batch_size).astype(np.int)  # batch index
         nb = bi[-1] + 1  # number of batches
         self.batch = bi  # batch index of image
         self.n = n
         self.indices = range(n)
+
+        # Update labels
+        include_class = []  # filter labels to include only these classes (optional)
+        include_class_array = np.array(include_class).reshape(1, -1)
+        for i, (label, segment) in enumerate(zip(self.labels, self.segments)):
+            if include_class:
+                j = (label[:, 0:1] == include_class_array).any(1)
+                self.labels[i] = label[j]
+                if segment:
+                    self.segments[i] = segment[j]
+            if single_cls:  # single-class training, merge all classes into 0
+                self.labels[i][:, 0] = 0
+                if segment:
+                    self.labels[i][:, 0] = 0
 
         # Rectangular Training
         if self.rect:

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -456,7 +456,7 @@ class LoadImagesAndLabels(Dataset):
             if single_cls:  # single-class training, merge all classes into 0
                 self.labels[i][:, 0] = 0
                 if segment:
-                    self.labels[i][:, 0] = 0
+                    self.segments[i][:, 0] = 0
 
         # Rectangular Training
         if self.rect:


### PR DESCRIPTION
Allows for training on a subset of total classes if `include_class` list is defined on datasets.py L448:
```python
        include_class = []  # filter labels to include only these classes (optional)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced filtering and label modification in YOLOv5 dataset initialization 🔄

### 📊 Key Changes
- Removed outdated single-class label modification logic.
- Added new logic to:
  - Optionally filter labels to include only specified classes.
  - Combine all classes into a single class if `single_cls` training is enabled.

### 🎯 Purpose & Impact
- **Purpose:**
  - Streamline the process of handling datasets where only a subset of classes need to be used.
  - Provide cleaner support for training models on datasets with a single class.
- **Impact:**
  - Gives users greater flexibility when training models with specific class requirements, potentially improving model accuracy.
  - Makes it simpler for users to perform single-class training, enhancing the ease of use and effectiveness of the YOLOv5 framework. 💪🎯