### PR TITLE
W&B: Media panel fix

### DIFF
--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -486,7 +486,7 @@ class WandbLogger():
         if self.wandb_run:
             with all_logging_disabled():
                 if self.bbox_media_panel_images:
-                    self.log_dict["Bounding Box Debugger/Images"] = self.bbox_media_panel_images
+                    self.log_dict["BoundingBoxDebugger"] = self.bbox_media_panel_images
                 wandb.log(self.log_dict)
                 self.log_dict = {}
                 self.bbox_media_panel_images = []


### PR DESCRIPTION
fix https://github.com/ultralytics/yolov5/issues/5315

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced labeling for bounding box debugging in Weights & Biases integration.

### 📊 Key Changes
- Renamed the logging key from "Bounding Box Debugger/Images" to "BoundingBoxDebugger".

### 🎯 Purpose & Impact
- **Purpose**: To streamline and perhaps enforce a naming convention that might be clearer or more consistent for users who inspect object detection bounding boxes within the Weights & Biases (W&B) platform.
- **Impact**: Users will experience a change in the labeling of bounding box debugging visuals within W&B, potentially improving readability and organisation in their W&B dashboard. No impact on the functionality of the model training or bounding box debugging itself.