### PR TITLE
Update Objects365.yaml to include the official validation set

### DIFF
--- a/data/Objects365.yaml
+++ b/data/Objects365.yaml
@@ -62,37 +62,35 @@ names: ['Person', 'Sneakers', 'Chair', 'Other Shoes', 'Hat', 'Car', 'Lamp', 'Gla
 download: |
   from pycocotools.coco import COCO
   from tqdm import tqdm
-
+  
   from utils.general import download, Path
-
+  
   # Make Directories
   dir = Path(yaml['path'])  # dataset root dir
   for p in 'images', 'labels':
       (dir / p).mkdir(parents=True, exist_ok=True)
       for q in 'train', 'val':
           (dir / p / q).mkdir(parents=True, exist_ok=True)
-
+  
+  # Train, Val Splits
   for split, patches in [('train', 50 + 1), ('val', 43 + 1)]:
       print(f"Processing {split} in {patches} patches ...")
       images, labels = dir / 'images' / split, dir / 'labels' / split
-
+  
       # Download
       url = f"https://dorc.ks3-cn-beijing.ksyun.com/data-set/2020Objects365%E6%95%B0%E6%8D%AE%E9%9B%86/{split}/"
       if split == 'train':
-          download([url + f'zhiyuan_objv2_{split}.tar.gz'], dir=dir, delete=False)  # annotations json
-          download([url + f for f in [f'patch{i}.tar.gz' for i in range(patches)]],
-                   dir=images, curl=True, delete=False, threads=8)
+          download([f'{url}zhiyuan_objv2_{split}.tar.gz'], dir=dir, delete=False)  # annotations json
+          download([f'{url}patch{i}.tar.gz' for i in range(patches)], dir=images, curl=True, delete=False, threads=8)
       elif split == 'val':
-          download([url + f'zhiyuan_objv2_{split}.json'], dir=dir, delete=False)  # annotations json
-          download([url + 'images/v1/' + f for f in [f'patch{i}.tar.gz' for i in range(15 + 1)]],
-                   dir=images, curl=True, delete=False, threads=8)
-          download([url + 'images/v2/' + f for f in [f'patch{i}.tar.gz' for i in range(16, patches)]],
-                   dir=images, curl=True, delete=False, threads=8)
-
+          download([f'{url}zhiyuan_objv2_{split}.json'], dir=dir, delete=False)  # annotations json
+          download([f'{url}images/v1/patch{i}.tar.gz' for i in range(15 + 1)], dir=images, curl=True, delete=False, threads=8)
+          download([f'{url}images/v2/patch{i}.tar.gz' for i in range(16, patches)], dir=images, curl=True, delete=False, threads=8)
+  
       # Move
       for f in tqdm(images.rglob('*.jpg'), desc=f'Moving {split} images'):
           f.rename(images / f.name)  # move to /images/{split}
-
+  
       # Labels
       coco = COCO(dir / f'zhiyuan_objv2_{split}.json')
       names = [x["name"] for x in coco.loadCats(coco.getCatIds())]
@@ -109,6 +107,5 @@ download: |
                           x, y, w, h = a['bbox']  # bounding box in xywh (xy top-left corner)
                           x, y = x + w / 2, y + h / 2  # xy to center
                           file.write(f"{cid} {x / width:.5f} {y / height:.5f} {w / width:.5f} {h / height:.5f}\n")
-
               except Exception as e:
                   print(e)

--- a/data/Objects365.yaml
+++ b/data/Objects365.yaml
@@ -72,43 +72,43 @@ download: |
       for q in 'train', 'val':
           (dir / p / q).mkdir(parents=True, exist_ok=True)
 
-  for split, patches in [('train', 50+1), ('val', 43+1)]:
-    print(f"Processing {split} in {patches} patches ...")
+  for split, patches in [('train', 50 + 1), ('val', 43 + 1)]:
+      print(f"Processing {split} in {patches} patches ...")
+      images, labels = dir / 'images' / split, dir / 'labels' / split
 
-    # Download split
-    url = f"https://dorc.ks3-cn-beijing.ksyun.com/data-set/2020Objects365%E6%95%B0%E6%8D%AE%E9%9B%86/{split}/"
-    if split == 'train':
-        download([url + f'zhiyuan_objv2_{split}.tar.gz'], dir=dir, delete=False)  # annotations json
-        download([url + f for f in [f'patch{i}.tar.gz' for i in range(patches)]], dir=dir / 'images' / split,
-                 curl=True, delete=False, threads=8)
-    elif split == 'val':
-        download([url + f'zhiyuan_objv2_{split}.json'], dir=dir, delete=False)    # annotations json
-        download([url + 'images/v1/' + f for f in [f'patch{i}.tar.gz' for i in range(15+1)]], dir=dir / 'images' / split,
-                 curl=True, delete=False, threads=8)
-        download([url + 'images/v2/' + f for f in [f'patch{i}.tar.gz' for i in range(16, patches)]], dir=dir / 'images' / split,
-                 curl=True, delete=False, threads=8)
+      # Download
+      url = f"https://dorc.ks3-cn-beijing.ksyun.com/data-set/2020Objects365%E6%95%B0%E6%8D%AE%E9%9B%86/{split}/"
+      if split == 'train':
+          download([url + f'zhiyuan_objv2_{split}.tar.gz'], dir=dir, delete=False)  # annotations json
+          download([url + f for f in [f'patch{i}.tar.gz' for i in range(patches)]],
+                   dir=images, curl=True, delete=False, threads=8)
+      elif split == 'val':
+          download([url + f'zhiyuan_objv2_{split}.json'], dir=dir, delete=False)  # annotations json
+          download([url + 'images/v1/' + f for f in [f'patch{i}.tar.gz' for i in range(15 + 1)]],
+                   dir=images, curl=True, delete=False, threads=8)
+          download([url + 'images/v2/' + f for f in [f'patch{i}.tar.gz' for i in range(16, patches)]],
+                   dir=images, curl=True, delete=False, threads=8)
 
-    # Move split images
-    splitP = dir / 'images' / split
-    for f in tqdm(splitP.rglob('*.jpg'), desc=f'Moving {split} images'):
-      f.rename(splitP / f.name)  # move to /images/{split}
+      # Move
+      for f in tqdm(images.rglob('*.jpg'), desc=f'Moving {split} images'):
+          f.rename(images / f.name)  # move to /images/{split}
 
-    # Split labels
-    coco = COCO(dir / f'zhiyuan_objv2_{split}.json')
-    names = [x["name"] for x in coco.loadCats(coco.getCatIds())]
-    for cid, cat in enumerate(names):
-      catIds = coco.getCatIds(catNms=[cat])
-      imgIds = coco.getImgIds(catIds=catIds)
-      for im in tqdm(coco.loadImgs(imgIds), desc=f'Class {cid + 1}/{len(names)} {cat}'):
-        width, height = im["width"], im["height"]
-        path = Path(im["file_name"])  # image filename
-        try:
-          with open(dir / 'labels' / split / path.with_suffix('.txt').name, 'a') as file:
-            annIds = coco.getAnnIds(imgIds=im["id"], catIds=catIds, iscrowd=None)
-            for a in coco.loadAnns(annIds):
-              x, y, w, h = a['bbox']  # bounding box in xywh (xy top-left corner)
-              x, y = x + w / 2, y + h / 2  # xy to center
-              file.write(f"{cid} {x / width:.5f} {y / height:.5f} {w / width:.5f} {h / height:.5f}\n")
+      # Labels
+      coco = COCO(dir / f'zhiyuan_objv2_{split}.json')
+      names = [x["name"] for x in coco.loadCats(coco.getCatIds())]
+      for cid, cat in enumerate(names):
+          catIds = coco.getCatIds(catNms=[cat])
+          imgIds = coco.getImgIds(catIds=catIds)
+          for im in tqdm(coco.loadImgs(imgIds), desc=f'Class {cid + 1}/{len(names)} {cat}'):
+              width, height = im["width"], im["height"]
+              path = Path(im["file_name"])  # image filename
+              try:
+                  with open(labels / path.with_suffix('.txt').name, 'a') as file:
+                      annIds = coco.getAnnIds(imgIds=im["id"], catIds=catIds, iscrowd=None)
+                      for a in coco.loadAnns(annIds):
+                          x, y, w, h = a['bbox']  # bounding box in xywh (xy top-left corner)
+                          x, y = x + w / 2, y + h / 2  # xy to center
+                          file.write(f"{cid} {x / width:.5f} {y / height:.5f} {w / width:.5f} {h / height:.5f}\n")
 
-        except Exception as e:
-          print(e)
+              except Exception as e:
+                  print(e)

--- a/data/Objects365.yaml
+++ b/data/Objects365.yaml
@@ -72,33 +72,43 @@ download: |
       for q in 'train', 'val':
           (dir / p / q).mkdir(parents=True, exist_ok=True)
 
-  # Download
-  url = "https://dorc.ks3-cn-beijing.ksyun.com/data-set/2020Objects365%E6%95%B0%E6%8D%AE%E9%9B%86/train/"
-  download([url + 'zhiyuan_objv2_train.tar.gz'], dir=dir, delete=False)  # annotations json
-  download([url + f for f in [f'patch{i}.tar.gz' for i in range(51)]], dir=dir / 'images' / 'train',
-           curl=True, delete=False, threads=8)
+  for split, patches in [('train', 50+1), ('val', 43+1)]:
+    print(f"Processing {split} in {patches} patches ...")
 
-  # Move
-  train = dir / 'images' / 'train'
-  for f in tqdm(train.rglob('*.jpg'), desc=f'Moving images'):
-      f.rename(train / f.name)  # move to /images/train
+    # Download split
+    url = f"https://dorc.ks3-cn-beijing.ksyun.com/data-set/2020Objects365%E6%95%B0%E6%8D%AE%E9%9B%86/{split}/"
+    if split == 'train':
+        download([url + f'zhiyuan_objv2_{split}.tar.gz'], dir=dir, delete=False)  # annotations json
+        download([url + f for f in [f'patch{i}.tar.gz' for i in range(patches)]], dir=dir / 'images' / split,
+                 curl=True, delete=False, threads=8)
+    elif split == 'val':
+        download([url + f'zhiyuan_objv2_{split}.json'], dir=dir, delete=False)    # annotations json
+        download([url + 'images/v1/' + f for f in [f'patch{i}.tar.gz' for i in range(15+1)]], dir=dir / 'images' / split,
+                 curl=True, delete=False, threads=8)
+        download([url + 'images/v2/' + f for f in [f'patch{i}.tar.gz' for i in range(16, patches)]], dir=dir / 'images' / split,
+                 curl=True, delete=False, threads=8)
 
-  # Labels
-  coco = COCO(dir / 'zhiyuan_objv2_train.json')
-  names = [x["name"] for x in coco.loadCats(coco.getCatIds())]
-  for cid, cat in enumerate(names):
+    # Move split images
+    splitP = dir / 'images' / split
+    for f in tqdm(splitP.rglob('*.jpg'), desc=f'Moving {split} images'):
+      f.rename(splitP / f.name)  # move to /images/{split}
+
+    # Split labels
+    coco = COCO(dir / f'zhiyuan_objv2_{split}.json')
+    names = [x["name"] for x in coco.loadCats(coco.getCatIds())]
+    for cid, cat in enumerate(names):
       catIds = coco.getCatIds(catNms=[cat])
       imgIds = coco.getImgIds(catIds=catIds)
       for im in tqdm(coco.loadImgs(imgIds), desc=f'Class {cid + 1}/{len(names)} {cat}'):
-          width, height = im["width"], im["height"]
-          path = Path(im["file_name"])  # image filename
-          try:
-              with open(dir / 'labels' / 'train' / path.with_suffix('.txt').name, 'a') as file:
-                  annIds = coco.getAnnIds(imgIds=im["id"], catIds=catIds, iscrowd=None)
-                  for a in coco.loadAnns(annIds):
-                      x, y, w, h = a['bbox']  # bounding box in xywh (xy top-left corner)
-                      x, y = x + w / 2, y + h / 2  # xy to center
-                      file.write(f"{cid} {x / width:.5f} {y / height:.5f} {w / width:.5f} {h / height:.5f}\n")
+        width, height = im["width"], im["height"]
+        path = Path(im["file_name"])  # image filename
+        try:
+          with open(dir / 'labels' / split / path.with_suffix('.txt').name, 'a') as file:
+            annIds = coco.getAnnIds(imgIds=im["id"], catIds=catIds, iscrowd=None)
+            for a in coco.loadAnns(annIds):
+              x, y, w, h = a['bbox']  # bounding box in xywh (xy top-left corner)
+              x, y = x + w / 2, y + h / 2  # xy to center
+              file.write(f"{cid} {x / width:.5f} {y / height:.5f} {w / width:.5f} {h / height:.5f}\n")
 
-          except Exception as e:
-              print(e)
+        except Exception as e:
+          print(e)


### PR DESCRIPTION
Include the official Objects365 validation set to download and convert the labels

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced `Objects365.yaml` to support both training and validation data splits.

### 📊 Key Changes
- 🔄 Implemented separate code paths for handling 'train' and 'val' data splits.
- ➕ Added download links and processes for the validation dataset.
- ⬇️ Automated downloading of annotation files and images.
- 🚚 Streamlined moving of images to their corresponding directory after download.
- 📝 Adapted label generation code to work with both training and validation images.

### 🎯 Purpose & Impact
- 🔍 The changes allow easier access to both training and validation datasets within the Objects365 dataset, facilitating proper machine learning model evaluation.
- 🤖 Users of the `yolov5` repository can now expect more streamlined download and setup processes for using the Objects365 dataset, potentially leading to more robust model training and validation.
- 👌 This update simplifies the usability of the dataset setup scripts, potentially increasing adoption and improving user experience.