### PR TITLE
Fix `imgsz` bug

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -38,7 +38,7 @@ from utils.torch_utils import select_device, time_sync
 @torch.no_grad()
 def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
         source=ROOT / 'data/images',  # file/dir/URL/glob, 0 for webcam
-        imgsz=(640, 640),  # inference size (pixels)
+        imgsz=(640, 640),  # inference size (height, width)
         conf_thres=0.25,  # confidence threshold
         iou_thres=0.45,  # NMS IOU threshold
         max_det=1000,  # maximum detections per image

--- a/detect.py
+++ b/detect.py
@@ -38,7 +38,7 @@ from utils.torch_utils import select_device, time_sync
 @torch.no_grad()
 def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
         source=ROOT / 'data/images',  # file/dir/URL/glob, 0 for webcam
-        imgsz=640,  # inference size (pixels)
+        imgsz=(640, 640),  # inference size (pixels)
         conf_thres=0.25,  # confidence threshold
         iou_thres=0.45,  # NMS IOU threshold
         max_det=1000,  # maximum detections per image


### PR DESCRIPTION
Closes #5947. The run(...) function had a default argument of 640; however, the parse_opt(...) function had a default argument of [640, 640]. This happens on this line: `opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand`.
In the run(...) function, `*imgsz` is used, so an int as a default argument will raise an error.
This changes the default run arg to be a tuple of size 2.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of input image size configuration for object detection in YOLOv5.

### 📊 Key Changes
- Changed `imgsz` parameter to accept a tuple specifying both height and width, rather than a single value for both.

### 🎯 Purpose & Impact
- 📐 **Purpose**: Allows for more flexible image input dimensions, accommodating images that are not square.
- 👁️ **Impact**: Users can now input images of different aspect ratios without distorting them, possibly improving detection accuracy on non-square images.