### PR TITLE
Do not save hyp.yaml and opt.yaml on evolve

### DIFF
--- a/train.py
+++ b/train.py
@@ -76,13 +76,14 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     LOGGER.info(colorstr('hyperparameters: ') + ', '.join(f'{k}={v}' for k, v in hyp.items()))
 
     # Save run settings
-    with open(save_dir / 'hyp.yaml', 'w') as f:
-        yaml.safe_dump(hyp, f, sort_keys=False)
-    with open(save_dir / 'opt.yaml', 'w') as f:
-        yaml.safe_dump(vars(opt), f, sort_keys=False)
-    data_dict = None
+    if not evolve:
+        with open(save_dir / 'hyp.yaml', 'w') as f:
+            yaml.safe_dump(hyp, f, sort_keys=False)
+        with open(save_dir / 'opt.yaml', 'w') as f:
+            yaml.safe_dump(vars(opt), f, sort_keys=False)
 
     # Loggers
+    data_dict = None
     if RANK in [-1, 0]:
         loggers = Loggers(save_dir, weights, opt, hyp, LOGGER)  # loggers instance
         if loggers.wandb:

--- a/utils/general.py
+++ b/utils/general.py
@@ -777,7 +777,7 @@ def print_mutation(results, hyp, save_dir, bucket):
         i = np.argmax(fitness(data.values[:, :7]))  #
         f.write('# YOLOv5 Hyperparameter Evolution Results\n' +
                 f'# Best generation: {i}\n' +
-                f'# Last generation: {len(data)}\n' +
+                f'# Last generation: {len(data) - 1}\n' +
                 '# ' + ', '.join(f'{x.strip():>20s}' for x in keys[:7]) + '\n' +
                 '# ' + ', '.join(f'{x:>20.5g}' for x in data.values[i, :7]) + '\n\n')
         yaml.safe_dump(hyp, f, sort_keys=False)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to configuration saving in training script and fix to generation indexing in hyperparameter evolution logging.

### 📊 Key Changes
- Conditional saving of `hyp.yaml` and `opt.yaml` files to exclude them during hyperparameter evolution (`evolve`).
- Correctly adjusted the index for displaying the last generation number in hyperparameter evolution results output.

### 🎯 Purpose & Impact
- The conditional saving prevents unnecessary overwriting of hyperparameter files when performing evolution, which can protect evolved configuration sets from being replaced. 🛡️
- The adjustment to the last generation index ensures the accurate representation of generations, enhancing user comprehension of the evolution process. 🧬

These changes aim to refine the training process and maintain clarity in the hyperparameter evolution procedure for users and developers alike.