### PR TITLE
Fix detect.py URL inference

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -24,10 +24,10 @@ if str(ROOT) not in sys.path:
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.experimental import attempt_load
-from utils.datasets import LoadImages, LoadStreams, IMG_FORMATS, VID_FORMATS
-from utils.general import (LOGGER, apply_classifier, check_img_size, check_imshow, check_requirements, check_suffix,
-                           colorstr, increment_path, non_max_suppression, print_args, save_one_box, scale_coords,
-                           strip_optimizer, xyxy2xywh, check_file)
+from utils.datasets import IMG_FORMATS, VID_FORMATS, LoadImages, LoadStreams
+from utils.general import (LOGGER, apply_classifier, check_file, check_img_size, check_imshow, check_requirements,
+                           check_suffix, colorstr, increment_path, non_max_suppression, print_args, save_one_box,
+                           scale_coords, strip_optimizer, xyxy2xywh)
 from utils.plots import Annotator, colors
 from utils.torch_utils import load_classifier, select_device, time_sync
 

--- a/detect.py
+++ b/detect.py
@@ -24,10 +24,10 @@ if str(ROOT) not in sys.path:
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.experimental import attempt_load
-from utils.datasets import LoadImages, LoadStreams
+from utils.datasets import LoadImages, LoadStreams, IMG_FORMATS, VID_FORMATS
 from utils.general import (LOGGER, apply_classifier, check_img_size, check_imshow, check_requirements, check_suffix,
                            colorstr, increment_path, non_max_suppression, print_args, save_one_box, scale_coords,
-                           strip_optimizer, xyxy2xywh)
+                           strip_optimizer, xyxy2xywh, check_file)
 from utils.plots import Annotator, colors
 from utils.torch_utils import load_classifier, select_device, time_sync
 
@@ -61,8 +61,11 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
         ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
-    webcam = source.isnumeric() or source.endswith('.txt') or source.lower().startswith(
-        ('rtsp://', 'rtmp://', 'http://', 'https://'))
+    is_file = Path(source).suffix[1:] in (IMG_FORMATS + VID_FORMATS)
+    is_url = source.lower().startswith(('rtsp://', 'rtmp://', 'http://', 'https://'))
+    webcam = source.isnumeric() or source.endswith('.txt') or (is_url and not is_file)
+    if is_url and is_file:
+        source = check_file(source)  # download
 
     # Directories
     save_dir = increment_path(Path(project) / name, exist_ok=exist_ok)  # increment run


### PR DESCRIPTION
Allows detect.py to run inference on remote URL sources, i.e.:

```python
!python detect.py --weights yolov5s.pt --source https://ultralytics.com/assets/zidane.jpg  # image URL
!python detect.py --weights yolov5s.pt --source https://ultralytics.com/assets/decelera_landscape.mov  # video URL
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced media source handling and format verification in the YOLOv5 detection script.

### 📊 Key Changes
- Added image and video format lists to detection utilities.
- Improved the clarity of the source type checking (webcam, file, or URL).
- Implemented automatic download of files from URLs if necessary.

### 🎯 Purpose & Impact
- 🎯 To streamline the process of identifying source types and handle them appropriately in the detection pipeline.
- 💡 Users benefit from more robust handling of various input source formats and the convenience of automatic file downloads when URLs are provided that point to valid media files.
- 🚀 Potential impact includes greater ease of use and a more user-friendly experience, especially for non-expert users not accustomed to manually downloading files for object detection tasks.