### PR TITLE
`NUM_THREADS` leave at least 1 CPU free

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -35,7 +35,7 @@ HELP_URL = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
 IMG_FORMATS = ['bmp', 'jpg', 'jpeg', 'png', 'tif', 'tiff', 'dng', 'webp', 'mpo']  # acceptable image suffixes
 VID_FORMATS = ['mov', 'avi', 'mp4', 'mpg', 'mpeg', 'm4v', 'wmv', 'mkv']  # acceptable video suffixes
 WORLD_SIZE = int(os.getenv('WORLD_SIZE', 1))  # DPP
-NUM_THREADS = min(8, os.cpu_count())  # number of multiprocessing threads
+NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of multiprocessing threads
 
 # Get orientation exif tag
 for orientation in ExifTags.TAGS.keys():


### PR DESCRIPTION
Updated strategy leaves at least 1 cpu free to avoid system overloads. Partially addresses https://github.com/ultralytics/yolov5/issues/5685

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved CPU usage by optimizing the number of utilised threads in data processing.

### 📊 Key Changes
- The computation of `NUM_THREADS` now reserves one CPU core by subtracting one from `os.cpu_count()`.

### 🎯 Purpose & Impact
- 👩‍💻 **Purpose:** To prevent the system from becoming unresponsive by avoiding the use of all CPU cores for data processing tasks.
- 💻 **Impact:** Users may experience smoother multitasking on their systems while running YOLOv5 processes, as there is now a dedicated CPU core for handling other tasks.