### PR TITLE
Update Objects365.yaml val count

### DIFF
--- a/data/Objects365.yaml
+++ b/data/Objects365.yaml
@@ -10,7 +10,7 @@
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: ../datasets/Objects365  # dataset root dir
 train: images/train  # train images (relative to 'path') 1742289 images
-val: images/val # val images (relative to 'path') 5570 images
+val: images/val # val images (relative to 'path') 80000 images
 test:  # test images (optional)
 
 # Classes


### PR DESCRIPTION
Follows improved validation set autodownlod in https://github.com/ultralytics/yolov5/pull/5194

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to the validation set size in Objects365 dataset configuration. 

### 📊 Key Changes
- 🖼 Updated the number of validation images from 5,570 to 80,000 in the Objects365 dataset configuration file.

### 🎯 Purpose & Impact
- 🎯 Ensures more comprehensive validation by increasing the dataset size, leading to potentially better model performance and generalization.
- 💪 Provides a larger dataset for evaluating model accuracy, which could lead to more robust AI models.
- 👩‍💻 Helps developers and researchers to train models with a more extensive set of validation data, improving the reliability of performance metrics.