### PR TITLE
Fix TensorRT potential unordered binding addresses

### DIFF
--- a/export.py
+++ b/export.py
@@ -276,7 +276,7 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
         assert onnx.exists(), f'failed to export ONNX file: {onnx}'
 
         LOGGER.info(f'\n{prefix} starting export with TensorRT {trt.__version__}...')
-        f = str(file).replace('.pt', '.engine')  # TensorRT engine file
+        f = file.with_suffix('.engine')  # TensorRT engine file
         logger = trt.Logger(trt.Logger.INFO)
         if verbose:
             logger.min_severity = trt.Logger.Severity.VERBOSE
@@ -309,6 +309,7 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
 
     except Exception as e:
         LOGGER.info(f'\n{prefix} export failure: {e}')
+
 
 @torch.no_grad()
 def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'

--- a/models/common.py
+++ b/models/common.py
@@ -333,7 +333,7 @@ class DetectMultiBackend(nn.Module):
                 shape = tuple(model.get_binding_shape(index))
                 data = torch.from_numpy(np.empty(shape, dtype=np.dtype(dtype))).to(device)
                 bindings[name] = Binding(name, dtype, shape, data, int(data.data_ptr()))
-            binding_addrs = OrderedDict({n: d.ptr for n, d in bindings.items()})
+            binding_addrs = OrderedDict((n, d.ptr) for n, d in bindings.items())
             context = model.create_execution_context()
             batch_size = bindings['images'].shape[0]
         else:  # TensorFlow model (TFLite, pb, saved_model)

--- a/models/common.py
+++ b/models/common.py
@@ -7,7 +7,7 @@ import json
 import math
 import platform
 import warnings
-from collections import namedtuple
+from collections import OrderedDict, namedtuple
 from copy import copy
 from pathlib import Path
 
@@ -326,14 +326,14 @@ class DetectMultiBackend(nn.Module):
             logger = trt.Logger(trt.Logger.INFO)
             with open(w, 'rb') as f, trt.Runtime(logger) as runtime:
                 model = runtime.deserialize_cuda_engine(f.read())
-            bindings = dict()
+            bindings = OrderedDict()
             for index in range(model.num_bindings):
                 name = model.get_binding_name(index)
                 dtype = trt.nptype(model.get_binding_dtype(index))
                 shape = tuple(model.get_binding_shape(index))
                 data = torch.from_numpy(np.empty(shape, dtype=np.dtype(dtype))).to(device)
                 bindings[name] = Binding(name, dtype, shape, data, int(data.data_ptr()))
-            binding_addrs = {n: d.ptr for n, d in bindings.items()}
+            binding_addrs = OrderedDict({n: d.ptr for n, d in bindings.items()})
             context = model.create_execution_context()
             batch_size = bindings['images'].shape[0]
         else:  # TensorFlow model (TFLite, pb, saved_model)


### PR DESCRIPTION
Hi, the `execute_v2` API of `TensorRT` expects the input binding address keep the same order as they read from the engine file. So I think it is better to use `OrderedDict` for bindings managemnt.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of file operations and ordered data handling in YOLOv5 export processes.

### 📊 Key Changes
- 🛠 Switched from string manipulation to pathlib `with_suffix` method for file extension replacement.
- 🏗 Replaced standard dictionary with `OrderedDict` to maintain the order of bindings in TensorRT models.

### 🎯 Purpose & Impact
- 💼 The use of `file.with_suffix('.engine')` improves code readability and maintainability.
- 📈 Using `OrderedDict` ensures consistent ordering, which may be crucial for frameworks expecting inputs in a specific order, resulting in more reliable model execution.
- 🚀 These changes contribute to code robustness and can enhance the compatibility and performance of model exports, benefiting developers and users deploying YOLOv5 models with TensorRT.