### PR TITLE
Patch train.py, fixing evolve issue when anchors = 0

### DIFF
--- a/train.py
+++ b/train.py
@@ -600,14 +600,14 @@ def main(opt, callbacks=Callbacks()):
                 hyp[k] = max(hyp[k], v[1])  # lower limit
                 hyp[k] = min(hyp[k], v[2])  # upper limit
                 hyp[k] = round(hyp[k], 5)  # significant digits
-            
+
             # Recheck fix anchor configuration
             with open(opt.hyp, errors='ignore') as f:
                 mom = yaml.safe_load(f)  # load hyps dict
                 if 'anchors' in mom:
                     if mom['anchors'] == 0:
                         hyp['anchors'] = 0
-            
+
             # Train mutation
             results = train(hyp.copy(), opt, device, callbacks)
 

--- a/train.py
+++ b/train.py
@@ -600,7 +600,14 @@ def main(opt, callbacks=Callbacks()):
                 hyp[k] = max(hyp[k], v[1])  # lower limit
                 hyp[k] = min(hyp[k], v[2])  # upper limit
                 hyp[k] = round(hyp[k], 5)  # significant digits
-
+            
+            # Recheck fix anchor configuration
+            with open(opt.hyp, errors='ignore') as f:
+                mom = yaml.safe_load(f)  # load hyps dict
+                if 'anchors' in mom:
+                    if mom['anchors'] == 0:
+                        hyp['anchors'] = 0
+            
             # Train mutation
             results = train(hyp.copy(), opt, device, callbacks)
 


### PR DESCRIPTION
More details on https://github.com/ultralytics/yolov5/issues/6079

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing a verification step for anchor configuration in the training script.

### 📊 Key Changes
- Added a new code block in `train.py` that checks the anchor configuration from the hyperparameters file.
- If the 'anchors' key is set to 0 in the hyperparameters (`hyp`) file, it will ensure that `hyp['anchors']` is set to 0 in the script.

### 🎯 Purpose & Impact
- **Purpose:** To ensure that the training script respects a user-defined preference for disabling anchor adjustments if specified in the hyperparameters file.
- **Impact:** Users now have the assurance that if they choose not to use anchor adjustments during training (by setting `anchors` to 0), their setting will be honored during the training process, potentially leading to more predictable and desirable outcomes in their model training.