### PR TITLE
Adjust legend labels for classes without instances

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -71,8 +71,8 @@ def ap_per_class(tp, conf, pred_cls, target_cls, plot=False, save_dir='.', names
 
     # Compute F1 (harmonic mean of precision and recall)
     f1 = 2 * p * r / (p + r + 1e-16)
-    names = [v for k, v in names.items() if k in unique_classes]  # List: only series that have data
-    names = {i: v for i, v in enumerate(names)}  # back to dict; re-indexed to start at 0
+    names = [v for k, v in names.items() if k in unique_classes]  # List: only classes that have data
+    names = {i: v for i, v in enumerate(names)}  # to dict
     if plot:
         plot_pr_curve(px, py, ap, Path(save_dir) / 'PR_curve.png', names)
         plot_mc_curve(px, f1, Path(save_dir) / 'F1_curve.png', names, ylabel='F1')

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -71,9 +71,8 @@ def ap_per_class(tp, conf, pred_cls, target_cls, plot=False, save_dir='.', names
 
     # Compute F1 (harmonic mean of precision and recall)
     f1 = 2 * p * r / (p + r + 1e-16)
-    # Adjust legend labels for gaps
-    names = {k: v for k, v in names.items() if k in unique_classes}
-    names = {i: v for i, v in enumerate(names.values())}
+    names = [v for k, v in names.items() if k in unique_classes]  # List: only series that have data
+    names = {i: v for i, v in enumerate(names)}  # back to dict; re-indexed to start at 0
     if plot:
         plot_pr_curve(px, py, ap, Path(save_dir) / 'PR_curve.png', names)
         plot_mc_curve(px, f1, Path(save_dir) / 'F1_curve.png', names, ylabel='F1')

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -71,6 +71,9 @@ def ap_per_class(tp, conf, pred_cls, target_cls, plot=False, save_dir='.', names
 
     # Compute F1 (harmonic mean of precision and recall)
     f1 = 2 * p * r / (p + r + 1e-16)
+    # Adjust legend labels for gaps
+    names = {k: v for k, v in names.items() if k in unique_classes}
+    names = {i: v for i, v in enumerate(names.values())}
     if plot:
         plot_pr_curve(px, py, ap, Path(save_dir) / 'PR_curve.png', names)
         plot_mc_curve(px, f1, Path(save_dir) / 'F1_curve.png', names, ylabel='F1')

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -71,7 +71,7 @@ def ap_per_class(tp, conf, pred_cls, target_cls, plot=False, save_dir='.', names
 
     # Compute F1 (harmonic mean of precision and recall)
     f1 = 2 * p * r / (p + r + 1e-16)
-    names = [v for k, v in names.items() if k in unique_classes]  # List: only classes that have data
+    names = [v for k, v in names.items() if k in unique_classes]  # list: only classes that have data
     names = {i: v for i, v in enumerate(names)}  # to dict
     if plot:
         plot_pr_curve(px, py, ap, Path(save_dir) / 'PR_curve.png', names)


### PR DESCRIPTION
See issue #5158

## Before

PR Curve legend has labels for "D00" and "D10" but should have labels for "D40" and "EB".
D00 and D10 have no bounding box instances, and no predictions.
'stats' omits classes that have len = 0; therefore 'names' should also omit empty classes.

![labels](https://user-images.githubusercontent.com/14794739/137230513-5de2d556-655f-4828-a3a1-6aff649d6774.jpg)
![PR_curve](https://user-images.githubusercontent.com/14794739/137230521-328966d3-b577-49a2-a950-5c41badb9fdc.png)
:

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved class naming handling in precision-recall and F1 score calculations and plots.

### 📊 Key Changes
- Added filtering to only include class names that correspond to classes with data when generating metrics.
- Converted the filtered class names list to a dictionary with an enumerated index for consistent referencing.

### 🎯 Purpose & Impact
- Ensures that metric plots only display relevant classes, reducing clutter and potential confusion.
- Impacts users by providing clearer and more accurate visualization of model performance metrics, aiding in better model evaluation and interpretation. 📈🔍