### PR TITLE
OpenVINO Export

### DIFF
--- a/export.py
+++ b/export.py
@@ -149,7 +149,7 @@ def export_coreml(model, im, file, prefix=colorstr('CoreML:')):
 def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
     # YOLOv5 OpenVINO export
     try:
-        check_requirements(('openvino',))  # requires openvino-dev: https://pypi.org/project/openvino-dev/
+        check_requirements(('openvino-dev',))  # requires openvino-dev: https://pypi.org/project/openvino-dev/
         import openvino.inference_engine as ie
 
         LOGGER.info(f'\n{prefix} starting export with openvino {ie.__version__}...')

--- a/export.py
+++ b/export.py
@@ -8,7 +8,7 @@ PyTorch                 | yolov5s.pt                | -
 TorchScript             | yolov5s.torchscript       | `torchscript`
 ONNX                    | yolov5s.onnx              | `onnx`
 CoreML                  | yolov5s.mlmodel           | `coreml`
-OpenVINO                | yolov5s.xml               | `openvino`
+OpenVINO                | yolov5s_openvino_model/   | `openvino`
 TensorFlow SavedModel   | yolov5s_saved_model/      | `saved_model`
 TensorFlow GraphDef     | yolov5s.pb                | `pb`
 TensorFlow Lite         | yolov5s.tflite            | `tflite`
@@ -23,7 +23,7 @@ Inference:
                                          yolov5s.torchscript
                                          yolov5s.onnx
                                          yolov5s.mlmodel  (under development)
-                                         yolov5s.xml  (under development)
+                                         yolov5s_openvino_model  (under development)
                                          yolov5s_saved_model
                                          yolov5s.pb
                                          yolov5s.tflite
@@ -154,9 +154,8 @@ def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
         import openvino.inference_engine as ie
 
         LOGGER.info(f'\n{prefix} starting export with openvino {ie.__version__}...')
-        f = [str(f) for f in (file.with_suffix('.xml'), file.with_suffix('.bin'), file.with_suffix('.mapping'))]
+        f = str(file.with_suffix('')) + '_openvino_model' + os.sep
 
-        f = str(file.with_suffix('')) + '_openvino'
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f}"
         subprocess.check_output(cmd, shell=True).decode()
 

--- a/export.py
+++ b/export.py
@@ -438,7 +438,7 @@ def parse_opt():
     parser.add_argument('--int8', action='store_true', help='CoreML/TF INT8 quantization')
     parser.add_argument('--dynamic', action='store_true', help='ONNX/TF: dynamic axes')
     parser.add_argument('--simplify', action='store_true', help='ONNX: simplify model')
-    parser.add_argument('--opset', type=int, default=14, help='ONNX: opset version')
+    parser.add_argument('--opset', type=int, default=12, help='ONNX: opset version')
     parser.add_argument('--verbose', action='store_true', help='TensorRT: verbose log')
     parser.add_argument('--workspace', type=int, default=4, help='TensorRT: workspace size (GB)')
     parser.add_argument('--nms', action='store_true', help='TF: add NMS to model')

--- a/export.py
+++ b/export.py
@@ -153,7 +153,7 @@ def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
         check_requirements(('openvino',))  # https://pypi.org/project/openvino-dev/
         import openvino.inference_engine as ie
 
-        LOGGER.info(f'\n{prefix} starting export with OpenVINO {ie.__version__}...')
+        LOGGER.info(f'\n{prefix} starting export with openvino {ie.__version__}...')
         f = [str(f) for f in (file.with_suffix('.xml'), file.with_suffix('.bin'), file.with_suffix('.mapping'))]
 
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {file.parent}"
@@ -345,7 +345,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
         int8=False,  # CoreML/TF INT8 quantization
         dynamic=False,  # ONNX/TF: dynamic axes
         simplify=False,  # ONNX: simplify model
-        opset=14,  # ONNX: opset version
+        opset=12,  # ONNX: opset version
         verbose=False,  # TensorRT: verbose log
         workspace=4,  # TensorRT: workspace size (GB)
         nms=False,  # TF: add NMS to model
@@ -358,8 +358,11 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
     t = time.time()
     include = [x.lower() for x in include]
     tf_exports = list(x in include for x in ('saved_model', 'pb', 'tflite', 'tfjs'))  # TensorFlow exports
-    imgsz *= 2 if len(imgsz) == 1 else 1  # expand
     file = Path(url2file(weights) if str(weights).startswith(('http:/', 'https:/')) else weights)
+
+    # Checks
+    imgsz *= 2 if len(imgsz) == 1 else 1  # expand
+    opset = 12 if ('openvino' in include) else opset  # OpenVINO requires opset <= 12
 
     # Load PyTorch model
     device = select_device(device)

--- a/export.py
+++ b/export.py
@@ -156,7 +156,7 @@ def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
         f = str(file).replace('.pt', '_openvino_model' + os.sep)
 
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f}"
-        subprocess.check_output(cmd, shell=True).decode()
+        subprocess.check_output(cmd, shell=True)
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')
     except Exception as e:

--- a/export.py
+++ b/export.py
@@ -157,7 +157,7 @@ def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
         f = file.with_suffix('.xml')
 
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {file.parent}"
-        subprocess.check_output(cmd, shell=True, timeout=5).decode()
+        subprocess.check_output(cmd, shell=True).decode()
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')
     except Exception as e:

--- a/export.py
+++ b/export.py
@@ -154,7 +154,7 @@ def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
         import openvino.inference_engine as ie
 
         LOGGER.info(f'\n{prefix} starting export with OpenVINO {ie.__version__}...')
-        f = [file.with_suffix('.xml'), file.with_suffix('.bin'), file.with_suffix('.mapping')]
+        f = [str(f) for f in (file.with_suffix('.xml'), file.with_suffix('.bin'), file.with_suffix('.mapping'))]
 
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {file.parent}"
         subprocess.check_output(cmd, shell=True).decode()

--- a/export.py
+++ b/export.py
@@ -156,10 +156,11 @@ def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
         LOGGER.info(f'\n{prefix} starting export with openvino {ie.__version__}...')
         f = [str(f) for f in (file.with_suffix('.xml'), file.with_suffix('.bin'), file.with_suffix('.mapping'))]
 
-        cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {file.parent}"
+        f = str(file.with_suffix('')) + '_openvino'
+        cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f}"
         subprocess.check_output(cmd, shell=True).decode()
 
-        LOGGER.info(f'{prefix} export success, saved as {f} ({sum(file_size(f) for f in f):.1f} MB)')
+        LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')
     except Exception as e:
         LOGGER.info(f'\n{prefix} export failure: {e}')
 

--- a/export.py
+++ b/export.py
@@ -154,12 +154,12 @@ def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
         import openvino.inference_engine as ie
 
         LOGGER.info(f'\n{prefix} starting export with OpenVINO {ie.__version__}...')
-        f = file.with_suffix('.xml')
+        f = [file.with_suffix('.xml'), file.with_suffix('.bin'), file.with_suffix('.mapping')]
 
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {file.parent}"
         subprocess.check_output(cmd, shell=True).decode()
 
-        LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')
+        LOGGER.info(f'{prefix} export success, saved as {f} ({sum(file_size(f) for f in f):.1f} MB)')
     except Exception as e:
         LOGGER.info(f'\n{prefix} export failure: {e}')
 

--- a/export.py
+++ b/export.py
@@ -148,13 +148,12 @@ def export_coreml(model, im, file, prefix=colorstr('CoreML:')):
 
 def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
     # YOLOv5 OpenVINO export
-    ct_model = None
     try:
-        check_requirements(('openvino',))  # https://pypi.org/project/openvino-dev/
+        check_requirements(('openvino',))  # requires openvino-dev: https://pypi.org/project/openvino-dev/
         import openvino.inference_engine as ie
 
         LOGGER.info(f'\n{prefix} starting export with openvino {ie.__version__}...')
-        f = str(file.with_suffix('')) + '_openvino_model' + os.sep
+        f = str(file).replace('.pt', '_openvino_model' + os.sep)
 
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f}"
         subprocess.check_output(cmd, shell=True).decode()

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ seaborn>=0.11.0
 # scikit-learn==0.19.2  # CoreML quantization
 # tensorflow>=2.4.1  # TFLite export
 # tensorflowjs>=3.9.0  # TF.js export
+# openvino-dev  # OpenVINO export
 
 # Extras --------------------------------------
 # albumentations>=1.0.3


### PR DESCRIPTION
Adds support for YOLOv5 Intel OpenVINO export.

```python
!git clone https://github.com/ultralytics/yolov5  # clone
%cd yolov5
%pip install -qr requirements.txt onnx openvino-dev  # install INCLUDING onnx and openvino-dev

import torch
from yolov5 import utils
display = utils.notebook_init()  # checks

# Export OpenVINO
!python export.py --include openvino
```

![image](https://user-images.githubusercontent.com/26833433/147242123-ec1575e0-5263-4713-8d40-dda9d1a128c0.png)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added OpenVINO export support to YOLOv5

### 📊 Key Changes
- 📦 Introduced export functionality for OpenVINO format in `export.py`
- 👾 Updated usage instructions to include `openvino` in the list of exportable formats
- 👁 Added inference command example for OpenVINO models (under development)
- 🛠 Implemented an `export_openvino` function to convert models to OpenVINO format
- 🔄 Modified default `opset` parameter from 14 to 12 for compatibility with OpenVINO
- 📄 Added `openvino-dev` to the requirements in `requirements.txt` (commented out)

### 🎯 Purpose & Impact
- 🌐 Users can now export their YOLOv5 models to OpenVINO, which allows deployment on Intel hardware and accelerators.
- 🚀 This feature broadens the applicability of YOLOv5 models, potentially improving performance on platforms that support OpenVINO.
- 🤝 By commenting out `openvino-dev`, users who require this functionality can easily install it, while those who do not need it avoid unnecessary dependencies.