### PR TITLE
Avoid inplace modifying`imgs` in `LoadStreams`

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -337,7 +337,7 @@ class LoadStreams:
                     self.imgs[i] = im
                 else:
                     LOGGER.warning('WARNING: Video stream unresponsive, please check your IP camera connection.')
-                    self.imgs[i] *= 0
+                    self.imgs[i] = np.zeros_like(self.imgs[i])
                     cap.open(stream)  # re-open stream if signal was lost
             time.sleep(1 / self.fps[i])  # wait time
 


### PR DESCRIPTION
When OpenCV retrieving image fail, original code would modify source images **inplace**, which may result in plotting bounding box on a black image. That is, before inference, source image `im0s[i]` is OK, but after inference before code block `Process predictions` in `detect.py`,  `im0s[i]` may already have been changed to zeros by threads in `LoadStreams`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced stability for handling unresponsive video streams in YOLOv5.

### 📊 Key Changes
- Replaced in-place zeroing of images with a call to `np.zeros_like` when video streams become unresponsive.

### 🎯 Purpose & Impact
- 🚀 Aim to improve the robustness of video stream error handling.
- 🛠️ Provides a clearer and more standard approach to resetting images.
- ⚙️ Ensures consistent image dimensions and data type during errors, which could prevent potential issues in downstream processing.
- 📹 Users can expect better performance when dealing with IP camera connections that temporarily fail.