### PR TITLE
correct resume True error

### DIFF
--- a/train.py
+++ b/train.py
@@ -491,6 +491,7 @@ def main(opt, callbacks=Callbacks()):
 
     # Resume
     if opt.resume and not check_wandb_resume(opt) and not opt.evolve:  # resume an interrupted run
+        opt.resume = True if opt.resume == 'True' else opt.resume
         ckpt = opt.resume if isinstance(opt.resume, str) else get_latest_run()  # specified or most recent path
         assert os.path.isfile(ckpt), 'ERROR: --resume checkpoint does not exist'
         with open(Path(ckpt).parent.parent / 'opt.yaml', errors='ignore') as f:


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced flexibility in resume argument handling for YOLOv5 training script.

### 📊 Key Changes
- Added a line in `train.py` to interpret the string `'True'` as a boolean `True` when passed as the `--resume` argument.

### 🎯 Purpose & Impact
- **Purpose:** This change ensures that the `--resume` functionality can handle both boolean values directly from the command line and when provided as strings.
- **Impact:** Users will experience more reliable behavior when attempting to resume training a YOLOv5 model, particularly when invoking the script with command-line interfaces or through other software tools that may pass arguments as strings. 🔄