### PR TITLE
Fix Detections class `tolist()` method

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -533,11 +533,16 @@ class Detections:
         self.pred = pred  # list of tensors pred[0] = (xyxy, conf, cls)
         self.names = names  # class names
         self.files = files  # image filenames
+        self.times = times # original times -- needed for tolist() 
         self.xyxy = pred  # xyxy pixels
         self.xywh = [xyxy2xywh(x) for x in pred]  # xywh pixels
         self.xyxyn = [x / g for x, g in zip(self.xyxy, gn)]  # xyxy normalized
         self.xywhn = [x / g for x, g in zip(self.xywh, gn)]  # xywh normalized
         self.n = len(self.pred)  # number of images (batch size)
+        if times is not None:
+            self.t = tuple((times[i + 1] - times[i]) * 1000 / self.n for i in range(3))  # timestamps (ms)
+        else:
+            self.t = None
         self.t = tuple((times[i + 1] - times[i]) * 1000 / self.n for i in range(3))  # timestamps (ms)
         self.s = shape  # inference BCHW shape
 
@@ -612,7 +617,7 @@ class Detections:
 
     def tolist(self):
         # return a list of Detections objects, i.e. 'for result in results.tolist():'
-        x = [Detections([self.imgs[i]], [self.pred[i]], names=self.names, shape=self.s) for i in range(self.n)]
+        x = [Detections([self.imgs[i]], [self.pred[i]], [self.files[i]], times=self.times, names=self.names, shape=self.s) for i in range(self.n)]
         for d in x:
             for k in ['imgs', 'pred', 'xyxy', 'xyxyn', 'xywh', 'xywhn']:
                 setattr(d, k, getattr(d, k)[0])  # pop out of list

--- a/models/common.py
+++ b/models/common.py
@@ -533,7 +533,7 @@ class Detections:
         self.pred = pred  # list of tensors pred[0] = (xyxy, conf, cls)
         self.names = names  # class names
         self.files = files  # image filenames
-        self.times = times  # original times -- needed for tolist() 
+        self.times = times  # original times -- needed for tolist()
         self.xyxy = pred  # xyxy pixels
         self.xywh = [xyxy2xywh(x) for x in pred]  # xywh pixels
         self.xyxyn = [x / g for x, g in zip(self.xyxy, gn)]  # xyxy normalized

--- a/models/common.py
+++ b/models/common.py
@@ -533,7 +533,7 @@ class Detections:
         self.pred = pred  # list of tensors pred[0] = (xyxy, conf, cls)
         self.names = names  # class names
         self.files = files  # image filenames
-        self.times = times # original times -- needed for tolist() 
+        self.times = times  # original times -- needed for tolist() 
         self.xyxy = pred  # xyxy pixels
         self.xywh = [xyxy2xywh(x) for x in pred]  # xywh pixels
         self.xyxyn = [x / g for x, g in zip(self.xyxy, gn)]  # xyxy normalized

--- a/models/common.py
+++ b/models/common.py
@@ -533,7 +533,7 @@ class Detections:
         self.pred = pred  # list of tensors pred[0] = (xyxy, conf, cls)
         self.names = names  # class names
         self.files = files  # image filenames
-        self.times = times # original times -- needed for tolist() 
+        self.times = times # original times -- needed for tolist()
         self.xyxy = pred  # xyxy pixels
         self.xywh = [xyxy2xywh(x) for x in pred]  # xywh pixels
         self.xyxyn = [x / g for x, g in zip(self.xyxy, gn)]  # xyxy normalized


### PR DESCRIPTION
This PR fixes #5944. It adds the appropriate `files` parameter to the `Detections.__init__()` call in the `tolist()` function.

Some tweaks were also made to the Detections __init__ function to support this properly.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved initialization of Detections class with default profiling times and simplification of `tolist` method.

### 📊 Key Changes
- Initialized `times` parameter with a default value `(0, 0, 0, 0)` in `Detections` class constructor.
- Refactored the `tolist` method to include `times` and `files` in the construction of `Detections` objects.
- Removed redundant code that popped out items from lists within the `tolist` method.

### 🎯 Purpose & Impact
- 🕒 Providing default values for `times` ensures that the `Detections` objects are constructed with all necessary information, avoiding potential errors from missing data.
- 🧹 The `tolist` method's refactor creates a cleaner and more efficient way to convert `Detections` objects into a list format, making the code easier to maintain and understand.
- 🚀 These changes could lead to more reliable profiling data for performance analysis and may improve the user experience by ensuring consistent results from inference operations.