### PR TITLE
Common `is_coco` logic betwen train.py and val.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -107,7 +107,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     nc = 1 if single_cls else int(data_dict['nc'])  # number of classes
     names = ['item'] if single_cls and len(data_dict['names']) != 1 else data_dict['names']  # class names
     assert len(names) == nc, f'{len(names)} names found for nc={nc} dataset in {data}'  # check
-    is_coco = data.endswith('coco.yaml') and nc == 80  # COCO dataset
+    is_coco = isinstance(val_path, str) and val_path.endswith('coco/val2017.txt')  # COCO dataset
 
     # Model
     check_suffix(weights, '.pt')  # check weights


### PR DESCRIPTION
Resolves https://github.com/ultralytics/yolov5/issues/3644

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to COCO dataset detection logic in training script.

### 📊 Key Changes
- Adjusted the method to identify if the COCO dataset is being used.
- Previously, checked if the data configuration ended with 'coco.yaml' and had 80 classes.
- Now, checks if the `val_path` is a string that ends with 'coco/val2017.txt'.

### 🎯 Purpose & Impact
- 🎨 Ensures more accurate detection of COCO dataset use by examining validation path.
- ⚙️ Potentially impacts users training models with COCO dataset, improving reliability for model setup.
- 🚀 Users can expect a more robust way of identifying the usage of COCO dataset, leading to fewer errors and assumptions during training.