### PR TITLE
Fix for *.yaml emojis on load

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -90,7 +90,7 @@ class Model(nn.Module):
         else:  # is *.yaml
             import yaml  # for torch hub
             self.yaml_file = Path(cfg).name
-            with open(cfg, errors='ignore') as f:
+            with open(cfg, encoding='ascii', errors='ignore') as f:
                 self.yaml = yaml.safe_load(f)  # model dict
 
         # Define model


### PR DESCRIPTION
Fix for Colab hub error:


```python
import yaml

with open('yolov5s.yaml', errors='ignore') as f:
     d = yaml.safe_load(f)  # model dict

print(d)

---------------------------------------------------------------------------
ReaderError                               Traceback (most recent call last)
<ipython-input-8-1150b5143073> in <module>()
      2 
      3 with open('yolov5s.yaml', errors='ignore') as f:
----> 4      d = yaml.safe_load(f)  # model dict
      5 
      6 print(d)

6 frames
/usr/local/lib/python3.7/dist-packages/yaml/reader.py in check_printable(self, data)
    142             position = self.index+(len(self.buffer)-self.pointer)+match.start()
    143             raise ReaderError(self.name, position, ord(character),
--> 144                     'unicode', "special characters are not allowed")
    145 
    146     def update(self, length):

ReaderError: unacceptable character #x1f680: special characters are not allowed
  in "yolov5s.yaml", position 9
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved file reading compatibility in YOLO model initialization.

### 📊 Key Changes
- Changed file opening method by specifying `encoding='ascii'` during YOLO model configuration file reading.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: Enhances compatibility with different system environments, ensuring files are read correctly regardless of the default system encoding.
- 💻 **Impact**: Users may experience fewer errors when initializing YOLO models, particularly on systems with non-ASCII default encodings. This small but crucial change can help in avoiding character encoding-related bugs.