### PR TITLE
support specfiy multiple frozen layers

### DIFF
--- a/train.py
+++ b/train.py
@@ -124,7 +124,10 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         model = Model(cfg, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
 
     # Freeze
-    freeze = [f'model.{x}.' for x in range(freeze)]  # layers to freeze
+    if len(freeze) >= 2:
+        freeze = [f'model.{x}.' for x in freeze]  # specify multiple frozen layer
+    else:
+        freeze = [f'model.{x}.' for x in range(freeze)] # specify frozen layer up to freeze
     for k, v in model.named_parameters():
         v.requires_grad = True  # train all layers
         if any(x in k for x in freeze):
@@ -469,7 +472,8 @@ def parse_opt(known=False):
     parser.add_argument('--linear-lr', action='store_true', help='linear LR')
     parser.add_argument('--label-smoothing', type=float, default=0.0, help='Label smoothing epsilon')
     parser.add_argument('--patience', type=int, default=100, help='EarlyStopping patience (epochs without improvement)')
-    parser.add_argument('--freeze', type=int, default=0, help='Number of layers to freeze. backbone=10, all=24')
+    parser.add_argument('--freeze', nargs='+', type=int, default=0,
+                        help='Specify the layers that you want to freeze in training. (e.g. 10 represents freeze up to 10, or 1 2 4 6 represents freeze layers 1,2,4,6)')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
 


### PR DESCRIPTION
related to [6001](https://github.com/ultralytics/yolov5/pull/6001)

@glenn-jocher HI, I'm here. Now is
```
python train.py --freeze 10  # freeze up to 10
python train.py --freeze 5 6 7 8 9 10  # freeze layers 5-10
python train.py --freeze 5 7 8 10  # freeze layers 5,7,8,10
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced layer freezing flexibility during model training in YOLOv5.

### 📊 Key Changes
- Modified the `freeze` behavior in `train.py` to support freezing specific layers.
- Updated argument parsing to accept multiple values for the `--freeze` flag.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: Allows more granular control over which layers of the neural network are frozen during training, enabling users to fine-tune their models more precisely.
- 💥 **Impact**: Users can now choose specific layers to freeze instead of only being able to freeze up to a certain layer. This could improve model performance and training efficiency for various use cases, particularly when fine-tuning pre-trained models.