### PR TITLE
Single-command multiple-model export

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $ python train.py --data coco.yaml --cfg yolov5s.yaml --weights '' --batch-size 
 * [Roboflow for Datasets, Labeling, and Active Learning](https://github.com/ultralytics/yolov5/issues/4975)&nbsp; 🌟 NEW
 * [Multi-GPU Training](https://github.com/ultralytics/yolov5/issues/475)
 * [PyTorch Hub](https://github.com/ultralytics/yolov5/issues/36)&nbsp; ⭐ NEW
-* [TorchScript, ONNX, CoreML Export](https://github.com/ultralytics/yolov5/issues/251) 🚀
+* [TFLite, ONNX, CoreML, TensorRT Export](https://github.com/ultralytics/yolov5/issues/251) 🚀
 * [Test-Time Augmentation (TTA)](https://github.com/ultralytics/yolov5/issues/303)
 * [Model Ensembling](https://github.com/ultralytics/yolov5/issues/318)
 * [Model Pruning/Sparsity](https://github.com/ultralytics/yolov5/issues/304)

--- a/export.py
+++ b/export.py
@@ -400,7 +400,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
 def parse_opt():
     parser = argparse.ArgumentParser()
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
-    parser.add_argument('--weights', type=str, default=ROOT / 'yolov5s.pt', help='weights path')
+    parser.add_argument('--weights', nargs='+', type=str, default=ROOT / 'yolov5s.pt', help='model.pt path(s)')
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[640, 640], help='image (h, w)')
     parser.add_argument('--batch-size', type=int, default=1, help='batch size')
     parser.add_argument('--device', default='cpu', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
@@ -427,7 +427,8 @@ def parse_opt():
 
 
 def main(opt):
-    run(**vars(opt))
+    for opt.weights in (opt.weights if isinstance(opt.weights, list) else [opt.weights]):
+        run(**vars(opt))
 
 
 if __name__ == "__main__":

--- a/export.py
+++ b/export.py
@@ -2,17 +2,17 @@
 """
 Export a YOLOv5 PyTorch model to other formats. TensorFlow exports authored by https://github.com/zldrobit
 
-Format                  | Example                   | Export `include=(...)` argument
+Format                  | Example                   | `--include ...` argument
 ---                     | ---                       | ---
 PyTorch                 | yolov5s.pt                | -
-TorchScript             | yolov5s.torchscript       | 'torchscript'
-ONNX                    | yolov5s.onnx              | 'onnx'
-CoreML                  | yolov5s.mlmodel           | 'coreml'
-TensorFlow SavedModel   | yolov5s_saved_model/      | 'saved_model'
-TensorFlow GraphDef     | yolov5s.pb                | 'pb'
-TensorFlow Lite         | yolov5s.tflite            | 'tflite'
-TensorFlow.js           | yolov5s_web_model/        | 'tfjs'
-TensorRT                | yolov5s.engine            | 'engine'
+TorchScript             | yolov5s.torchscript       | `torchscript`
+ONNX                    | yolov5s.onnx              | `onnx`
+CoreML                  | yolov5s.mlmodel           | `coreml`
+TensorFlow SavedModel   | yolov5s_saved_model/      | `saved_model`
+TensorFlow GraphDef     | yolov5s.pb                | `pb`
+TensorFlow Lite         | yolov5s.tflite            | `tflite`
+TensorFlow.js           | yolov5s_web_model/        | `tfjs`
+TensorRT                | yolov5s.engine            | `engine`
 
 Usage:
     $ python path/to/export.py --weights yolov5s.pt --include torchscript onnx coreml saved_model pb tflite tfjs


### PR DESCRIPTION
Export multiple models in series by adding additional `*.pt` files to the `--weights` argument, i.e.:

```bash
python export.py --include tflite --weights yolov5n.pt  # export 1 model
python export.py --include tflite --weights yolov5n.pt yolov5s.pt yolov5m.pt  # export 3 models
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR refines the argument interface for exporting models and updates the README.

### 📊 Key Changes
- Changed the export format documentation in `export.py`, opting for `--include ...` style over `include=(...)`.
- Updated the `--weights` argument in `export.py` to accept multiple paths, allowing the export of several models in a batch.

### 🎯 Purpose & Impact
- Streamlines user experience by making the export command more intuitive with the `--include` flag. 🛠️
- Enhances functionality by enabling batch export of models, improving efficiency for users that work with multiple models. 🔄
- Directly impacts users involved in model exporting, offering a more flexible command-line interface. 🔧