### PR TITLE
Fix `check_requirements()` resource warning allocation open file

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -264,7 +264,8 @@ def check_requirements(requirements=ROOT / 'requirements.txt', exclude=(), insta
     if isinstance(requirements, (str, Path)):  # requirements.txt file
         file = Path(requirements)
         assert file.exists(), f"{prefix} {file.resolve()} not found, check failed."
-        requirements = [f'{x.name}{x.specifier}' for x in pkg.parse_requirements(file.open()) if x.name not in exclude]
+        with file.open() as fh:
+            requirements = [f'{x.name}{x.specifier}' for x in pkg.parse_requirements(fh) if x.name not in exclude]
     else:  # list or tuple of packages
         requirements = [x for x in requirements if x not in exclude]
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -264,8 +264,8 @@ def check_requirements(requirements=ROOT / 'requirements.txt', exclude=(), insta
     if isinstance(requirements, (str, Path)):  # requirements.txt file
         file = Path(requirements)
         assert file.exists(), f"{prefix} {file.resolve()} not found, check failed."
-        with file.open() as fh:
-            requirements = [f'{x.name}{x.specifier}' for x in pkg.parse_requirements(fh) if x.name not in exclude]
+        with file.open() as f:
+            requirements = [f'{x.name}{x.specifier}' for x in pkg.parse_requirements(f) if x.name not in exclude]
     else:  # list or tuple of packages
         requirements = [x for x in requirements if x not in exclude]
 


### PR DESCRIPTION
The file.open usage was throwing ResourceWarning Exceptions within our internal testing framework, tracked down to the unclosed file handler while checking the requirements.txt file.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in handling requirements file parsing in `utils/general.py`.

### 📊 Key Changes
- Shift from a direct file open approach to utilizing a context manager for reading `requirements.txt`.

### 🎯 Purpose & Impact
- **Purpose:** Ensure that the requirements file is properly closed after its contents are read, which adheres to best coding practices and avoids potential resource leaks.
- **Impact:** This update results in cleaner code and more reliable resource management, but it should not affect the functionality from the user's perspective. Maintainers and developers, however, will benefit from code that is more robust and maintainable. 👍🔒