### PR TITLE
train -> val comment fix

### DIFF
--- a/data/coco.yaml
+++ b/data/coco.yaml
@@ -10,7 +10,7 @@
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
 path: ../datasets/coco  # dataset root dir
 train: train2017.txt  # train images (relative to 'path') 118287 images
-val: val2017.txt  # train images (relative to 'path') 5000 images
+val: val2017.txt  # val images (relative to 'path') 5000 images
 test: test-dev2017.txt  # 20288 of 40670 images, submit to https://competitions.codalab.org/competitions/20794
 
 # Classes


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Fix typo in COCO dataset configuration file.

### 📊 Key Changes
- Corrected a comment within the COCO dataset YAML configuration, changing the word "train" to "val" for the validation dataset description.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: Provides clearer documentation and understanding of the dataset structure.
- 🧩 **Impact**: Ensures accurate information is available to users setting up their datasets, particularly beneficial for beginners or those unfamiliar with the COCO dataset. No impact on actual code functionality.