### PR TITLE
DDP `nl` fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -246,7 +246,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         model = DDP(model, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK)
 
     # Model parameters
-    nl = model.model[-1].nl  # number of detection layers (to scale hyps)
+    nl = de_parallel(model).model[-1].nl  # number of detection layers (to scale hyps)
     hyp['box'] *= 3. / nl  # scale to layers
     hyp['cls'] *= nc / 80. * 3. / nl  # scale to classes and layers
     hyp['obj'] *= (imgsz / 640) ** 2 * 3. / nl  # scale to image size and layers


### PR DESCRIPTION
Fix for https://github.com/ultralytics/yolov5/issues/5160#issuecomment-950915142

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved multi-GPU training support by ensuring model parameter scaling accounts for the wrapped model.

### 📊 Key Changes
- Modified the retrieval of the `nl` (number of detection layers) to use `de_parallel` function when the model is in Distributed Data Parallel (DDP) mode.

### 🎯 Purpose & Impact
- **Purpose:** The change ensures that when a model is being used across multiple GPUs, the detection layers count is correctly retrieved even when the model is wrapped for parallel processing.
- **Impact:** This improvement could lead to more accurate scaling of hyperparameters (`hyp`) during multi-GPU training, which enhances model performance and training stability. Users employing DDP will benefit from accurate hyperparameters adjustments irrespective of the number of GPUs used. 🚀