### PR TITLE
autosplit: take image files with uppercase extensions into account

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -406,7 +406,7 @@ class LoadImagesAndLabels(Dataset):
                 else:
                     raise Exception(f'{prefix}{p} does not exist')
             self.img_files = sorted([x.replace('/', os.sep) for x in f if x.split('.')[-1].lower() in IMG_FORMATS])
-            # self.img_files = sorted([x for x in f if x.suffix[1:].lower() in img_formats])  # pathlib
+            # self.img_files = sorted([x for x in f if x.suffix[1:].lower() in IMG_FORMATS])  # pathlib
             assert self.img_files, f'{prefix}No images found'
         except Exception as e:
             raise Exception(f'{prefix}Error loading data from {path}: {e}\nSee {HELP_URL}')

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -865,8 +865,9 @@ def autosplit(path='../datasets/coco128/images', weights=(0.9, 0.1, 0.0), annota
         weights:         Train, val, test weights (list, tuple)
         annotated_only:  Only use images with an annotated txt file
     """
+    IMG_FORMATS_CASE_INSENSITIVE = [''.join('[%s%s]' % (c.lower(), c.upper()) for c in ext) for ext in IMG_FORMATS]
     path = Path(path)  # images dir
-    files = sum([list(path.rglob(f"*.{img_ext}")) for img_ext in IMG_FORMATS], [])  # image files only
+    files = sum([list(path.rglob(f"*.{img_ext}")) for img_ext in IMG_FORMATS_CASE_INSENSITIVE], [])  # image files only
     n = len(files)  # number of files
     random.seed(0)  # for reproducibility
     indices = random.choices([0, 1, 2], weights=weights, k=n)  # assign each image to a split

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -865,9 +865,8 @@ def autosplit(path='../datasets/coco128/images', weights=(0.9, 0.1, 0.0), annota
         weights:         Train, val, test weights (list, tuple)
         annotated_only:  Only use images with an annotated txt file
     """
-    IMG_FORMATS_CASE_INSENSITIVE = [''.join('[%s%s]' % (c.lower(), c.upper()) for c in ext) for ext in IMG_FORMATS]
     path = Path(path)  # images dir
-    files = sum([list(path.rglob(f"*.{img_ext}")) for img_ext in IMG_FORMATS_CASE_INSENSITIVE], [])  # image files only
+    files = sorted([x for x in path.rglob('*.*') if x.suffix[1:].lower() in IMG_FORMATS])  # image files only
     n = len(files)  # number of files
     random.seed(0)  # for reproducibility
     indices = random.choices([0, 1, 2], weights=weights, k=n)  # assign each image to a split

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -396,7 +396,7 @@ class LoadImagesAndLabels(Dataset):
                 p = Path(p)  # os-agnostic
                 if p.is_dir():  # dir
                     f += glob.glob(str(p / '**' / '*.*'), recursive=True)
-                    # f = list(p.rglob('**/*.*'))  # pathlib
+                    # f = list(p.rglob('*.*'))  # pathlib
                 elif p.is_file():  # file
                     with open(p, 'r') as t:
                         t = t.read().strip().splitlines()


### PR DESCRIPTION
IMG_FORMATS contains lowercase versions of image file extensions.

In all other uses of IMG_FORMATS, care is taken to take into account image files regardless of the extension's case. However, the autosplit() function doesn't: it silently fails to include files whose extensions have any uppercase letter. This is not a problem on Windows, but has bitten me on Linux. This commit fixes the problem.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refined image file filtering mechanism in the dataset loading process.

### 📊 Key Changes
- Altered the file search pattern from '**/*.*' to '*.*' to adjust the scope of recursive search.
- Synchronized the commented pathlib-based alternative with the IMG_FORMATS global.
- Ensured the file list is always sorted, improving the consistency of data processing.

### 🎯 Purpose & Impact
- 🎨 **Purpose:** To streamline the file discovery process, ensuring that only relevant image files are included in the dataset. The pathlib alternative is kept up-to-date for potential future use.
- 🚀 **Impact:** 
  - Users can expect more reliable dataset loading with a refined search that may improve load times and reduce errors.
  - Consistent sorting of files contributes to reproducibility, important for model training and evaluation tasks.