### PR TITLE
Add dependabot for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,14 @@ updates:
       - glenn-jocher
     labels:
       - dependencies
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "04:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - glenn-jocher
+    labels:
+      - dependencies


### PR DESCRIPTION
Hi @glenn-jocher , Seems that the Dependabot can update the Actions automatically. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced dependency management for GitHub Actions in the YOLOv5 repository.

### 📊 Key Changes
- 🔃 Added a new update rule for the package-ecosystem of GitHub Actions.
- ⏰ The schedule for checking GitHub Actions dependencies is set to weekly.
- 🕓 Selected time for the update check is at 04:00.
- 🚦 The open-pull-requests-limit is set to 5.
- 🔖 Dependencies label will be applied to relevant pull requests.
- 👤 Glenn Jocher will be automatically added as a reviewer for these pull requests.

### 🎯 Purpose & Impact
- 💡 Ensures that GitHub Actions dependencies are kept up to date regularly, which is crucial for the CI/CD pipeline's security and reliability.
- 🛠️ Helps maintain an optimal number of dependency update PRs, avoiding an overwhelming number of updates at once.
- 🙌 Users can expect a more stable and secure repository environment with consistent updates to the CI/CD process.