### PR TITLE
W&B: track batch size after autobatch

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,6 +138,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     # Batch size
     if RANK == -1 and batch_size == -1:  # single-GPU only, estimate best batch size
         batch_size = check_train_batch_size(model, imgsz)
+        loggers.on_params_update({"batch_size": batch_size})
 
     # Optimizer
     nbs = 64  # nominal batch size

--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -32,7 +32,7 @@ class Callbacks:
             'on_fit_epoch_end': [],  # fit = train + val
             'on_model_save': [],
             'on_train_end': [],
-
+            'on_params_update': [],
             'teardown': [],
         }
 

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -159,7 +159,7 @@ class Loggers():
                 self.wandb = WandbLogger(self.opt)
 
     def on_params_update(self, params):
-        # update hyperparams or configs of the experiment
-        # params: A dict containing param: value pairs
+        # Update hyperparams or configs of the experiment
+        # params: A dict containing {param: value} pairs
         if self.wandb:
             self.wandb.wandb_run.config.update(params, allow_val_change=True)

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -4,7 +4,6 @@ Logging utils
 """
 
 import os
-from typing import Dict
 import warnings
 from threading import Thread
 

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -4,6 +4,7 @@ Logging utils
 """
 
 import os
+from typing import Dict
 import warnings
 from threading import Thread
 
@@ -157,3 +158,9 @@ class Loggers():
             else:
                 self.wandb.finish_run()
                 self.wandb = WandbLogger(self.opt)
+
+    def on_params_update(self, params):
+        # update hyperparams or configs of the experiment
+        # params: A dict containing param: value pairs
+        if self.wandb:
+            self.wandb.wandb_run.config.update(params, allow_val_change = True)

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -162,4 +162,4 @@ class Loggers():
         # update hyperparams or configs of the experiment
         # params: A dict containing param: value pairs
         if self.wandb:
-            self.wandb.wandb_run.config.update(params, allow_val_change = True)
+            self.wandb.wandb_run.config.update(params, allow_val_change=True)


### PR DESCRIPTION
fixes https://github.com/ultralytics/yolov5/issues/6008
@glenn-jocher based on your suggestion from before, I've not added any wandb specific code in the train.py. I've added a new function in the loggers class that can be used for all loggers to update parameters at any point in the experiment. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved parameter logging for dynamic batch size configuration in YOLOv5 training.

### 📊 Key Changes
- Added a new callback `on_params_update` to the `loggers` module.
- Ensured dynamic batch size changes during single-GPU training are logged.

### 🎯 Purpose & Impact
- **Purpose:** Allows logging of changes to parameters such as the batch size during training, ensuring that these changes are tracked and can be reviewed later.
- **Impact:** Users can now have better insight into the automatic adjustments made during training, like the optimal batch size determination, particularly beneficial for single-GPU setups. This feature enhances the transparency and reproducibility of training experiments when using the Ultralytics YOLOv5 model. 🧐🔍📈