### PR TITLE
Fix tf.py `LoadImages()` dataloader return values

### DIFF
--- a/models/tf.py
+++ b/models/tf.py
@@ -411,7 +411,7 @@ class AgnosticNMS(keras.layers.Layer):
 
 def representative_dataset_gen(dataset, ncalib=100):
     # Representative dataset generator for use with converter.representative_dataset, returns a generator of np arrays
-    for n, (path, img, im0s, vid_cap) in enumerate(dataset):
+    for n, (path, img, im0s, vid_cap, string) in enumerate(dataset):
         input = np.transpose(img, [1, 2, 0])
         input = np.expand_dims(input, axis=0).astype(np.float32)
         input /= 255.0


### PR DESCRIPTION
Fix for https://github.com/ultralytics/yolov5/issues/5446#issuecomment-958059087

Additional LoadImages() dataloader 'string' return value defined in logging PR #4854. 

@zldrobit be aware PR #4854 may affect your other TF export tools based on `master` that use representative_dataset generator.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgrade of the representative dataset generator function with additional data handling.

### 📊 Key Changes
- Altered the tuple structure unpacked during dataset iteration to include a `string` element.

### 🎯 Purpose & Impact
- The change allows the generator to handle an additional `string` data point per dataset item. This could potentially enable more descriptive dataset outputs or support new features that rely on string-based data representation.
- Users may see improved dataset handling, particularly where a string identifier or descriptor is essential. However, this requires changes in dataset preparation to include the string component.