### PR TITLE
`intersect_dicts()` in hubconf.py fix

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -30,7 +30,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
     from models.experimental import attempt_load
     from models.yolo import Model
     from utils.downloads import attempt_download
-    from utils.general import check_requirements, set_logging
+    from utils.general import check_requirements, intersect_dicts, set_logging
     from utils.torch_utils import select_device
 
     file = Path(__file__).resolve()
@@ -49,9 +49,8 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
             model = Model(cfg, channels, classes)  # create model
             if pretrained:
                 ckpt = torch.load(attempt_download(path), map_location=device)  # load
-                msd = model.state_dict()  # model state_dict
                 csd = ckpt['model'].float().state_dict()  # checkpoint state_dict as FP32
-                csd = {k: v for k, v in csd.items() if msd[k].shape == v.shape}  # filter
+                csd = intersect_dicts(csd, model.state_dict(), exclude=['anchors'])  # intersect
                 model.load_state_dict(csd, strict=False)  # load
                 if len(ckpt['model'].names) == classes:
                     model.names = ckpt['model'].names  # set class names attribute

--- a/train.py
+++ b/train.py
@@ -43,15 +43,14 @@ from utils.datasets import create_dataloader
 from utils.downloads import attempt_download
 from utils.general import (LOGGER, check_dataset, check_file, check_git_status, check_img_size, check_requirements,
                            check_suffix, check_yaml, colorstr, get_latest_run, increment_path, init_seeds,
-                           labels_to_class_weights, labels_to_image_weights, methods, one_cycle, print_args,
-                           print_mutation, strip_optimizer)
+                           intersect_dicts, labels_to_class_weights, labels_to_image_weights, methods, one_cycle,
+                           print_args, print_mutation, strip_optimizer)
 from utils.loggers import Loggers
 from utils.loggers.wandb.wandb_utils import check_wandb_resume
 from utils.loss import ComputeLoss
 from utils.metrics import fitness
 from utils.plots import plot_evolve, plot_labels
-from utils.torch_utils import (EarlyStopping, ModelEMA, de_parallel, intersect_dicts, select_device,
-                               torch_distributed_zero_first)
+from utils.torch_utils import EarlyStopping, ModelEMA, de_parallel, select_device, torch_distributed_zero_first
 
 LOCAL_RANK = int(os.getenv('LOCAL_RANK', -1))  # https://pytorch.org/docs/stable/elastic/run.html
 RANK = int(os.getenv('RANK', -1))

--- a/utils/general.py
+++ b/utils/general.py
@@ -125,6 +125,11 @@ def init_seeds(seed=0):
     cudnn.benchmark, cudnn.deterministic = (False, True) if seed == 0 else (True, False)
 
 
+def intersect_dicts(da, db, exclude=()):
+    # Dictionary intersection of matching keys and shapes, omitting 'exclude' keys, using da values
+    return {k: v for k, v in da.items() if k in db and not any(x in k for x in exclude) and v.shape == db[k].shape}
+
+
 def get_latest_run(search_dir='.'):
     # Return path to most recent 'last.pt' in /runs (i.e. to --resume from)
     last_list = glob.glob(f'{search_dir}/**/last*.pt', recursive=True)

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -153,11 +153,6 @@ def de_parallel(model):
     return model.module if is_parallel(model) else model
 
 
-def intersect_dicts(da, db, exclude=()):
-    # Dictionary intersection of matching keys and shapes, omitting 'exclude' keys, using da values
-    return {k: v for k, v in da.items() if k in db and not any(x in k for x in exclude) and v.shape == db[k].shape}
-
-
 def initialize_weights(model):
     for m in model.modules():
         t = type(m)


### PR DESCRIPTION
Fix for https://github.com/ultralytics/yolov5/issues/2609#issuecomment-962461091
```python
import torch

for ch in 1, 3, 4, 10:
    model = torch.hub.load('ultralytics/yolov5', 'yolov5s', channels=ch)
    results = model(np.array((640, 640, ch)))
    results.print()
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactoring and cleanup of the intersection logic used in model state dict updates.

### 📊 Key Changes
- `intersect_dicts` function moved from `utils/torch_utils.py` to `utils/general.py`.
- Updated references to `intersect_dicts` in `hubconf.py` and `train.py` to reflect its new location.
- Now using `intersect_dicts` during model initialization in `hubconf.py` to filter checkpoint state_dict before loading.

### 🎯 Purpose & Impact
- This refactoring improves code modularity and maintainability by placing `intersect_dicts` in a more general utility file.
- It ensures that only relevant parts of the pretrained model checkpoints are loaded, preventing potential shape mismatches and excluding specific keys when necessary.
- Users will benefit from a more robust and error-resistant model loading process, potentially improving the ease of use and reliability of the YOLOv5 models.