### PR TITLE
Update `check_git_status()` to run under `ROOT` working directory

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -206,11 +206,13 @@ def check_online():
 def check_git_status():
     # Recommend 'git pull' if code is out of date
     msg = ', for updates see https://github.com/ultralytics/yolov5'
+    cwd = Path.cwd()
     print(colorstr('github: '), end='')
-    assert Path('.git').exists(), 'skipping check (not a git repository)' + msg
+    assert Path(ROOT / '.git').exists(), 'skipping check (not a git repository)' + msg
     assert not is_docker(), 'skipping check (Docker image)' + msg
     assert check_online(), 'skipping check (offline)' + msg
 
+    os.chdir(ROOT)  # Changing the current working directory to YOLOv5 repository root
     cmd = 'git fetch && git config --get remote.origin.url'
     url = check_output(cmd, shell=True, timeout=5).decode().strip().rstrip('.git')  # git fetch
     branch = check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode().strip()  # checked out
@@ -220,6 +222,7 @@ def check_git_status():
     else:
         s = f'up to date with {url} ✅'
     print(emojis(s))  # emoji-safe
+    os.chdir(cwd)  # Reverting back to the original working directory
 
 
 def check_python(minimum='3.6.2'):

--- a/utils/general.py
+++ b/utils/general.py
@@ -82,11 +82,14 @@ class Timeout(contextlib.ContextDecorator):
 
 class ChangeWorkingDirectory(contextlib.ContextDecorator):
     # Temporarily change the current working directory to a different one.
-    # Usage: @ChangeWorkingDirectory(dir) decorator
-    # or 'with ChangeWorkingDirectory(dir):' context manager
-    def __enter__(self, dir):
+    # Usage: @ChangeWorkingDirectory(directory) decorator
+    # or 'with ChangeWorkingDirectory(directory):' context manager
+    def __init__(self, directory):
+        self.directory = directory
         self.cwd = Path.cwd().resolve()
-        os.chdir(dir)
+
+    def __enter__(self):
+        os.chdir(self.directory)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         os.chdir(self.cwd)

--- a/utils/general.py
+++ b/utils/general.py
@@ -216,20 +216,19 @@ def check_online():
 
 
 @try_except
+@WorkingDirectory(ROOT)
 def check_git_status():
     # Recommend 'git pull' if code is out of date
     msg = ', for updates see https://github.com/ultralytics/yolov5'
     print(colorstr('github: '), end='')
-    assert (ROOT / '.git').exists(), 'skipping check (not a git repository)' + msg
+    assert Path('.git').exists(), 'skipping check (not a git repository)' + msg
     assert not is_docker(), 'skipping check (Docker image)' + msg
     assert check_online(), 'skipping check (offline)' + msg
 
-    with WorkingDirectory(ROOT):
-        cmd = 'git fetch && git config --get remote.origin.url'
-        url = check_output(cmd, shell=True, timeout=5).decode().strip().rstrip('.git')  # git fetch
-        branch = check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode().strip()  # checked out
-        n = int(check_output(f'git rev-list {branch}..origin/master --count', shell=True))  # commits behind
-
+    cmd = 'git fetch && git config --get remote.origin.url'
+    url = check_output(cmd, shell=True, timeout=5).decode().strip().rstrip('.git')  # git fetch
+    branch = check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode().strip()  # checked out
+    n = int(check_output(f'git rev-list {branch}..origin/master --count', shell=True))  # commits behind
     if n > 0:
         s = f"⚠️ YOLOv5 is out of date by {n} commit{'s' * (n > 1)}. Use `git pull` or `git clone {url}` to update."
     else:

--- a/utils/general.py
+++ b/utils/general.py
@@ -217,7 +217,7 @@ def check_git_status():
     # Recommend 'git pull' if code is out of date
     msg = ', for updates see https://github.com/ultralytics/yolov5'
     print(colorstr('github: '), end='')
-    assert Path(ROOT / '.git').exists(), 'skipping check (not a git repository)' + msg
+    assert (ROOT / '.git').exists(), 'skipping check (not a git repository)' + msg
     assert not is_docker(), 'skipping check (Docker image)' + msg
     assert check_online(), 'skipping check (offline)' + msg
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -80,16 +80,15 @@ class Timeout(contextlib.ContextDecorator):
         if self.suppress and exc_type is TimeoutError:  # Suppress TimeoutError
             return True
 
-class ChangeWorkingDirectory(contextlib.ContextDecorator):
-    # Temporarily change the current working directory to a different one.
-    # Usage: @ChangeWorkingDirectory(directory) decorator
-    # or 'with ChangeWorkingDirectory(directory):' context manager
-    def __init__(self, directory):
-        self.directory = directory
-        self.cwd = Path.cwd().resolve()
+
+class WorkingDirectory(contextlib.ContextDecorator):
+    # Usage: @WorkingDirectory(dir) decorator or 'with WorkingDirectory(dir):' context manager
+    def __init__(self, new_dir):
+        self.dir = new_dir  # new dir
+        self.cwd = Path.cwd().resolve()  # current dir
 
     def __enter__(self):
-        os.chdir(self.directory)
+        os.chdir(self.dir)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         os.chdir(self.cwd)
@@ -225,7 +224,7 @@ def check_git_status():
     assert not is_docker(), 'skipping check (Docker image)' + msg
     assert check_online(), 'skipping check (offline)' + msg
 
-    with ChangeWorkingDirectory(ROOT):
+    with WorkingDirectory(ROOT):
         cmd = 'git fetch && git config --get remote.origin.url'
         url = check_output(cmd, shell=True, timeout=5).decode().strip().rstrip('.git')  # git fetch
         branch = check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode().strip()  # checked out

--- a/utils/general.py
+++ b/utils/general.py
@@ -80,12 +80,13 @@ class Timeout(contextlib.ContextDecorator):
         if self.suppress and exc_type is TimeoutError:  # Suppress TimeoutError
             return True
 
-class ChangeWorkingDirectoryToRoot(contextlib.ContextDecorator):
-    # Usage: @ChangeWorkingDirectoryToRoot() decorator
-    # or 'with ChangeWorkingDirectoryToRoot():' context manager
-    def __enter__(self):
+class ChangeWorkingDirectory(contextlib.ContextDecorator):
+    # Temporarily change the current working directory to a different one.
+    # Usage: @ChangeWorkingDirectory(dir) decorator
+    # or 'with ChangeWorkingDirectory(dir):' context manager
+    def __enter__(self, dir):
         self.cwd = Path.cwd().resolve()
-        os.chdir(ROOT)
+        os.chdir(dir)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         os.chdir(self.cwd)
@@ -221,7 +222,7 @@ def check_git_status():
     assert not is_docker(), 'skipping check (Docker image)' + msg
     assert check_online(), 'skipping check (offline)' + msg
 
-    with ChangeWorkingDirectoryToRoot():
+    with ChangeWorkingDirectory(ROOT):
         cmd = 'git fetch && git config --get remote.origin.url'
         url = check_output(cmd, shell=True, timeout=5).decode().strip().rstrip('.git')  # git fetch
         branch = check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode().strip()  # checked out

--- a/utils/general.py
+++ b/utils/general.py
@@ -89,7 +89,7 @@ class ChangeWorkingDirectoryToRoot(contextlib.ContextDecorator):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         os.chdir(self.cwd)
-        
+
 
 def try_except(func):
     # try-except function. Usage: @try_except decorator


### PR DESCRIPTION
Fixes #5440 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
New context manager for changing working directory in code sections.

### 📊 Key Changes
- Introduced a new class `WorkingDirectory` as a context manager to change the current working directory within a code block.
- The `@WorkingDirectory(ROOT)` decorator has been applied to the `check_git_status` function.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: This change allows developers to seamlessly change the working directory while executing certain functions or code blocks, improving code organization and keeping file path references relative and consistent.
- 💥 **Impact**: Users can expect more reliable file handling when the script changes directories, potentially reducing file path errors. Additionally, the developers can use this functionality to ensure that certain functions always run in the same directory context, which is especially helpful for maintaining relative paths.