### PR TITLE
Add ONNX inference providers

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -320,9 +320,11 @@ class DetectMultiBackend(nn.Module):
             net = cv2.dnn.readNetFromONNX(w)
         elif onnx:  # ONNX Runtime
             LOGGER.info(f'Loading {w} for ONNX Runtime inference...')
-            check_requirements(('onnx', 'onnxruntime-gpu' if torch.cuda.is_available() else 'onnxruntime'))
+            cuda = torch.cuda.is_available()
+            check_requirements(('onnx', 'onnxruntime-gpu' if cuda else 'onnxruntime'))
             import onnxruntime
-            session = onnxruntime.InferenceSession(w, providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
+            providers = ['CUDAExecutionProvider', 'CPUExecutionProvider'] if cuda else ['CPUExecutionProvider']
+            session = onnxruntime.InferenceSession(w, providers=providers)
         elif engine:  # TensorRT
             LOGGER.info(f'Loading {w} for TensorRT inference...')
             import tensorrt as trt  # https://developer.nvidia.com/nvidia-tensorrt-download

--- a/models/common.py
+++ b/models/common.py
@@ -322,7 +322,7 @@ class DetectMultiBackend(nn.Module):
             LOGGER.info(f'Loading {w} for ONNX Runtime inference...')
             check_requirements(('onnx', 'onnxruntime-gpu' if torch.cuda.is_available() else 'onnxruntime'))
             import onnxruntime
-            session = onnxruntime.InferenceSession(w, None)
+            session = onnxruntime.InferenceSession(w, providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
         elif engine:  # TensorRT
             LOGGER.info(f'Loading {w} for TensorRT inference...')
             import tensorrt as trt  # https://developer.nvidia.com/nvidia-tensorrt-download


### PR DESCRIPTION
Fix for https://github.com/ultralytics/yolov5/issues/5916

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of ONNX Runtime inference support in YOLOv5.

### 📊 Key Changes
- Added a check for the presence of a CUDA-enabled GPU when determining requirements for ONNX Runtime.
- Specified provider order for ONNX Runtime inference, prioritizing CUDA if available.

### 🎯 Purpose & Impact
- **Enhanced Compatibility**: By checking for a GPU, the model only requests GPU dependencies if one is available, preventing unnecessary installation of GPU-related packages on systems without a GPU.
- **Optimized Inference**: Specifying `CUDAExecutionProvider` before `CPUExecutionProvider` ensures that ONNX Runtime will use the GPU for inference if one is present, leading to faster inference times for users with compatible hardware. 🚀
- **User Experience**: This update makes it smoother for users to deploy YOLOv5 models, as it automatically adjusts to their system's capabilities. 🖥️💨