### PR TITLE
Default DataLoader `shuffle=True` for training

### DIFF
--- a/train.py
+++ b/train.py
@@ -212,7 +212,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     train_loader, dataset = create_dataloader(train_path, imgsz, batch_size // WORLD_SIZE, gs, single_cls,
                                               hyp=hyp, augment=True, cache=opt.cache, rect=opt.rect, rank=LOCAL_RANK,
                                               workers=workers, image_weights=opt.image_weights, quad=opt.quad,
-                                              prefix=colorstr('train: '))
+                                              prefix=colorstr('train: '), shuffle=True)
     mlc = int(np.concatenate(dataset.labels, 0)[:, 0].max())  # max label class
     nb = len(train_loader)  # number of batches
     assert mlc < nc, f'Label class {mlc} exceeds nc={nc} in {data}. Possible class labels are 0-{nc - 1}'

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -22,7 +22,7 @@ import torch
 import torch.nn.functional as F
 import yaml
 from PIL import ExifTags, Image, ImageOps
-from torch.utils.data import Dataset, DataLoader, distributed, dataloader
+from torch.utils.data import DataLoader, Dataset, dataloader, distributed
 from tqdm import tqdm
 
 from utils.augmentations import Albumentations, augment_hsv, copy_paste, letterbox, mixup, random_perspective

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -97,7 +97,7 @@ def create_dataloader(path, imgsz, batch_size, stride, single_cls=False, hyp=Non
     if rect and shuffle:
         LOGGER.warning('WARNING: --rect is incompatible with Dataloader shuffle, setting shuffle=False')
         shuffle = False
-    with torch_distributed_zero_first(rank):  # Init dataset *.cache only once if DDP
+    with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
         dataset = LoadImagesAndLabels(path, imgsz, batch_size,
                                       augment=augment,  # augmentation
                                       hyp=hyp,  # hyperparameters

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -108,6 +108,7 @@ def create_dataloader(path, imgsz, batch_size, stride, single_cls=False, hyp=Non
                                       prefix=prefix)
 
     batch_size = min(batch_size, len(dataset))
+    shuffle = shuffle and not rect  # disable shuffle in rect mode to keep the dataset sorted by aspect ratio
     nw = min([os.cpu_count() // WORLD_SIZE, batch_size if batch_size > 1 else 0, workers])  # number of workers
     sampler = torch.utils.data.distributed.DistributedSampler(dataset, shuffle=shuffle) if rank != -1 else None
     loader = torch.utils.data.DataLoader if image_weights else InfiniteDataLoader

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -95,7 +95,7 @@ def exif_transpose(image):
 def create_dataloader(path, imgsz, batch_size, stride, single_cls=False, hyp=None, augment=False, cache=False, pad=0.0,
                       rect=False, rank=-1, workers=8, image_weights=False, quad=False, prefix='', shuffle=False):
     if rect and shuffle:
-        LOGGER.warning('WARNING: --rect is incompatible with Dataloader shuffle, setting shuffle=False')
+        LOGGER.warning('WARNING: --rect is incompatible with DataLoader shuffle, setting shuffle=False')
         shuffle = False
     with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
         dataset = LoadImagesAndLabels(path, imgsz, batch_size,
@@ -112,7 +112,7 @@ def create_dataloader(path, imgsz, batch_size, stride, single_cls=False, hyp=Non
     batch_size = min(batch_size, len(dataset))
     nw = min([os.cpu_count() // WORLD_SIZE, batch_size if batch_size > 1 else 0, workers])  # number of workers
     sampler = None if rank == -1 else distributed.DistributedSampler(dataset, shuffle=shuffle)
-    loader = DataLoader if image_weights else InfiniteDataLoader  # only Dataloader allows for attribute updates
+    loader = DataLoader if image_weights else InfiniteDataLoader  # only DataLoader allows for attribute updates
     return loader(dataset,
                   batch_size=batch_size,
                   shuffle=shuffle and sampler is None,

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -114,6 +114,7 @@ def create_dataloader(path, imgsz, batch_size, stride, single_cls=False, hyp=Non
     # Use torch.utils.data.DataLoader() if dataset.properties will update during training else InfiniteDataLoader()
     dataloader = loader(dataset,
                         batch_size=batch_size,
+                        shuffle=(sampler is None),
                         num_workers=nw,
                         sampler=sampler,
                         pin_memory=True,


### PR DESCRIPTION
If the issue https://github.com/ultralytics/yolov5/issues/5622 is relevant, I have added the `shuffle` argument to `create_dataloader`. It defaults to False and is set to True only when creating the training dataloader.
This shuffle parameter is then passed to the `DataLoader` or `DistributedSampler` to maintain a coherent behaviour. (in pytorch doc, shuffle defaults to False for DataLoader and to True for DistributedSampler)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced data loading with shuffle option for YOLOv5 training.

### 📊 Key Changes
- `train.py` now passes a `shuffle=True` argument to the data loader, enabling data shuffling during training.
- `create_dataloader` function in `utils/datasets.py` now accepts a `shuffle` argument.
- Rectangular training (`rect=True`) and shuffling are made mutually exclusive to avoid potential conflicts.
- Refactored the use of `DataLoader` and `InfiniteDataLoader` to allow attribute updates, with a conditional use of `DistributedSampler` based on rank.
- Adjusted imports in `utils/datasets.py` for clearer code structure.

### 🎯 Purpose & Impact
- Data shuffling is a common technique to improve model generalization and prevent overfitting, which can lead to better performance.
- By preventing the incompatible configuration of rectangular batches with shuffling, the PR ensures stable training behavior.
- The changes enhance scalability and usability for distributed training scenarios, potentially improving user experiences during training on various hardware setups.
- Overall, these modifications might contribute to more robust model performance and smoother user experiences with the YOLOv5 training pipeline.