### PR TITLE
Multi-layer capable `--freeze` argument

### DIFF
--- a/train.py
+++ b/train.py
@@ -124,10 +124,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         model = Model(cfg, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
 
     # Freeze
-    if type(freeze) == list:
-        freeze = [f'model.{x}.' for x in freeze]  # specify multiple frozen layer
-    else:
-        freeze = [f'model.{x}.' for x in range(freeze)] # specify frozen layer up to freeze
+    freeze = [f'model.{x}.' for x in (freeze if isinstance(freeze, list) else range(freeze))]  # layers to freeze
     for k, v in model.named_parameters():
         v.requires_grad = True  # train all layers
         if any(x in k for x in freeze):

--- a/train.py
+++ b/train.py
@@ -124,7 +124,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         model = Model(cfg, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
 
     # Freeze
-    if len(freeze) >= 2:
+    if type(freeze) == list:
         freeze = [f'model.{x}.' for x in freeze]  # specify multiple frozen layer
     else:
         freeze = [f'model.{x}.' for x in range(freeze)] # specify frozen layer up to freeze

--- a/train.py
+++ b/train.py
@@ -124,7 +124,10 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         model = Model(cfg, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
 
     # Freeze
-    freeze = [f'model.{x}.' for x in range(freeze)]  # layers to freeze
+    if len(freeze) >= 2:
+        freeze = [f'model.{x}.' for x in freeze]  # specify multiple frozen layer
+    else:
+        freeze = [f'model.{x}.' for x in range(freeze)] # specify frozen layer up to freeze
     for k, v in model.named_parameters():
         v.requires_grad = True  # train all layers
         if any(x in k for x in freeze):
@@ -469,7 +472,8 @@ def parse_opt(known=False):
     parser.add_argument('--linear-lr', action='store_true', help='linear LR')
     parser.add_argument('--label-smoothing', type=float, default=0.0, help='Label smoothing epsilon')
     parser.add_argument('--patience', type=int, default=100, help='EarlyStopping patience (epochs without improvement)')
-    parser.add_argument('--freeze', type=int, default=0, help='Number of layers to freeze. backbone=10, all=24')
+    parser.add_argument('--freeze', nargs='+', type=int, default=0,
+                        help='Specify the layers that you want to freeze in training. (e.g. 10 represents freeze up to 10, or 1 2 4 6 represents freeze layers 1,2,4,6)')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
 

--- a/train.py
+++ b/train.py
@@ -469,8 +469,7 @@ def parse_opt(known=False):
     parser.add_argument('--linear-lr', action='store_true', help='linear LR')
     parser.add_argument('--label-smoothing', type=float, default=0.0, help='Label smoothing epsilon')
     parser.add_argument('--patience', type=int, default=100, help='EarlyStopping patience (epochs without improvement)')
-    parser.add_argument('--freeze', nargs='+', type=int, default=0,
-                        help='Specify the layers that you want to freeze in training. (e.g. 10 represents freeze up to 10, or 1 2 4 6 represents freeze layers 1,2,4,6)')
+    parser.add_argument('--freeze', nargs='+', type=int, default=0, help='Freeze layers: backbone=10, first3=0 1 2')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
 


### PR DESCRIPTION
Related to [6001](https://github.com/ultralytics/yolov5/pull/6001)

@glenn-jocher HI, I'm here. Now is
```
python train.py --freeze 10  # freeze up to 10
python train.py --freeze 5 6 7 8 9 10  # freeze layers 5-10
python train.py --freeze 5 7 8 10  # freeze layers 5,7,8,10
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to layer freezing granularity in YOLOv5's training script.

### 📊 Key Changes
- The `--freeze` command-line argument now accepts a list of layer indices to freeze, instead of just a single value.
- Layer freezing logic in `train.py` updated to handle both individual and ranges of layers.

### 🎯 Purpose & Impact
- 🎨 **Enhances flexibility**: Users can now freeze specific layers or ranges of layers, allowing for more customized and fine-tuned models.
- 🚀 **Streamlines experimentation**: This feature may lead to better performing models with less training time, by only training the most impactful parts of the network.
- ➕ **Adds clarity**: Updates the help message for the `--freeze` parameter, making it more informative for users to understand its use.