### PR TITLE
Update NMS `max_wh=7680` for 8k images

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -660,7 +660,7 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
     assert 0 <= iou_thres <= 1, f'Invalid IoU {iou_thres}, valid values are between 0.0 and 1.0'
 
     # Settings
-    min_wh, max_wh = 2, 4096  # (pixels) minimum and maximum box width and height
+    min_wh, max_wh = 2, 7680  # (pixels) minimum and maximum box width and height
     max_nms = 30000  # maximum number of boxes into torchvision.ops.nms()
     time_limit = 10.0  # seconds to quit after
     redundant = True  # require redundant detections


### PR DESCRIPTION
In response to discussion on 8k inference in #6137 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Increased maximum bounding box size in NMS.

### 📊 Key Changes
- The maximum width and height for bounding boxes in non-maximum suppression (NMS) has been increased from 4096 to 7680 pixels.

### 🎯 Purpose & Impact
- 📈 This change allows the system to handle larger images, which could be beneficial for high-resolution datasets.
- 🌐 Users working with high-resolution imagery will benefit from this change as it improves the model's ability to detect large objects.
- 💡 There should be minimal impact on existing users unless they work with high-resolution images, where they'll see improved detection capabilities.