### PR TITLE
`--freeze` fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -60,7 +60,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
           device,
           callbacks
           ):
-    save_dir, epochs, batch_size, weights, single_cls, evolve, data, cfg, resume, noval, nosave, workers, freeze, = \
+    save_dir, epochs, batch_size, weights, single_cls, evolve, data, cfg, resume, noval, nosave, workers, freeze = \
         Path(opt.save_dir), opt.epochs, opt.batch_size, opt.weights, opt.single_cls, opt.evolve, opt.data, opt.cfg, \
         opt.resume, opt.noval, opt.nosave, opt.workers, opt.freeze
 
@@ -124,7 +124,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
         model = Model(cfg, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
 
     # Freeze
-    freeze = [f'model.{x}.' for x in (freeze if isinstance(freeze, list) else range(freeze))]  # layers to freeze
+    freeze = [f'model.{x}.' for x in (freeze if len(freeze) > 1 else range(freeze[0]))]  # layers to freeze
     for k, v in model.named_parameters():
         v.requires_grad = True  # train all layers
         if any(x in k for x in freeze):
@@ -469,7 +469,7 @@ def parse_opt(known=False):
     parser.add_argument('--linear-lr', action='store_true', help='linear LR')
     parser.add_argument('--label-smoothing', type=float, default=0.0, help='Label smoothing epsilon')
     parser.add_argument('--patience', type=int, default=100, help='EarlyStopping patience (epochs without improvement)')
-    parser.add_argument('--freeze', nargs='+', type=int, default=0, help='Freeze layers: backbone=10, first3=0 1 2')
+    parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
 


### PR DESCRIPTION
Fix for https://github.com/ultralytics/yolov5/issues/6038

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to layer freezing functionality in the YOLOv5 training script.

### 📊 Key Changes
- Streamlined assignment of training script arguments by removing an extraneous comma.
- Corrected the layer freezing logic to handle both single integers and lists properly.
- Adjusted the `--freeze` argument to default to a list with a single element, improving clarity.

### 🎯 Purpose & Impact
- Ensures that the layer freezing functionality works as expected, whether specifying individual layers or a range of layers to freeze during training. This can help with transfer learning or fine-tuning models where only certain layers need updating.
- The modification of the default value for the `--freeze` argument to a list prevents confusion and potential errors when users do not specify any layers to freeze.
- These changes potentially improve the usability and flexibility of the training script, making it easier for users to customize model training to their specific needs.