### PR TITLE
Add *.engine (TensorRT extensions) to .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@ data/samples/*
 **/*.pt
 **/*.pth
 **/*.onnx
+**/*.engine
 **/*.mlmodel
 **/*.torchscript
 **/*.torchscript.pt

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ VOC/
 *.pt
 *.pb
 *.onnx
+*.engine
 *.mlmodel
 *.torchscript
 *.tflite


### PR DESCRIPTION
Add .engine files in the .gitignore due to PR #5699

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgraded `.gitignore` and `.dockerignore` for better file management 🚀

### 📊 Key Changes
- Added `*.engine` files to both `.gitignore` and `.dockerignore`.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: Prevents NVIDIA TensorRT engine files from cluttering the repository and Docker images.
- 🧹 **Impact**: Keeps the codebase and Docker context cleaner, reducing the chance of accidentally committing or including unnecessary binary files. This can lead to smaller Docker image sizes and a cleaner development environment.