### PR TITLE
fix .gitignore not tracking existing folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,12 +26,11 @@
 storage.googleapis.com
 runs/*
 data/*
-data/training/*
+data/images/*
 !data/*.yaml
 !data/hyps
 !data/scripts
 !data/images
-data/images/*
 !data/images/zidane.jpg
 !data/images/bus.jpg
 !data/*.sh

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,12 @@
 storage.googleapis.com
 runs/*
 data/*
-!data/hyps/*
+data/training/*
+!data/*.yaml
+!data/hyps
+!data/scripts
+!data/images
+data/images/*
 !data/images/zidane.jpg
 !data/images/bus.jpg
 !data/*.sh


### PR DESCRIPTION
Fix `.gitignore` so that the files that are in the repository are actually being tracked.

Everything in the `data/` folder is ignored, which also means the subdirectories are ignored. Fix so that the subdirectories and their contents are still tracked.

```
# ignore everything in the `dist` folder
dist/*
# … but don’t ignore the `dist/samples` folder
!dist/samples/
# … but ignore everything inside that `dist/samples` folder
dist/samples/*
# … except the `README.md` there
!dist/samples/README.md
```
See [StackOverflow](https://stackoverflow.com/a/35279076/5915763) discussion

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced `.gitignore` to better manage data files and scripts.

### 📊 Key Changes
- **Excluding Specific Data Folders:** General data folder exclusion with exceptions for YAML files and certain subdirectories (like `hyps` and `scripts`).
- **Inclusion of Data Images:** Data image files are now individually ignored, except for example images (`zidane.jpg`, `bus.jpg`).
- **Improved Organization:** By specifying what to ignore, the repository stays cleaner, ensuring only necessary files are tracked.

### 🎯 Purpose & Impact
- **Cleaner Repositories:** Helps keep the repository free from unnecessary data files which can clutter the project and slow down operations.
- **Selective Tracking:** Allows for precise control over which files are tracked by Git, improving project structure and clarity.
- **Ease of Use:** New contributors can easily understand which files should be committed, reducing accidental commits of large or personal data files.