### PR TITLE
precommit: isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     rev: 5.9.3
     hooks:
       - id: isort
-        name: imports
+        name: Sort imports
 
   # TODO
   #- repo: https://github.com/pre-commit/mirrors-yapf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,12 +30,11 @@ repos:
         args: [--py36-plus]
         name: Upgrade code
 
-  # TODO
-  #- repo: https://github.com/PyCQA/isort
-  #  rev: 5.9.3
-  #  hooks:
-  #    - id: isort
-  #      name: imports
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.9.3
+    hooks:
+      - id: isort
+        name: imports
 
   # TODO
   #- repo: https://github.com/pre-commit/mirrors-yapf

--- a/detect.py
+++ b/detect.py
@@ -24,8 +24,22 @@ ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.experimental import attempt_load
 from utils.datasets import LoadImages, LoadStreams
-from utils.general import apply_classifier, check_img_size, check_imshow, check_requirements, check_suffix, colorstr, \
-    increment_path, non_max_suppression, print_args, save_one_box, scale_coords, strip_optimizer, xyxy2xywh, LOGGER
+from utils.general import (
+    apply_classifier,
+    check_img_size,
+    check_imshow,
+    check_requirements,
+    check_suffix,
+    colorstr,
+    increment_path,
+    LOGGER,
+    non_max_suppression,
+    print_args,
+    save_one_box,
+    scale_coords,
+    strip_optimizer,
+    xyxy2xywh,
+)
 from utils.plots import Annotator, colors
 from utils.torch_utils import load_classifier, select_device, time_sync
 

--- a/detect.py
+++ b/detect.py
@@ -24,22 +24,9 @@ ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.experimental import attempt_load
 from utils.datasets import LoadImages, LoadStreams
-from utils.general import (
-    apply_classifier,
-    check_img_size,
-    check_imshow,
-    check_requirements,
-    check_suffix,
-    colorstr,
-    increment_path,
-    LOGGER,
-    non_max_suppression,
-    print_args,
-    save_one_box,
-    scale_coords,
-    strip_optimizer,
-    xyxy2xywh,
-)
+from utils.general import (LOGGER, apply_classifier, check_img_size, check_imshow, check_requirements, check_suffix,
+                           colorstr, increment_path, non_max_suppression, print_args, save_one_box, scale_coords,
+                           strip_optimizer, xyxy2xywh)
 from utils.plots import Annotator, colors
 from utils.torch_utils import load_classifier, select_device, time_sync
 

--- a/export.py
+++ b/export.py
@@ -42,8 +42,16 @@ from models.experimental import attempt_load
 from models.yolo import Detect
 from utils.activations import SiLU
 from utils.datasets import LoadImages
-from utils.general import check_dataset, check_img_size, check_requirements, colorstr, file_size, print_args, \
-    url2file, LOGGER
+from utils.general import (
+    check_dataset,
+    check_img_size,
+    check_requirements,
+    colorstr,
+    file_size,
+    LOGGER,
+    print_args,
+    url2file,
+)
 from utils.torch_utils import select_device
 
 
@@ -135,7 +143,8 @@ def export_saved_model(model, im, file, dynamic,
     try:
         import tensorflow as tf
         from tensorflow import keras
-        from models.tf import TFModel, TFDetect
+
+        from models.tf import TFDetect, TFModel
 
         LOGGER.info(f'\n{prefix} starting export with tensorflow {tf.__version__}...')
         f = str(file).replace('.pt', '_saved_model')
@@ -182,6 +191,7 @@ def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('Te
     # YOLOv5 TensorFlow Lite export
     try:
         import tensorflow as tf
+
         from models.tf import representative_dataset_gen
 
         LOGGER.info(f'\n{prefix} starting export with tensorflow {tf.__version__}...')
@@ -215,6 +225,7 @@ def export_tfjs(keras_model, im, file, prefix=colorstr('TensorFlow.js:')):
     try:
         check_requirements(('tensorflowjs',))
         import re
+
         import tensorflowjs as tfjs
 
         LOGGER.info(f'\n{prefix} starting export with tensorflowjs {tfjs.__version__}...')

--- a/export.py
+++ b/export.py
@@ -42,16 +42,8 @@ from models.experimental import attempt_load
 from models.yolo import Detect
 from utils.activations import SiLU
 from utils.datasets import LoadImages
-from utils.general import (
-    check_dataset,
-    check_img_size,
-    check_requirements,
-    colorstr,
-    file_size,
-    LOGGER,
-    print_args,
-    url2file,
-)
+from utils.general import (LOGGER, check_dataset, check_img_size, check_requirements, colorstr, file_size, print_args,
+                           url2file)
 from utils.torch_utils import select_device
 
 

--- a/hubconf.py
+++ b/hubconf.py
@@ -27,10 +27,10 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
     """
     from pathlib import Path
 
-    from models.yolo import Model
     from models.experimental import attempt_load
-    from utils.general import check_requirements, set_logging
+    from models.yolo import Model
     from utils.downloads import attempt_download
+    from utils.general import check_requirements, set_logging
     from utils.torch_utils import select_device
 
     file = Path(__file__).resolve()
@@ -125,10 +125,11 @@ if __name__ == '__main__':
     # model = custom(path='path/to/model.pt')  # custom
 
     # Verify inference
+    from pathlib import Path
+
     import cv2
     import numpy as np
     from PIL import Image
-    from pathlib import Path
 
     imgs = ['data/images/zidane.jpg',  # filename
             Path('data/images/zidane.jpg'),  # Path

--- a/models/common.py
+++ b/models/common.py
@@ -18,8 +18,15 @@ from PIL import Image
 from torch.cuda import amp
 
 from utils.datasets import exif_transpose, letterbox
-from utils.general import colorstr, increment_path, make_divisible, non_max_suppression, save_one_box, \
-    scale_coords, xyxy2xywh
+from utils.general import (
+    colorstr,
+    increment_path,
+    make_divisible,
+    non_max_suppression,
+    save_one_box,
+    scale_coords,
+    xyxy2xywh,
+)
 from utils.plots import Annotator, colors
 from utils.torch_utils import time_sync
 

--- a/models/common.py
+++ b/models/common.py
@@ -18,15 +18,8 @@ from PIL import Image
 from torch.cuda import amp
 
 from utils.datasets import exif_transpose, letterbox
-from utils.general import (
-    colorstr,
-    increment_path,
-    make_divisible,
-    non_max_suppression,
-    save_one_box,
-    scale_coords,
-    xyxy2xywh,
-)
+from utils.general import (colorstr, increment_path, make_divisible, non_max_suppression, save_one_box, scale_coords,
+                           xyxy2xywh)
 from utils.plots import Annotator, colors
 from utils.torch_utils import time_sync
 

--- a/models/experimental.py
+++ b/models/experimental.py
@@ -3,6 +3,7 @@
 Experimental modules
 """
 import math
+
 import numpy as np
 import torch
 import torch.nn as nn

--- a/models/tf.py
+++ b/models/tf.py
@@ -28,11 +28,11 @@ import torch
 import torch.nn as nn
 from tensorflow import keras
 
-from models.common import Bottleneck, BottleneckCSP, Concat, Conv, C3, DWConv, Focus, SPP, SPPF, autopad
-from models.experimental import CrossConv, MixConv2d, attempt_load
+from models.common import autopad, Bottleneck, BottleneckCSP, C3, Concat, Conv, DWConv, Focus, SPP, SPPF
+from models.experimental import attempt_load, CrossConv, MixConv2d
 from models.yolo import Detect
-from utils.general import make_divisible, print_args, LOGGER
 from utils.activations import SiLU
+from utils.general import LOGGER, make_divisible, print_args
 
 
 class TFBN(keras.layers.Layer):

--- a/models/tf.py
+++ b/models/tf.py
@@ -28,8 +28,8 @@ import torch
 import torch.nn as nn
 from tensorflow import keras
 
-from models.common import autopad, Bottleneck, BottleneckCSP, C3, Concat, Conv, DWConv, Focus, SPP, SPPF
-from models.experimental import attempt_load, CrossConv, MixConv2d
+from models.common import C3, SPP, SPPF, Bottleneck, BottleneckCSP, Concat, Conv, DWConv, Focus, autopad
+from models.experimental import CrossConv, MixConv2d, attempt_load
 from models.yolo import Detect
 from utils.activations import SiLU
 from utils.general import LOGGER, make_divisible, print_args

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -20,10 +20,17 @@ if str(ROOT) not in sys.path:
 from models.common import *
 from models.experimental import *
 from utils.autoanchor import check_anchor_order
-from utils.general import check_version, check_yaml, make_divisible, print_args, LOGGER
+from utils.general import check_version, check_yaml, LOGGER, make_divisible, print_args
 from utils.plots import feature_visualization
-from utils.torch_utils import copy_attr, fuse_conv_and_bn, initialize_weights, model_info, scale_img, \
-    select_device, time_sync
+from utils.torch_utils import (
+    copy_attr,
+    fuse_conv_and_bn,
+    initialize_weights,
+    model_info,
+    scale_img,
+    select_device,
+    time_sync,
+)
 
 try:
     import thop  # for FLOPs computation

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -20,17 +20,10 @@ if str(ROOT) not in sys.path:
 from models.common import *
 from models.experimental import *
 from utils.autoanchor import check_anchor_order
-from utils.general import check_version, check_yaml, LOGGER, make_divisible, print_args
+from utils.general import LOGGER, check_version, check_yaml, make_divisible, print_args
 from utils.plots import feature_visualization
-from utils.torch_utils import (
-    copy_attr,
-    fuse_conv_and_bn,
-    initialize_weights,
-    model_info,
-    scale_img,
-    select_device,
-    time_sync,
-)
+from utils.torch_utils import (copy_attr, fuse_conv_and_bn, initialize_weights, model_info, scale_img, select_device,
+                               time_sync)
 
 try:
     import thop  # for FLOPs computation

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,8 +46,6 @@ ignore =
 
 
 [isort]
+# https://pycqa.github.io/isort/docs/configuration/options.html
 line_length = 120
-order_by_type = False
-# 3 - Vertical Hanging Indent
-multi_line_output = 3
-include_trailing_comma = True
+multi_line_output = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,3 +43,11 @@ ignore =
     F403
     E302
     F541
+
+
+[isort]
+line_length = 120
+order_by_type = False
+# 3 - Vertical Hanging Indent
+multi_line_output = 3
+include_trailing_comma = True

--- a/train.py
+++ b/train.py
@@ -23,7 +23,7 @@ import torch.nn as nn
 import yaml
 from torch.cuda import amp
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.optim import Adam, SGD, lr_scheduler
+from torch.optim import Adam, lr_scheduler, SGD
 from tqdm import tqdm
 
 FILE = Path(__file__).resolve()
@@ -37,19 +37,43 @@ from models.experimental import attempt_load
 from models.yolo import Model
 from utils.autoanchor import check_anchors
 from utils.autobatch import check_train_batch_size
-from utils.datasets import create_dataloader
-from utils.general import labels_to_class_weights, increment_path, labels_to_image_weights, init_seeds, \
-    strip_optimizer, get_latest_run, check_dataset, check_git_status, check_img_size, check_requirements, \
-    check_file, check_yaml, check_suffix, print_args, print_mutation, one_cycle, colorstr, methods, LOGGER
-from utils.downloads import attempt_download
-from utils.loss import ComputeLoss
-from utils.plots import plot_labels, plot_evolve
-from utils.torch_utils import EarlyStopping, ModelEMA, de_parallel, intersect_dicts, select_device, \
-    torch_distributed_zero_first
-from utils.loggers.wandb.wandb_utils import check_wandb_resume
-from utils.metrics import fitness
-from utils.loggers import Loggers
 from utils.callbacks import Callbacks
+from utils.datasets import create_dataloader
+from utils.downloads import attempt_download
+from utils.general import (
+    check_dataset,
+    check_file,
+    check_git_status,
+    check_img_size,
+    check_requirements,
+    check_suffix,
+    check_yaml,
+    colorstr,
+    get_latest_run,
+    increment_path,
+    init_seeds,
+    labels_to_class_weights,
+    labels_to_image_weights,
+    LOGGER,
+    methods,
+    one_cycle,
+    print_args,
+    print_mutation,
+    strip_optimizer,
+)
+from utils.loggers import Loggers
+from utils.loggers.wandb.wandb_utils import check_wandb_resume
+from utils.loss import ComputeLoss
+from utils.metrics import fitness
+from utils.plots import plot_evolve, plot_labels
+from utils.torch_utils import (
+    de_parallel,
+    EarlyStopping,
+    intersect_dicts,
+    ModelEMA,
+    select_device,
+    torch_distributed_zero_first,
+)
 
 LOCAL_RANK = int(os.getenv('LOCAL_RANK', -1))  # https://pytorch.org/docs/stable/elastic/run.html
 RANK = int(os.getenv('RANK', -1))

--- a/train.py
+++ b/train.py
@@ -23,7 +23,7 @@ import torch.nn as nn
 import yaml
 from torch.cuda import amp
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.optim import Adam, lr_scheduler, SGD
+from torch.optim import SGD, Adam, lr_scheduler
 from tqdm import tqdm
 
 FILE = Path(__file__).resolve()
@@ -40,40 +40,17 @@ from utils.autobatch import check_train_batch_size
 from utils.callbacks import Callbacks
 from utils.datasets import create_dataloader
 from utils.downloads import attempt_download
-from utils.general import (
-    check_dataset,
-    check_file,
-    check_git_status,
-    check_img_size,
-    check_requirements,
-    check_suffix,
-    check_yaml,
-    colorstr,
-    get_latest_run,
-    increment_path,
-    init_seeds,
-    labels_to_class_weights,
-    labels_to_image_weights,
-    LOGGER,
-    methods,
-    one_cycle,
-    print_args,
-    print_mutation,
-    strip_optimizer,
-)
+from utils.general import (LOGGER, check_dataset, check_file, check_git_status, check_img_size, check_requirements,
+                           check_suffix, check_yaml, colorstr, get_latest_run, increment_path, init_seeds,
+                           labels_to_class_weights, labels_to_image_weights, methods, one_cycle, print_args,
+                           print_mutation, strip_optimizer)
 from utils.loggers import Loggers
 from utils.loggers.wandb.wandb_utils import check_wandb_resume
 from utils.loss import ComputeLoss
 from utils.metrics import fitness
 from utils.plots import plot_evolve, plot_labels
-from utils.torch_utils import (
-    de_parallel,
-    EarlyStopping,
-    intersect_dicts,
-    ModelEMA,
-    select_device,
-    torch_distributed_zero_first,
-)
+from utils.torch_utils import (EarlyStopping, ModelEMA, de_parallel, intersect_dicts, select_device,
+                               torch_distributed_zero_first)
 
 LOCAL_RANK = int(os.getenv('LOCAL_RANK', -1))  # https://pytorch.org/docs/stable/elastic/run.html
 RANK = int(os.getenv('RANK', -1))

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -10,7 +10,7 @@ import random
 import cv2
 import numpy as np
 
-from utils.general import colorstr, segment2box, resample_segments, check_version
+from utils.general import check_version, colorstr, resample_segments, segment2box
 from utils.metrics import bbox_ioa
 
 

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -12,7 +12,7 @@ import random
 import shutil
 import time
 from itertools import repeat
-from multiprocessing.pool import ThreadPool, Pool
+from multiprocessing.pool import Pool, ThreadPool
 from pathlib import Path
 from threading import Thread
 from zipfile import ZipFile
@@ -22,13 +22,23 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 import yaml
-from PIL import Image, ImageOps, ExifTags
+from PIL import ExifTags, Image, ImageOps
 from torch.utils.data import Dataset
 from tqdm import tqdm
 
 from utils.augmentations import Albumentations, augment_hsv, copy_paste, letterbox, mixup, random_perspective
-from utils.general import check_dataset, check_requirements, check_yaml, clean_str, segments2boxes, \
-    xywh2xyxy, xywhn2xyxy, xyxy2xywhn, xyn2xy, LOGGER
+from utils.general import (
+    check_dataset,
+    check_requirements,
+    check_yaml,
+    clean_str,
+    LOGGER,
+    segments2boxes,
+    xyn2xy,
+    xywh2xyxy,
+    xywhn2xyxy,
+    xyxy2xywhn,
+)
 from utils.torch_utils import torch_distributed_zero_first
 
 # Parameters

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -27,18 +27,8 @@ from torch.utils.data import Dataset
 from tqdm import tqdm
 
 from utils.augmentations import Albumentations, augment_hsv, copy_paste, letterbox, mixup, random_perspective
-from utils.general import (
-    check_dataset,
-    check_requirements,
-    check_yaml,
-    clean_str,
-    LOGGER,
-    segments2boxes,
-    xyn2xy,
-    xywh2xyxy,
-    xywhn2xyxy,
-    xyxy2xywhn,
-)
+from utils.general import (LOGGER, check_dataset, check_requirements, check_yaml, clean_str, segments2boxes, xyn2xy,
+                           xywh2xyxy, xywhn2xyxy, xyxy2xywhn)
 from utils.torch_utils import torch_distributed_zero_first
 
 # Parameters

--- a/utils/flask_rest_api/restapi.py
+++ b/utils/flask_rest_api/restapi.py
@@ -5,8 +5,8 @@ import argparse
 import io
 
 import torch
-from PIL import Image
 from flask import Flask, request
+from PIL import Image
 
 app = Flask(__name__)
 

--- a/utils/loggers/wandb/sweep.py
+++ b/utils/loggers/wandb/sweep.py
@@ -8,10 +8,10 @@ ROOT = FILE.parents[3]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
 
-from train import train, parse_opt
+from train import parse_opt, train
+from utils.callbacks import Callbacks
 from utils.general import increment_path
 from utils.torch_utils import select_device
-from utils.callbacks import Callbacks
 
 
 def sweep():

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -16,8 +16,7 @@ ROOT = FILE.parents[3]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
 
-from utils.datasets import LoadImagesAndLabels
-from utils.datasets import img2label_paths
+from utils.datasets import img2label_paths, LoadImagesAndLabels
 from utils.general import check_dataset, check_file
 
 try:

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -16,7 +16,7 @@ ROOT = FILE.parents[3]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
 
-from utils.datasets import img2label_paths, LoadImagesAndLabels
+from utils.datasets import LoadImagesAndLabels, img2label_paths
 from utils.general import check_dataset, check_file
 
 try:

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -17,7 +17,7 @@ import seaborn as sn
 import torch
 from PIL import Image, ImageDraw, ImageFont
 
-from utils.general import user_config_dir, is_ascii, is_chinese, xywh2xyxy, xyxy2xywh
+from utils.general import is_ascii, is_chinese, user_config_dir, xywh2xyxy, xyxy2xywh
 from utils.metrics import fitness
 
 # Settings

--- a/val.py
+++ b/val.py
@@ -26,24 +26,10 @@ ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 from models.experimental import attempt_load
 from utils.callbacks import Callbacks
 from utils.datasets import create_dataloader
-from utils.general import (
-    box_iou,
-    check_dataset,
-    check_img_size,
-    check_requirements,
-    check_suffix,
-    check_yaml,
-    coco80_to_coco91_class,
-    colorstr,
-    increment_path,
-    LOGGER,
-    non_max_suppression,
-    print_args,
-    scale_coords,
-    xywh2xyxy,
-    xyxy2xywh,
-)
-from utils.metrics import ap_per_class, ConfusionMatrix
+from utils.general import (LOGGER, box_iou, check_dataset, check_img_size, check_requirements, check_suffix, check_yaml,
+                           coco80_to_coco91_class, colorstr, increment_path, non_max_suppression, print_args,
+                           scale_coords, xywh2xyxy, xyxy2xywh)
+from utils.metrics import ConfusionMatrix, ap_per_class
 from utils.plots import output_to_target, plot_images, plot_val_study
 from utils.torch_utils import select_device, time_sync
 

--- a/val.py
+++ b/val.py
@@ -24,14 +24,28 @@ if str(ROOT) not in sys.path:
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.experimental import attempt_load
+from utils.callbacks import Callbacks
 from utils.datasets import create_dataloader
-from utils.general import box_iou, coco80_to_coco91_class, colorstr, check_dataset, check_img_size, \
-    check_requirements, check_suffix, check_yaml, increment_path, non_max_suppression, print_args, scale_coords, \
-    xyxy2xywh, xywh2xyxy, LOGGER
+from utils.general import (
+    box_iou,
+    check_dataset,
+    check_img_size,
+    check_requirements,
+    check_suffix,
+    check_yaml,
+    coco80_to_coco91_class,
+    colorstr,
+    increment_path,
+    LOGGER,
+    non_max_suppression,
+    print_args,
+    scale_coords,
+    xywh2xyxy,
+    xyxy2xywh,
+)
 from utils.metrics import ap_per_class, ConfusionMatrix
 from utils.plots import output_to_target, plot_images, plot_val_study
 from utils.torch_utils import select_device, time_sync
-from utils.callbacks import Callbacks
 
 
 def save_one_txt(predn, save_conf, shape, file):


### PR DESCRIPTION
use Isort as default import formatting
Partial alternative to #4983

This PR defines Isort as pre-commit hook and lets the bot fix it... rabbit

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR brings codebase improvements mainly by enlisting third-party tools for code clean-up and organizing imports.

### 📊 Key Changes
- Enabled `isort` tool in `.pre-commit-config.yaml` to automatically sort the imports.
- Refactoring import statements across multiple files like `detect.py`, `export.py`, `hubconf.py`, and others to be more organized and readable based on the `isort` standard.
- Set `isort` configuration in `setup.cfg`, specifying a line length of 120 characters and a single-line output for multiple imports.
- Reshuffling import statements and minor updates to spaces and blank lines to adhere to cleaner code standards.

### 🎯 Purpose & Impact
- The use of `isort` 🔄 ensures that the imports are consistently formatted, which makes the code easier to read and maintain.
- With better-structured imports, developers can understand dependencies at a glance 🧐.
- This can potentially reduce merge conflicts related to import lines for contributors in the future ✨.
- Streamlined code patterns contribute to a more stable and standardized codebase 🛠️.