### PR TITLE
Fix `nan`-robust stream FPS

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -6,6 +6,7 @@ Dataloaders and dataset utils
 import glob
 import hashlib
 import json
+import math
 import os
 import random
 import shutil
@@ -308,8 +309,9 @@ class LoadStreams:
             assert cap.isOpened(), f'{st}Failed to open {s}'
             w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
             h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-            self.fps[i] = max(cap.get(cv2.CAP_PROP_FPS) % 100, 0) or 30.0  # 30 FPS fallback
+            fps = cap.get(cv2.CAP_PROP_FPS)  # warning: may return 0 or nan
             self.frames[i] = max(int(cap.get(cv2.CAP_PROP_FRAME_COUNT)), 0) or float('inf')  # infinite stream fallback
+            self.fps[i] = max((fps if math.isfinite(fps) else 0) % 100, 0) or 30  # 30 FPS fallback
 
             _, self.imgs[i] = cap.read()  # guarantee first frame
             self.threads[i] = Thread(target=self.update, args=([i, cap, s]), daemon=True)


### PR DESCRIPTION
Fix for Webcam stop working suddenly (Issue #6197)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved video frame rate detection in YOLOv5's dataset utility.

### 📊 Key Changes
- Imported the `math` library to handle numeric operations.
- Updated the frame-per-second (fps) detection to handle non-finite values gracefully.

### 🎯 Purpose & Impact
- To ensure that the fps value is valid and to avoid potential errors with incorrect values.
- Users should experience more reliable video processing with accurate frame rate handling, especially when the fps value returned by a video capture is `0` or `nan` (not a number).
- The fallback fps is set to 30, providing a consistent default when actual fps can't be determined. 🎥⏱