### PR TITLE
More informative `EarlyStopping()` message

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -299,7 +299,10 @@ class EarlyStopping:
         self.possible_stop = delta >= (self.patience - 1)  # possible stop may occur next epoch
         stop = delta >= self.patience  # stop training if patience exceeded
         if stop:
-            LOGGER.info(f'EarlyStopping patience {self.patience} exceeded, stopping training.')
+            LOGGER.info(f'Stopping training early as no improvement observed in last {self.patience} epochs. '
+                        f'Best results observed at epoch {self.best_epoch}, best model saved as best.pt.\n'
+                        f'To update EarlyStopping(patience={self.patience}) pass a new patience value, '
+                        f'i.e. `python train.py --patience 300` or use `--patience 0` to disable EarlyStopping.')
         return stop
 
 


### PR DESCRIPTION
Improve user understanding of this feature, addresses https://github.com/ultralytics/yolov5/issues/5288

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced EarlyStopping Logging for Clarity 🛑✨

### 📊 Key Changes
- Updated the EarlyStopping logging message with more details.
- Now includes information about the epoch with the best results.
- Provides instruction on how to change the patience or disable EarlyStopping.

### 🎯 Purpose & Impact
- **Improved Transparency**: Users get clearer feedback on why training stopped and at which epoch the best model was saved.
- **Enhanced Usability**: The updated log message guides users on how to adjust EarlyStopping settings to their preference, which is especially useful for fine-tuning model training.
- **Potential Increase in Efficiency**: By understanding EarlyStopping better, users can more effectively manage their training runs, potentially saving time and resources. 🚀