### PR TITLE
Add `--conf-thres` >> 0.001 warning

### DIFF
--- a/val.py
+++ b/val.py
@@ -330,6 +330,8 @@ def main(opt):
     check_requirements(requirements=ROOT / 'requirements.txt', exclude=('tensorboard', 'thop'))
 
     if opt.task in ('train', 'val', 'test'):  # run normally
+        if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466
+            LOGGER.info(f'WARNING: confidence threshold {opt.conf_thres} >> 0.001 will produce invalid mAP values.')
         run(**vars(opt))
 
     elif opt.task == 'speed':  # speed benchmarks


### PR DESCRIPTION
Partially addresses invalid mAPs at higher confidence threshold issue https://github.com/ultralytics/yolov5/issues/1466.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved user warning for high confidence thresholds during validation.

### 📊 Key Changes
- Added a warning message that triggers when the confidence threshold (`conf_thres`) is set higher than 0.001.

### 🎯 Purpose & Impact
- **Ensures Clarity:** Alerts users to potential miscalculation of mean Average Precision (mAP) values when `conf_thres` is too high.
- **Enhances User Experience:** Prevents users from unintentionally using a threshold that may lead to incorrect validation results.
- **Supports Best Practices:** Encourages users to adhere to the recommended confidence threshold for accurate model validation.