### PR TITLE
Suppress ONNX export trace warning

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -55,7 +55,7 @@ class Detect(nn.Module):
             x[i] = x[i].view(bs, self.na, self.no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
 
             if not self.training:  # inference
-                if self.grid[i].shape[2:4] != x[i].shape[2:4] or self.onnx_dynamic:
+                if self.onnx_dynamic or self.grid[i].shape[2:4] != x[i].shape[2:4]:
                     self.grid[i], self.anchor_grid[i] = self._make_grid(nx, ny, i)
 
                 y = x[i].sigmoid()


### PR DESCRIPTION
Checking for `onnx_dynamic` first should suppress the warning:

```log
TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if self.grid[i].shape[2:4] != x[i].shape[2:4] or self.onnx_dynamic
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved condition check ordering in YOLO model inference logic.

### 📊 Key Changes
- Swapped the order of condition checks during the inference pathway when determining if the grid needs to be recalculated.

### 🎯 Purpose & Impact
- **Purpose**: To optimize the condition check for consistency and potentially improve the execution speed by prioritizing the `onnx_dynamic` check.
- **Impact**: This may lead to minor performance improvements during model inference, especially beneficial for ONNX runtime environments. It helps streamline the model's forward pass by efficiently determining when to recalculate the anchor grids. Users may experience more responsive inference with specific deployment scenarios, though overall impact might be minimal for most users.