### PR TITLE
Add `on_fit_epoch_end` callback

### DIFF
--- a/train.py
+++ b/train.py
@@ -426,7 +426,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                     if is_coco:
                         callbacks.run('on_fit_epoch_end', list(mloss) + list(results) + lr, epoch, best_fitness, fi)
 
-        callbacks.run('on_train_end', last, best, plots, epoch)
+        callbacks.run('on_train_end', last, best, plots, epoch, results)
         LOGGER.info(f"Results saved to {colorstr('bold', save_dir)}")
 
     torch.cuda.empty_cache()

--- a/train.py
+++ b/train.py
@@ -423,6 +423,8 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                                             plots=True,
                                             callbacks=callbacks,
                                             compute_loss=compute_loss)  # val best model with plots
+                    if is_coco:
+                        callbacks.run('on_fit_epoch_end', list(mloss) + list(results) + lr, epoch, best_fitness, fi)
 
         callbacks.run('on_train_end', last, best, plots, epoch)
         LOGGER.info(f"Results saved to {colorstr('bold', save_dir)}")

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -131,7 +131,7 @@ class Loggers():
             if ((epoch + 1) % self.opt.save_period == 0 and not final_epoch) and self.opt.save_period != -1:
                 self.wandb.log_model(last.parent, self.opt, epoch, fi, best_model=best_fitness == fi)
 
-    def on_train_end(self, last, best, plots, epoch):
+    def on_train_end(self, last, best, plots, epoch, results):
         # Callback runs on training end
         if plots:
             plot_results(file=self.save_dir / 'results.csv')  # save results.png


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to training callbacks for COCO dataset evaluations and improved results logging.

### 📊 Key Changes
- Added an additional callback condition specifically for the COCO dataset during the training phase.
- Updated the `on_train_end` callback to include the results in its parameters.

### 🎯 Purpose & Impact
- 🎲 **Tailored Callbacks for COCO Dataset:** The update enables custom behavior during training when the model is using the COCO dataset, likely to process evaluation results specifically for this common benchmark.
- 📈 **Enhanced Results Logging:** By including results in the `on_train_end` callback, more detailed information will be logged at the end of training, providing users with better insights into model performance.
- Both changes should improve the user's insight and control over the training process, particularly when working with the well-known COCO dataset, potentially leading to more informed decision-making and streamlined workflows.