### PR TITLE
Update `dataset_stats()` to `cv2.INTER_AREA`

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -974,7 +974,7 @@ def dataset_stats(path='coco128.yaml', autodownload=False, verbose=False, profil
             im_height, im_width = im.shape[:2]
             r = max_dim / max(im_height, im_width)  # ratio
             if r < 1.0:  # image too large
-                im = cv2.resize(im, (int(im_width * r), int(im_height * r)), interpolation=cv2.INTER_LINEAR)
+                im = cv2.resize(im, (int(im_width * r), int(im_height * r)), interpolation=cv2.INTER_AREA)
             cv2.imwrite(str(f_new), im)
 
     zipped, data_dir, yaml_path = unzip(Path(path))


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimizing image resizing method for better quality and efficiency.

### 📊 Key Changes
- Switched the image resizing interpolation method from `cv2.INTER_LINEAR` to `cv2.INTER_AREA`.

### 🎯 Purpose & Impact
- The new interpolation method `cv2.INTER_AREA` is better for downsizing images, providing higher quality results.
- Users should see an improvement in image clarity when using the YOLOv5 model for processing large images that need to be resized.
- Potentially could lead to slightly improved object detection accuracy due to better image quality.