### PR TITLE
Make `select_device()` robust to `batch_size=-1`

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -68,7 +68,7 @@ def select_device(device='', batch_size=None, newline=True):
     if cuda:
         devices = device.split(',') if device else '0'  # range(torch.cuda.device_count())  # i.e. 0,1,6,7
         n = len(devices)  # device count
-        if n > 1 and batch_size:  # check batch_size is divisible by device_count
+        if n > 1 and batch_size > 0:  # check batch_size is divisible by device_count
             assert batch_size % n == 0, f'batch-size {batch_size} not multiple of GPU count {n}'
         space = ' ' * (len(s) + 1)
         for i, d in enumerate(devices):

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -53,7 +53,7 @@ def git_describe(path=Path(__file__).parent):  # path must be a directory
         return ''  # not a git repository
 
 
-def select_device(device='', batch_size=None, newline=True):
+def select_device(device='', batch_size=0, newline=True):
     # device = 'cpu' or '0' or '0,1,2,3'
     s = f'YOLOv5 🚀 {git_describe() or date_modified()} torch {torch.__version__} '  # string
     device = str(device).strip().lower().replace('cuda:', '')  # to string, 'cuda:0' to '0'


### PR DESCRIPTION
reproduce:
run train.py with --batch-size = -1.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement in GPU device selection and batch size handling for the YOLOv5 model.

### 📊 Key Changes
- Changed the default `batch_size` parameter in `select_device` function from `None` to `0`.
- Modified the condition to check if `batch_size` is a multiple of GPU count to accommodate the new `batch_size` default value.

### 🎯 Purpose & Impact
- 🤖 **Prevent Errors:** Ensures the function behaves properly when no batch size is specified (defaults to single-device mode).
- ✨ **Clarify Usage:** Makes it clear that a `batch_size` of `0` indicates no specific batch size preference, simplifying the logic for dividing workload across devices.
- 🔍 **Improve Validation:** The batch size divisibility check is now only applied when the batch size is greater than zero, preventing unnecessary assertions and potential runtime errors.
- 🏗 **Better Defaults:** The change improves user experience by providing sensible defaults that reduce the need for manual configuration.