### PR TITLE
workaround when reading broken video frames

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -199,6 +199,16 @@ class LoadImages:
             # Read video
             self.mode = 'video'
             ret_val, img0 = self.cap.read()
+
+            if not ret_val and self.frame < self.frames - 1:
+                fake_frame_skip = 1000
+                while not ret_val and fake_frame_skip > 0:
+                    fake_frame_skip -= 1
+                    ret_val, img0 = self.cap.read()
+                if not ret_val:
+                    raise Exception(
+                        f'Video stream ended unexpectedly. See this issue for details: https://github.com/ultralytics/yolov5/issues/2064')
+
             while not ret_val:
                 self.count += 1
                 self.cap.release()


### PR DESCRIPTION
Some videos are being read with additional fake/broken frames that may
cause an unexpected early exit. This attempts to skip over these broken
frames if more were expected, based on the initally acquired frame
count.

According to other reports upstream, the number of broken frames read
varies. To avoid getting stuck in an endless loop, e.g. when the video
is actually broken, this gives up after 1000 reads.

see https://github.com/ultralytics/yolov5/issues/2064
see https://github.com/opencv/opencv/issues/15352

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving video stream handling in YOLOv5's dataset utility.

### 📊 Key Changes
- Added a check to see if a video frame is not received despite the video not having ended.
- Attempt to skip up to 1000 frames if a frame is not properly read, rather than failing immediately.
- Raise an exception with a helpful error message linking to an existing GitHub issue if video reading issues persist.

### 🎯 Purpose & Impact
- 🛠️ **Prevents premature video stream interruption**: Helps to ensure that video streams are processed entirely, only raising an error if frames continue to be unreadable.
- 🔄 **Introduces retries for reading frames**: Decreases the likelihood of an entire video stream failing due to intermittent read errors.
- 📚 **Provides better error information**: Users encountering video stream issues will have a reference to a GitHub issue for more context and potential solutions.

The changes should make YOLOv5 more robust in handling video data, leading to a smoother user experience and less time troubleshooting video input issues.