### PR TITLE
W&B: Log best results after training ends

### DIFF
--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -147,9 +147,11 @@ class Loggers():
                 self.tb.add_image(f.stem, cv2.imread(str(f))[..., ::-1], epoch, dataformats='HWC')
 
         if self.wandb:
+            x = {k: v for k, v in zip(self.keys[3:10], results)}  # dict
+            self.wandb.log(x)
             self.wandb.log({"Results": [wandb.Image(str(f), caption=f.name) for f in files]})
             # Calling wandb.log. TODO: Refactor this into WandbLogger.log_model
-            if not self.opt.evolve:
+            if not self.opt.evolve: 
                 wandb.log_artifact(str(best if best.exists() else last), type='model',
                                    name='run_' + self.wandb.wandb_run.id + '_model',
                                    aliases=['latest', 'best', 'stripped'])

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -151,7 +151,7 @@ class Loggers():
             self.wandb.log(x)
             self.wandb.log({"Results": [wandb.Image(str(f), caption=f.name) for f in files]})
             # Calling wandb.log. TODO: Refactor this into WandbLogger.log_model
-            if not self.opt.evolve: 
+            if not self.opt.evolve:
                 wandb.log_artifact(str(best if best.exists() else last), type='model',
                                    name='run_' + self.wandb.wandb_run.id + '_model',
                                    aliases=['latest', 'best', 'stripped'])

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -147,8 +147,7 @@ class Loggers():
                 self.tb.add_image(f.stem, cv2.imread(str(f))[..., ::-1], epoch, dataformats='HWC')
 
         if self.wandb:
-            x = {k: v for k, v in zip(self.keys[3:10], results)}  # dict
-            self.wandb.log(x)
+            self.wandb.log({k: v for k, v in zip(self.keys[3:10], results)})  # log best.pt val results
             self.wandb.log({"Results": [wandb.Image(str(f), caption=f.name) for f in files]})
             # Calling wandb.log. TODO: Refactor this into WandbLogger.log_model
             if not self.opt.evolve:


### PR DESCRIPTION
@glenn-jocher I noticed the final val results from `best.pt` was not being logged in the loggers class for both wandb and tb. This PR addressed multiple issues and PRs.
fixes issue -> https://github.com/ultralytics/yolov5/issues/6116
Solves PR -> https://github.com/ultralytics/yolov5/pull/6085

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved logging for the YOLOv5 Weights & Biases integration.

### 📊 Key Changes
- Added enhanced Weights & Biases (WandB) logging capabilities.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: This change aims to provide more detailed performance metrics of the best model version during training by logging additional validation results to WandB.
- 🔍 **Impact**: Users will be able to see a more comprehensive set of metrics in their WandB project, allowing for better tracking of model improvements and easier identification of the best model. This can lead to more informed decisions during model development and optimization.