### PR TITLE
TFDetect dynamic anchor count assignment fix

### DIFF
--- a/models/tf.py
+++ b/models/tf.py
@@ -233,7 +233,7 @@ class TFDetect(keras.layers.Layer):
                 xy /= tf.constant([[self.imgsz[1], self.imgsz[0]]], dtype=tf.float32)
                 wh /= tf.constant([[self.imgsz[1], self.imgsz[0]]], dtype=tf.float32)
                 y = tf.concat([xy, wh, y[..., 4:]], -1)
-                z.append(tf.reshape(y, [-1, self.anchors.shape[1] * ny * nx, self.no]))
+                z.append(tf.reshape(y, [-1, self.na * ny * nx, self.no]))
 
         return x if self.training else (tf.concat(z, 1), x)
 

--- a/models/tf.py
+++ b/models/tf.py
@@ -16,12 +16,6 @@ import sys
 from copy import deepcopy
 from pathlib import Path
 
-FILE = Path(__file__).resolve()
-ROOT = FILE.parents[1]  # YOLOv5 root directory
-if str(ROOT) not in sys.path:
-    sys.path.append(str(ROOT))  # add ROOT to PATH
-# ROOT = ROOT.relative_to(Path.cwd())  # relative
-
 import numpy as np
 import tensorflow as tf
 import torch
@@ -33,6 +27,12 @@ from models.experimental import CrossConv, MixConv2d, attempt_load
 from models.yolo import Detect
 from utils.activations import SiLU
 from utils.general import LOGGER, make_divisible, print_args
+
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[1]  # YOLOv5 root directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # add ROOT to PATH
+# ROOT = ROOT.relative_to(Path.cwd())  # relative
 
 
 class TFBN(keras.layers.Layer):
@@ -233,7 +233,7 @@ class TFDetect(keras.layers.Layer):
                 xy /= tf.constant([[self.imgsz[1], self.imgsz[0]]], dtype=tf.float32)
                 wh /= tf.constant([[self.imgsz[1], self.imgsz[0]]], dtype=tf.float32)
                 y = tf.concat([xy, wh, y[..., 4:]], -1)
-                z.append(tf.reshape(y, [-1, 3 * ny * nx, self.no]))
+                z.append(tf.reshape(y, [-1, self.anchors.shape[1] * ny * nx, self.no]))
 
         return x if self.training else (tf.concat(z, 1), x)
 

--- a/models/tf.py
+++ b/models/tf.py
@@ -16,6 +16,12 @@ import sys
 from copy import deepcopy
 from pathlib import Path
 
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[1]  # YOLOv5 root directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # add ROOT to PATH
+# ROOT = ROOT.relative_to(Path.cwd())  # relative
+
 import numpy as np
 import tensorflow as tf
 import torch
@@ -27,12 +33,6 @@ from models.experimental import CrossConv, MixConv2d, attempt_load
 from models.yolo import Detect
 from utils.activations import SiLU
 from utils.general import LOGGER, make_divisible, print_args
-
-FILE = Path(__file__).resolve()
-ROOT = FILE.parents[1]  # YOLOv5 root directory
-if str(ROOT) not in sys.path:
-    sys.path.append(str(ROOT))  # add ROOT to PATH
-# ROOT = ROOT.relative_to(Path.cwd())  # relative
 
 
 class TFBN(keras.layers.Layer):


### PR DESCRIPTION
1. Currently the TFDetect layer is hardcoded to `3` anchors. change it to take care of a dynamic number of anchors in the model

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement to output tensor reshaping in TensorFlow model wrapper.

### 📊 Key Changes
- Modified the reshaping of the output tensor from `3 * ny * nx` to `self.na * ny * nx`.

### 🎯 Purpose & Impact
- **Purpose:** To fix the logic for reshaping the output tensor to correctly reflect the anchor boxes count (`self.na`) used in the object detection model.
- **Impact:** This change ensures accurate output dimensions, which is critical for proper functioning of object detection. It might affect downstream tasks such as object localization and classification performance. Users working with TensorFlow models will have more reliable output, potentially improving the model's overall predictions on image data.