### PR TITLE
take EXIF orientation tags into account when fixing corrupt images

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -896,7 +896,7 @@ def verify_image_label(args):
             with open(im_file, 'rb') as f:
                 f.seek(-2, 2)
                 if f.read() != b'\xff\xd9':  # corrupt JPEG
-                    ImageOps.exif_transpose(Image.open(im_file)).save(im_file, format='JPEG', subsampling=0, quality=100)  # re-save image
+                    ImageOps.exif_transpose(Image.open(im_file)).save(im_file, 'JPEG', subsampling=0, quality=100)
                     msg = f'{prefix}WARNING: {im_file}: corrupt JPEG restored and saved'
 
         # verify labels

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -22,7 +22,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 import yaml
-from PIL import Image, ExifTags, ImageOps
+from PIL import Image, ImageOps, ExifTags
 from torch.utils.data import Dataset
 from tqdm import tqdm
 

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -69,7 +69,7 @@ def exif_size(img):
 def exif_transpose(image):
     """
     Transpose a PIL image accordingly if it has an EXIF Orientation tag.
-    Inplace version of https://github.com/python-pillow/Pillow/blob/master/src/PIL/ImageOps.py
+    Inplace version of https://github.com/python-pillow/Pillow/blob/master/src/PIL/ImageOps.py exif_transpose()
 
     :param image: The image to transpose.
     :return: An image.

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -69,7 +69,7 @@ def exif_size(img):
 def exif_transpose(image):
     """
     Transpose a PIL image accordingly if it has an EXIF Orientation tag.
-    From https://github.com/python-pillow/Pillow/blob/master/src/PIL/ImageOps.py
+    Inplace version of https://github.com/python-pillow/Pillow/blob/master/src/PIL/ImageOps.py
 
     :param image: The image to transpose.
     :return: An image.

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -22,7 +22,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 import yaml
-from PIL import Image, ExifTags
+from PIL import Image, ExifTags, ImageOps
 from torch.utils.data import Dataset
 from tqdm import tqdm
 
@@ -896,7 +896,7 @@ def verify_image_label(args):
             with open(im_file, 'rb') as f:
                 f.seek(-2, 2)
                 if f.read() != b'\xff\xd9':  # corrupt JPEG
-                    Image.open(im_file).save(im_file, format='JPEG', subsampling=0, quality=100)  # re-save image
+                    ImageOps.exif_transpose(Image.open(im_file)).save(im_file, format='JPEG', subsampling=0, quality=100)  # re-save image
                     msg = f'{prefix}WARNING: {im_file}: corrupt JPEG restored and saved'
 
         # verify labels


### PR DESCRIPTION
I have some images that OpenCV can open just fine, but are detected as corrupt in verify_image_label(). They have, however, EXIF orientation tags that OpenCV handles just fine, but are ignored by Pillow unless using a specific incantation. The result is that some images are transposed without also transposing the labels.

This makes Pillow apply EXIF orientation tags, if present, before saving the image, in order to avoid wreaking havoc on training datasets.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgraded image handling with EXIF-aware transposition during verification.

### 📊 Key Changes
- `ImageOps` module from PIL is now imported.
- An inplace version of the EXIF transpose function is used.
- Corrupt JPEG images get EXIF transposed before being re-saved.

### 🎯 Purpose & Impact
- **Purpose**: The update is intended to ensure proper orientation of images based on their EXIF data during the image verification process, and repair corrupt JPEG images when encountered.
- **Impact**: This enhancement will lead to more accurately oriented images when used within the YOLOv5 framework, providing a better experience for users who rely on the correct visual representation of their data. It might also prevent errors caused by incorrectly oriented images and fix minor corruptions in JPEG files.🔄