### PR TITLE
Replace 2 `transpose()` with 1 `permute` in TransformerBlock()`

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -86,8 +86,8 @@ class TransformerBlock(nn.Module):
         if self.conv is not None:
             x = self.conv(x)
         b, _, w, h = x.shape
-        p = x.flatten(2).unsqueeze(0).transpose(0, 3).squeeze(3)
-        return self.tr(p + self.linear(p)).unsqueeze(3).transpose(0, 3).reshape(b, self.c2, w, h)
+        p = x.flatten(2).permute(2, 0, 1)
+        return self.tr(p + self.linear(p)).permute(1, 2, 0).reshape(b, self.c2, w, h)
 
 
 class Bottleneck(nn.Module):


### PR DESCRIPTION
As discussed in the comment of #2329, using `permute()` to change dimensions of the feature in `TransformerBlock` instead of 2 `transpose()`s looks more elegant and readable.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced tensor manipulation for efficiency in YOLOv5 models.

### 📊 Key Changes
- Replaced a sequence of tensor operations (`unsqueeze`, `transpose`, `squeeze`) with a single `permute` operation.
- Simplified tensor reshaping in forward method to improve code readability.

### 🎯 Purpose & Impact
- 🔍 **Clarity**: The new tensor operations are easier to understand.
- ⚡ **Performance**: Could potentially increase the efficiency of the model by using less memory-intensive tensor operations.
- 🛠 **Maintainability**: Simpler codebase for future updates and maintenance.