### PR TITLE
update detect.py for videos start index

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ $ python detect.py --source 0  # webcam
                             path/*.jpg  # glob
                             'https://youtu.be/Zgi9g1ksQHc'  # YouTube
                             'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP stream
+
+
+$ python path/to/detect.py --weights yolov5s.pt --source  path/*.mp4 or avi  # directory
+                                                 --start your_video_start_index
 ```
 
 </details>

--- a/detect.py
+++ b/detect.py
@@ -61,6 +61,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
         hide_conf=False,  # hide confidences
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
+        start=0,
         ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
@@ -92,7 +93,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
         dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt)
         bs = len(dataset)  # batch_size
     else:
-        dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt)
+        dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt, video_start_idx=start)
         bs = 1  # batch_size
     vid_path, vid_writer = [None] * bs, [None] * bs
 
@@ -227,6 +228,7 @@ def parse_opt():
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
+    parser.add_argument('--start', default=0, help=' Your test video start index. If you want to test some videos, you can try it.')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(FILE.stem, opt)

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -200,7 +200,7 @@ class LoadImages:
             # Read video
             self.mode = 'video'
             ret_val, img0 = self.cap.read()
-            if not ret_val:
+            while not ret_val:
                 self.count += 1
                 self.cap.release()
                 if self.count == self.nf:  # last video

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -158,7 +158,7 @@ class _RepeatSampler:
 
 class LoadImages:
     # YOLOv5 image/video dataloader, i.e. `python detect.py --source image.jpg/vid.mp4`
-    def __init__(self, path, img_size=640, stride=32, auto=True):
+    def __init__(self, path, img_size=640, stride=32, auto=True, video_start_idx=0):
         p = str(Path(path).resolve())  # os-agnostic absolute path
         if '*' in p:
             files = sorted(glob.glob(p, recursive=True))  # glob
@@ -180,20 +180,27 @@ class LoadImages:
         self.video_flag = [False] * ni + [True] * nv
         self.mode = 'image'
         self.auto = auto
+        self.video_start_idx = video_start_idx
         if any(videos):
-            self.new_video(videos[0])  # new video
+            try:
+                self.new_video(videos[self.video_start_idx])  # new video
+            except:
+                self.new_video(videos[0])  # new video
         else:
             self.cap = None
         assert self.nf > 0, f'No images or videos found in {p}. ' \
                             f'Supported formats are:\nimages: {IMG_FORMATS}\nvideos: {VID_FORMATS}'
 
     def __iter__(self):
-        self.count = 0
+        self.count = self.video_start_idx
+        # self.count = 0
         return self
 
     def __next__(self):
         if self.count == self.nf:
             raise StopIteration
+        while self.count < self.video_start_idx:
+            self.count += 1
         path = self.files[self.count]
 
         if self.video_flag[self.count]:


### PR DESCRIPTION
update detect.py for videos start index

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced video processing in YOLOv5 with a customizable video start index.

### 📊 Key Changes
- 🔄 Added a new `--start` argument to the detect.py script and README.
- 📹 Modified the LoadImages class to accept a start index for video processing.
- 🔧 Updated the video handling logic to start processing from a user-defined index.

### 🎯 Purpose & Impact
- 🎬 Allows users to start video inference at a specific frame, saving time and resources when not all frames need analyzing.
- 🚀 Enhances YOLOv5's usability for videos, potentially broadening its applications in video analysis tasks.
- 🛠️ Offers a more flexible tool for developers and end-users working with video data.