### PR TITLE
Update autodownload fallbacks to v6.0 assets

### DIFF
--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -60,12 +60,12 @@ def attempt_download(file, repo='ultralytics/yolov5'):  # from utils.downloads i
             assets = [x['name'] for x in response['assets']]  # release assets, i.e. ['yolov5s.pt', 'yolov5m.pt', ...]
             tag = response['tag_name']  # i.e. 'v1.0'
         except:  # fallback plan
-            assets = ['yolov5s.pt', 'yolov5m.pt', 'yolov5l.pt', 'yolov5x.pt',
-                      'yolov5s6.pt', 'yolov5m6.pt', 'yolov5l6.pt', 'yolov5x6.pt']
+            assets = ['yolov5n.pt', 'yolov5s.pt', 'yolov5m.pt', 'yolov5l.pt', 'yolov5x.pt',
+                      'yolov5n6.pt', 'yolov5s6.pt', 'yolov5m6.pt', 'yolov5l6.pt', 'yolov5x6.pt']
             try:
                 tag = subprocess.check_output('git tag', shell=True, stderr=subprocess.STDOUT).decode().split()[-1]
             except:
-                tag = 'v5.0'  # current release
+                tag = 'v6.0'  # current release
 
         if name in assets:
             safe_download(file,


### PR DESCRIPTION
Minor bug fix, this should have been a part of release v6.0 PR.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update fallback download assets and release tag in `downloads.py`.

### 📊 Key Changes
- Added 'yolov5n.pt' and 'yolov5n6.pt' to the list of fallback assets.
- Updated the fallback release tag from 'v5.0' to 'v6.0'.

### 🎯 Purpose & Impact
- Ensures the availability of the newest model weights (`yolov5n` and `yolov5n6`) in case the primary method of fetching release assets fails. 🆕
- Reflects the latest release version in the fallback plan, which aids in maintaining the relevance and up-to-dateness of the download script. 🔄
- Users reliant on the fallback will have access to the latest models, enhancing their experience with more recent and potentially improved pre-trained weights. 💪