### PR TITLE
set lr by command line option

### DIFF
--- a/data/hyps/hyp.finetune.yaml
+++ b/data/hyps/hyp.finetune.yaml
@@ -8,8 +8,6 @@
 #                   P         R     mAP.5 mAP.5:.95       box       obj       cls
 # Metrics:        0.6     0.936     0.896     0.684    0.0115   0.00805   0.00146
 
-lr0: 0.0032
-lrf: 0.12
 momentum: 0.843
 weight_decay: 0.00036
 warmup_epochs: 2.0

--- a/data/hyps/hyp.finetune_objects365.yaml
+++ b/data/hyps/hyp.finetune_objects365.yaml
@@ -1,7 +1,5 @@
 # YOLOv5 🚀 by Ultralytics, GPL-3.0 license
 
-lr0: 0.00258
-lrf: 0.17
 momentum: 0.779
 weight_decay: 0.00058
 warmup_epochs: 1.33

--- a/data/hyps/hyp.scratch-high.yaml
+++ b/data/hyps/hyp.scratch-high.yaml
@@ -3,8 +3,6 @@
 # python train.py --batch 32 --cfg yolov5m6.yaml --weights '' --data coco.yaml --img 1280 --epochs 300
 # See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials
 
-lr0: 0.01  # initial learning rate (SGD=1E-2, Adam=1E-3)
-lrf: 0.2  # final OneCycleLR learning rate (lr0 * lrf)
 momentum: 0.937  # SGD momentum/Adam beta1
 weight_decay: 0.0005  # optimizer weight decay 5e-4
 warmup_epochs: 3.0  # warmup epochs (fractions ok)

--- a/data/hyps/hyp.scratch-low.yaml
+++ b/data/hyps/hyp.scratch-low.yaml
@@ -3,8 +3,6 @@
 # python train.py --batch 64 --cfg yolov5n6.yaml --weights '' --data coco.yaml --img 640 --epochs 300 --linear
 # See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials
 
-lr0: 0.01  # initial learning rate (SGD=1E-2, Adam=1E-3)
-lrf: 0.01  # final OneCycleLR learning rate (lr0 * lrf)
 momentum: 0.937  # SGD momentum/Adam beta1
 weight_decay: 0.0005  # optimizer weight decay 5e-4
 warmup_epochs: 3.0  # warmup epochs (fractions ok)

--- a/data/hyps/hyp.scratch-med.yaml
+++ b/data/hyps/hyp.scratch-med.yaml
@@ -3,8 +3,6 @@
 # python train.py --batch 32 --cfg yolov5m6.yaml --weights '' --data coco.yaml --img 1280 --epochs 300
 # See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials
 
-lr0: 0.01  # initial learning rate (SGD=1E-2, Adam=1E-3)
-lrf: 0.1  # final OneCycleLR learning rate (lr0 * lrf)
 momentum: 0.937  # SGD momentum/Adam beta1
 weight_decay: 0.0005  # optimizer weight decay 5e-4
 warmup_epochs: 3.0  # warmup epochs (fractions ok)

--- a/data/hyps/hyp.scratch.yaml
+++ b/data/hyps/hyp.scratch.yaml
@@ -3,8 +3,6 @@
 # python train.py --batch 40 --cfg yolov5m.yaml --weights '' --data coco.yaml --img 640 --epochs 300
 # See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials
 
-lr0: 0.01  # initial learning rate (SGD=1E-2, Adam=1E-3)
-lrf: 0.1  # final OneCycleLR learning rate (lr0 * lrf)
 momentum: 0.937  # SGD momentum/Adam beta1
 weight_decay: 0.0005  # optimizer weight decay 5e-4
 warmup_epochs: 3.0  # warmup epochs (fractions ok)

--- a/train.py
+++ b/train.py
@@ -275,8 +275,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     scheduler.last_epoch = start_epoch - 1  # do not move
     scaler = amp.GradScaler(enabled=cuda)
     stopper = EarlyStopping(patience=opt.patience)
-    adapt_to_batch_size = opt.optimizer == 'SGD'
-    compute_loss = ComputeLoss(model, adapt_to_batch_size)  # init loss class
+    compute_loss = ComputeLoss(model, adapt_to_batch_size=not opt.disable_loss_scaling)  # init loss class
     LOGGER.info(f'Image sizes {imgsz} train, {imgsz} val\n'
                 f'Using {train_loader.num_workers * WORLD_SIZE} dataloader workers\n'
                 f"Logging results to {colorstr('bold', save_dir)}\n"
@@ -483,6 +482,7 @@ def parse_opt(known=False):
     parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
+    parser.add_argument('--disable-loss-scaling', action='store_true', help='disable scaling loss along with batch size')
 
     # Weights & Biases arguments
     parser.add_argument('--entity', default=None, help='W&B: Entity')

--- a/train.py
+++ b/train.py
@@ -275,7 +275,8 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     scheduler.last_epoch = start_epoch - 1  # do not move
     scaler = amp.GradScaler(enabled=cuda)
     stopper = EarlyStopping(patience=opt.patience)
-    compute_loss = ComputeLoss(model)  # init loss class
+    adapt_to_batch_size = opt.optimizer == 'SGD'
+    compute_loss = ComputeLoss(model, adapt_to_batch_size)  # init loss class
     LOGGER.info(f'Image sizes {imgsz} train, {imgsz} val\n'
                 f'Using {train_loader.num_workers * WORLD_SIZE} dataloader workers\n'
                 f"Logging results to {colorstr('bold', save_dir)}\n"

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -90,7 +90,8 @@ class QFocalLoss(nn.Module):
 
 class ComputeLoss:
     # Compute losses
-    def __init__(self, model, autobalance=False):
+    def __init__(self, model, autobalance=False, adapt_to_batch_size=True):
+        self.adapt_to_batch_size = adapt_to_batch_size
         self.sort_obj_iou = False
         device = next(model.parameters()).device  # get model device
         h = model.hyp  # hyperparameters
@@ -163,8 +164,9 @@ class ComputeLoss:
         lobj *= self.hyp['obj']
         lcls *= self.hyp['cls']
         bs = tobj.shape[0]  # batch size
+        scale = bs if self.adapt_to_batch_size else 1
 
-        return (lbox + lobj + lcls) * bs, torch.cat((lbox, lobj, lcls)).detach()
+        return (lbox + lobj + lcls) * scale, torch.cat((lbox, lobj, lcls)).detach()
 
     def build_targets(self, p, targets):
         # Build targets for compute_loss(), input targets(image,class,x,y,w,h)


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated learning rate configurations and loss scaling for Ultralytics YOLOv5 training.

### 📊 Key Changes
- Removed initial learning rate (`lr0`) and final learning rate factor (`lrf`) from multiple hyperparameter files.
- Learning rates are now set directly in `train.py` via new command line arguments `--lr0` and `--lrf`.
- The loss computation class `ComputeLoss` has been updated with an option to disable scaling loss with batch size.

### 🎯 Purpose & Impact
- 💡 _**Purpose:**_ Streamline learning rate configuration and make loss scaling flexible during training.
- 🚀 _**Impact:**_ Users can easily set and adjust learning rates when executing training runs, potentially enhancing model performance. The scalability of loss calculations with batch sizes can be toggled, allowing for finer control over loss behavior, which might be beneficial in specific training scenarios.