### PR TITLE
Clip Objects365 autodownload labels

### DIFF
--- a/data/Objects365.yaml
+++ b/data/Objects365.yaml
@@ -63,7 +63,7 @@ download: |
   from pycocotools.coco import COCO
   from tqdm import tqdm
   
-  from utils.general import download, Path
+  from utils.general import Path, download, np, xyxy2xywhn
   
   # Make Directories
   dir = Path(yaml['path'])  # dataset root dir
@@ -105,7 +105,8 @@ download: |
                       annIds = coco.getAnnIds(imgIds=im["id"], catIds=catIds, iscrowd=None)
                       for a in coco.loadAnns(annIds):
                           x, y, w, h = a['bbox']  # bounding box in xywh (xy top-left corner)
-                          x, y = x + w / 2, y + h / 2  # xy to center
-                          file.write(f"{cid} {x / width:.5f} {y / height:.5f} {w / width:.5f} {h / height:.5f}\n")
+                          xyxy = np.array([x, y, x + w, y + h])[None]  # pixels(1,4)
+                          x, y, w, h = xyxy2xywhn(xyxy, w=width, h=height, clip=True)[0]  # normalized and clipped
+                          file.write(f"{cid} {x:.5f} {y:.5f} {w:.5f} {h:.5f}\n")
               except Exception as e:
                   print(e)


### PR DESCRIPTION
Fixes out of bounds labels that seem to affect ~10% of images in dataset.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgraded bounding box calculations for Objects365 dataset configuration in YOLOv5.

### 📊 Key Changes
- Imported additional utility functions, including `xyxy2xywhn` from `utils.general`.
- Revised the way bounding box dimensions are calculated, now using `xyxy2xywhn` for normalization and clipping.

### 🎯 Purpose & Impact
- 🎨 **Improved Accuracy**: Using `xyxy2xywhn` helps ensure bounding box coordinates are normalized and clipped correctly, which may reduce errors during training and inference.
- 🛠️ **Code Maintainability**: Relying on a dedicated utility function for coordinate transformations makes the codebase cleaner and more maintainable.
- 🔍 **Data Quality**: Ensures that the bounding box data for the Objects365 dataset is more precise, potentially leading to improved model performance for users working with this dataset.