### PR TITLE
Log best results

### DIFF
--- a/train.py
+++ b/train.py
@@ -371,8 +371,8 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
             if fi > best_fitness:
                 best_fitness = fi
                 if loggers.wandb:
-                    br = np.array(results).reshape(-1)[:4]
-                    for i, name in enumerate(['P', 'R', 'mAP@.5', 'mAP@.5-.95']):
+                    br = np.concatenate([np.array(results).reshape(-1)[:4], epoch])
+                    for i, name in enumerate(['P', 'R', 'mAP@.5', 'mAP@.5-.95', 'epoch']):
                         loggers.wandb.wandb_run.summary[f'best/{name}'] = br[i]  # log best results in the summary
             log_vals = list(mloss) + list(results) + lr
             callbacks.run('on_fit_epoch_end', log_vals, epoch, best_fitness, fi)

--- a/train.py
+++ b/train.py
@@ -370,6 +370,10 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
             fi = fitness(np.array(results).reshape(1, -1))  # weighted combination of [P, R, mAP@.5, mAP@.5-.95]
             if fi > best_fitness:
                 best_fitness = fi
+                if loggers.wandb:
+                    br = np.array(results).reshape(-1)[:4]
+                    for i, name in enumerate(['P', 'R', 'mAP@.5', 'mAP@.5-.95']):
+                        loggers.wandb.wandb_run.summary[f'best/{name}'] = br[i]
             log_vals = list(mloss) + list(results) + lr
             callbacks.run('on_fit_epoch_end', log_vals, epoch, best_fitness, fi)
 

--- a/train.py
+++ b/train.py
@@ -371,7 +371,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
             if fi > best_fitness:
                 best_fitness = fi
                 if loggers.wandb:
-                    br = np.concatenate([np.array(results).reshape(-1)[:4], epoch])
+                    br = np.concatenate([np.array(results).reshape(-1)[:4], [epoch]])
                     for i, name in enumerate(['P', 'R', 'mAP@.5', 'mAP@.5-.95', 'epoch']):
                         loggers.wandb.wandb_run.summary[f'best/{name}'] = br[i]  # log best results in the summary
             log_vals = list(mloss) + list(results) + lr

--- a/train.py
+++ b/train.py
@@ -370,10 +370,6 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
             fi = fitness(np.array(results).reshape(1, -1))  # weighted combination of [P, R, mAP@.5, mAP@.5-.95]
             if fi > best_fitness:
                 best_fitness = fi
-                if loggers.wandb:
-                    br = np.concatenate([np.array(results).reshape(-1)[:4], [epoch]])
-                    for i, name in enumerate(['P', 'R', 'mAP@.5', 'mAP@.5-.95', 'epoch']):
-                        loggers.wandb.wandb_run.summary[f'best/{name}'] = br[i]  # log best results in the summary
             log_vals = list(mloss) + list(results) + lr
             callbacks.run('on_fit_epoch_end', log_vals, epoch, best_fitness, fi)
 

--- a/train.py
+++ b/train.py
@@ -373,7 +373,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 if loggers.wandb:
                     br = np.array(results).reshape(-1)[:4]
                     for i, name in enumerate(['P', 'R', 'mAP@.5', 'mAP@.5-.95']):
-                        loggers.wandb.wandb_run.summary[f'best/{name}'] = br[i]
+                        loggers.wandb.wandb_run.summary[f'best/{name}'] = br[i] # log best results in the summary
             log_vals = list(mloss) + list(results) + lr
             callbacks.run('on_fit_epoch_end', log_vals, epoch, best_fitness, fi)
 

--- a/train.py
+++ b/train.py
@@ -373,7 +373,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 if loggers.wandb:
                     br = np.array(results).reshape(-1)[:4]
                     for i, name in enumerate(['P', 'R', 'mAP@.5', 'mAP@.5-.95']):
-                        loggers.wandb.wandb_run.summary[f'best/{name}'] = br[i] # log best results in the summary
+                        loggers.wandb.wandb_run.summary[f'best/{name}'] = br[i]  # log best results in the summary
             log_vals = list(mloss) + list(results) + lr
             callbacks.run('on_fit_epoch_end', log_vals, epoch, best_fitness, fi)
 

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -47,6 +47,7 @@ class Loggers():
                      'metrics/precision', 'metrics/recall', 'metrics/mAP_0.5', 'metrics/mAP_0.5:0.95',  # metrics
                      'val/box_loss', 'val/obj_loss', 'val/cls_loss',  # val loss
                      'x/lr0', 'x/lr1', 'x/lr2']  # params
+        self.best_keys = ['best/epoch', 'best/precision', 'best/recall', 'best/mAP_0.5', 'best/mAP_0.5:0.95',]
         for k in LOGGERS:
             setattr(self, k, None)  # init empty logger dictionary
         self.csv = True  # always log to csv
@@ -125,6 +126,10 @@ class Loggers():
                 self.tb.add_scalar(k, v, epoch)
 
         if self.wandb:
+            if best_fitness==fi:
+                    best_results = [epoch] + vals[3:7]
+                    for i, name in enumerate(self.best_keys):
+                        self.wandb.wandb_run.summary[name] = best_results[i]  # log best results in the summary
             self.wandb.log(x)
             self.wandb.end_epoch(best_result=best_fitness == fi)
 

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -126,10 +126,10 @@ class Loggers():
                 self.tb.add_scalar(k, v, epoch)
 
         if self.wandb:
-            if best_fitness==fi:
-                    best_results = [epoch] + vals[3:7]
-                    for i, name in enumerate(self.best_keys):
-                        self.wandb.wandb_run.summary[name] = best_results[i]  # log best results in the summary
+            if best_fitness == fi:
+                best_results = [epoch] + vals[3:7]
+                for i, name in enumerate(self.best_keys):
+                    self.wandb.wandb_run.summary[name] = best_results[i]  # log best results in the summary
             self.wandb.log(x)
             self.wandb.end_epoch(best_result=best_fitness == fi)
 


### PR DESCRIPTION
`metrics/map@0.5` doesn't log the best result rather it logs the latest result. So, where **best_score** != **latest_score** we have to figure out the **best_score** from plot which a bit time consuming. Check out this pic below,
![image](https://user-images.githubusercontent.com/36858976/147312497-80db93cf-d557-40dc-8268-976a45bf0328.png)

 It would be cool to have `best/map@0.5` where we can check **best_scores** after each epoch. So, even our run gets canceled we can know in which epoch we had the **best_result**. This will help us to compare different runs easily.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging for 'best' metrics in YOLOv5 training runs.

### 📊 Key Changes
- Added a new attribute `best_keys` to the logger, holding keys for best epoch and best metrics.
- Implemented conditional logic to log best training results into the Weights & Biases (WandB) summary.

### 🎯 Purpose & Impact
- 🎯 **Purpose:** The update ensures that the best epoch and the best values for precision, recall, and mean Average Precision (mAP) at different IoU thresholds are recorded. This allows users to easily identify and review top-performing epochs within their machine learning experiments.
- 🚀 **Impact:** Users conducting experiments with YOLOv5 will benefit from a more streamlined way to understand their model's best performance outputs. This can lead to more informed decisions around model improvement and tuning.