### PR TITLE
Uncomment OpenCV 4.5.4 requirement in detect.py

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -89,7 +89,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
             modelc.load_state_dict(torch.load('resnet50.pt', map_location=device)['model']).to(device).eval()
     elif onnx:
         if dnn:
-            # check_requirements(('opencv-python>=4.5.4',))
+            check_requirements(('opencv-python>=4.5.4',))
             net = cv2.dnn.readNetFromONNX(w)
         else:
             check_requirements(('onnx', 'onnxruntime-gpu' if torch.has_cuda else 'onnxruntime'))


### PR DESCRIPTION
pip package of opencv-python has been updated to version 4.5.4. https://pypi.org/project/opencv-python/
requirement can now be uncommented.

related https://github.com/ultralytics/yolov5/issues/4811#issuecomment-940369899

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in ONNX model support with environment checks within the `detect.py` script.

### 📊 Key Changes
- Uncommented requirement check for OpenCV when using ONNX models with DNN.

### 🎯 Purpose & Impact
- **Purpose**: Ensures that users have the correct version of OpenCV installed when opting to run the model with OpenCV's DNN module.
- **Impact**: Enhances user experience by providing clear requirements, potentially reducing setup issues and improving model compatibility. 🛠️