### PR TITLE
Add `--workers 8` argument to val.py

### DIFF
--- a/val.py
+++ b/val.py
@@ -89,6 +89,7 @@ def run(data,
         iou_thres=0.6,  # NMS IoU threshold
         task='val',  # train, val, test, speed or study
         device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
+        workers=8,
         single_cls=False,  # treat as single-class dataset
         augment=False,  # augmented inference
         verbose=False,  # verbose output
@@ -152,7 +153,7 @@ def run(data,
         model.warmup(imgsz=(1, 3, imgsz, imgsz), half=half)  # warmup
         pad = 0.0 if task == 'speed' else 0.5
         task = task if task in ('train', 'val', 'test') else 'val'  # path to train/val/test images
-        dataloader = create_dataloader(data[task], imgsz, batch_size, stride, single_cls, pad=pad, rect=pt,
+        dataloader = create_dataloader(data[task], imgsz, batch_size, stride, single_cls, pad=pad, rect=pt, workers=workers,
                                        prefix=colorstr(f'{task}: '))[0]
 
     seen = 0
@@ -312,6 +313,7 @@ def parse_opt():
     parser.add_argument('--iou-thres', type=float, default=0.6, help='NMS IoU threshold')
     parser.add_argument('--task', default='val', help='train, val, test, speed or study')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
+    parser.add_argument('--workers', type=int, default=8, help='max dataloader workers (per RANK in DDP mode)')
     parser.add_argument('--single-cls', action='store_true', help='treat as single-class dataset')
     parser.add_argument('--augment', action='store_true', help='augmented inference')
     parser.add_argument('--verbose', action='store_true', help='report mAP by class')

--- a/val.py
+++ b/val.py
@@ -89,7 +89,7 @@ def run(data,
         iou_thres=0.6,  # NMS IoU threshold
         task='val',  # train, val, test, speed or study
         device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
-        workers=8,
+        workers=8,  # max dataloader workers (per RANK in DDP mode)
         single_cls=False,  # treat as single-class dataset
         augment=False,  # augmented inference
         verbose=False,  # verbose output

--- a/val.py
+++ b/val.py
@@ -153,8 +153,8 @@ def run(data,
         model.warmup(imgsz=(1, 3, imgsz, imgsz), half=half)  # warmup
         pad = 0.0 if task == 'speed' else 0.5
         task = task if task in ('train', 'val', 'test') else 'val'  # path to train/val/test images
-        dataloader = create_dataloader(data[task], imgsz, batch_size, stride, single_cls, pad=pad, rect=pt, workers=workers,
-                                       prefix=colorstr(f'{task}: '))[0]
+        dataloader = create_dataloader(data[task], imgsz, batch_size, stride, single_cls, pad=pad, rect=pt,
+                                       workers=workers, prefix=colorstr(f'{task}: '))[0]
 
     seen = 0
     confusion_matrix = ConfusionMatrix(nc=nc)


### PR DESCRIPTION
Add an option to choose number of workers if not called by train.py

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing adjustable dataloader worker support for improved dataloading efficiency! 🚀

### 📊 Key Changes
- Added a new `workers` parameter to the `run` function in `val.py`. 🧑‍🔧
- Incorporated the `workers` argument in the `create_dataloader` function call. 🔄
- Provided the option to set the number of dataloader workers via command-line with a new `--workers` flag. 🖥️

### 🎯 Purpose & Impact
- The `workers` parameter can optimize data loading times, potentially speeding up the validation/inference process. ⏱️
- By allowing users to configure the number of workers, the data pipeline can be adapted to the capabilities of their system (e.g., CPU cores available), providing more flexibility and efficiency. 🛠️
- This change can enhance overall performance on various hardware configurations, improving user experience when running validation tasks. 📈