### PR TITLE
Reduce G/D/CIoU logic operations 

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -222,20 +222,20 @@ def bbox_iou(box1, box2, x1y1x2y2=True, GIoU=False, DIoU=False, CIoU=False, eps=
     union = w1 * h1 + w2 * h2 - inter + eps
 
     iou = inter / union
-    if GIoU or DIoU or CIoU:
+    if CIoU or DIoU or GIoU:
         cw = torch.max(b1_x2, b2_x2) - torch.min(b1_x1, b2_x1)  # convex (smallest enclosing box) width
         ch = torch.max(b1_y2, b2_y2) - torch.min(b1_y1, b2_y1)  # convex height
         if CIoU or DIoU:  # Distance or Complete IoU https://arxiv.org/abs/1911.08287v1
             c2 = cw ** 2 + ch ** 2 + eps  # convex diagonal squared
             rho2 = ((b2_x1 + b2_x2 - b1_x1 - b1_x2) ** 2 +
                     (b2_y1 + b2_y2 - b1_y1 - b1_y2) ** 2) / 4  # center distance squared
-            if DIoU:
-                return iou - rho2 / c2  # DIoU
-            elif CIoU:  # https://github.com/Zzh-tju/DIoU-SSD-pytorch/blob/master/utils/box/box_utils.py#L47
+            if CIoU:  # https://github.com/Zzh-tju/DIoU-SSD-pytorch/blob/master/utils/box/box_utils.py#L47
                 v = (4 / math.pi ** 2) * torch.pow(torch.atan(w2 / h2) - torch.atan(w1 / h1), 2)
                 with torch.no_grad():
                     alpha = v / (v - iou + (1 + eps))
                 return iou - (rho2 / c2 + v * alpha)  # CIoU
+            else:
+                return iou - rho2 / c2  # DIoU
         else:  # GIoU https://arxiv.org/pdf/1902.09630.pdf
             c_area = cw * ch + eps  # convex area
             return iou - (c_area - union) / c_area  # GIoU


### PR DESCRIPTION
Consider that the default value is CIOU，adjust the order of judgment could reduce the number of judgments.
And “elif CIoU:” didn't need 'if'.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of Intersection over Union (IoU) calculation in object detection metrics.

### 📊 Key Changes
- Streamlined IoU-related calculations by reordering the conditional checks for CIoU, DIoU, and GIoU.
- Adjusted the code structure to prioritize CIoU calculation when both CIoU and DIoU are requested.
- Minor restructuring of `if-else` conditions, improving code readability and maintainability.

### 🎯 Purpose & Impact
- **Enhanced Clarity:** The restructuring in order of operations makes the code more understandable by grouping related IoU variants together.
- **Maintainability:** By isolating CIoU in its own condition, it's easier to maintain and update IoU variants independently.
- **User Experience:** Users of the repository may experience more consistent behavior with the established IoU calculations in their projects.