### PR TITLE
Remove `check_requirements(('tensorflow>=2.4.1',))`

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -94,7 +94,6 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
             import onnxruntime
             session = onnxruntime.InferenceSession(w, None)
     else:  # TensorFlow models
-        check_requirements(('tensorflow>=2.4.1',))
         import tensorflow as tf
         if pb:  # https://www.tensorflow.org/guide/migrate#a_graphpb_or_graphpbtxt
             def wrap_frozen_graph(gd, inputs, outputs):


### PR DESCRIPTION
`check_requirements()` is unreliable for large packages like torch and tensorflow that may have multiple installation routes (i.e. conda, pip, tensorflow-cpu, etc.)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model inference support in `detect.py`.

### 📊 Key Changes
- Removed the TensorFlow version check requirement in the detection script.

### 🎯 Purpose & Impact
- 🔨 Simplify the code by eliminating unnecessary TensorFlow version checks.
- 🚀 Potentially reduce import times and streamline the running process for TensorFlow users.
- 🤝 Enhances user experience by removing a step in the setup process for running detections with TensorFlow models.