### PR TITLE
Allow `--weights URL`

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -296,7 +296,7 @@ class DetectMultiBackend(nn.Module):
         check_suffix(w, suffixes)  # check weights have acceptable suffix
         pt, jit, onnx, engine, tflite, pb, saved_model, coreml = (suffix == x for x in suffixes)  # backend booleans
         stride, names = 64, [f'class{i}' for i in range(1000)]  # assign defaults
-        attempt_download(w)  # download if not local
+        w = attempt_download(w)  # download if not local
 
         if jit:  # TorchScript
             LOGGER.info(f'Loading {w} for TorchScript inference...')
@@ -306,7 +306,7 @@ class DetectMultiBackend(nn.Module):
                 d = json.loads(extra_files['config.txt'])  # extra_files dict
                 stride, names = int(d['stride']), d['names']
         elif pt:  # PyTorch
-            model = attempt_load(weights, map_location=device)
+            model = attempt_load(weights if isinstance(weights, list) else w, map_location=device)
             stride = int(model.stride.max())  # model stride
             names = model.module.names if hasattr(model, 'module') else model.names  # get class names
             self.model = model  # explicitly assign for to(), cpu(), cuda(), half()

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -49,9 +49,12 @@ def attempt_download(file, repo='ultralytics/yolov5'):  # from utils.downloads i
         name = Path(urllib.parse.unquote(str(file))).name  # decode '%2F' to '/' etc.
         if str(file).startswith(('http:/', 'https:/')):  # download
             url = str(file).replace(':/', '://')  # Pathlib turns :// -> :/
-            name = name.split('?')[0]  # parse authentication https://url.com/file.txt?auth...
-            safe_download(file=name, url=url, min_bytes=1E5)
-            return name
+            file = name.split('?')[0]  # parse authentication https://url.com/file.txt?auth...
+            if Path(file).is_file():
+                print(f'Found {url} locally at {file}')  # file already exists
+            else:
+                safe_download(file=file, url=url, min_bytes=1E5)
+            return file
 
         # GitHub assets
         file.parent.mkdir(parents=True, exist_ok=True)  # make parent dir (if required)


### PR DESCRIPTION
Allows train.py, val.py, detect.py, export.py to pass a URL for the --weights argument, i.e.:

```bash
# Download arbitrary weights from any URL
python detect.py --weights https://github.com/ultralytics/yolov5/releases/download/v6.0/yolov5s.pt 

# Autodownload official weights from YOLOv5 assets
python detect.py --weights yolov5s.pt
```

Weights will only download if not already found locally in root directory (they will not download twice by running command twice).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved file download handling and model loading in Ultralytics YOLOv5.

### 📊 Key Changes
- The `attempt_download` function's return value is now correctly assigned, ensuring the downloaded file path is used subsequently.
- The `attempt_load` function within `common.py` now handles the `weights` parameter more flexibly, allowing for both list inputs and single string inputs.

### 🎯 Purpose & Impact
- Ensures that downloaded files are properly referenced post-download, preventing errors related to file paths.
- Flexibility in model loading allows for a smoother experience when using different types of weight inputs, enhancing usability.
- The changes can help prevent bugs and improve the overall robustness of model instantiation and weight file handling. 🛠️