### PR TITLE
TFLite `--int8` 'flatbuffers==1.12' fix

### DIFF
--- a/export.py
+++ b/export.py
@@ -288,6 +288,7 @@ def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('Te
         converter.target_spec.supported_types = [tf.float16]
         converter.optimizations = [tf.lite.Optimize.DEFAULT]
         if int8:
+            check_requirements(('flatbuffers==1.12',))  # issue https://github.com/ultralytics/yolov5/issues/5707
             dataset = LoadImages(check_dataset(data)['train'], img_size=imgsz, auto=False)  # representative data
             converter.representative_dataset = lambda: representative_dataset_gen(dataset, ncalib)
             converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]

--- a/export.py
+++ b/export.py
@@ -275,8 +275,6 @@ def export_pb(keras_model, im, file, prefix=colorstr('TensorFlow GraphDef:')):
 def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('TensorFlow Lite:')):
     # YOLOv5 TensorFlow Lite export
     try:
-        if int8:
-            check_requirements(('flatbuffers==1.12',))  # issue https://github.com/ultralytics/yolov5/issues/5707
         import tensorflow as tf
 
         LOGGER.info(f'\n{prefix} starting export with tensorflow {tf.__version__}...')
@@ -289,6 +287,7 @@ def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('Te
         converter.optimizations = [tf.lite.Optimize.DEFAULT]
         if int8:
             from models.tf import representative_dataset_gen
+            check_requirements(('flatbuffers==1.12',))  # https://github.com/ultralytics/yolov5/issues/5707
             dataset = LoadImages(check_dataset(data)['train'], img_size=imgsz, auto=False)  # representative data
             converter.representative_dataset = lambda: representative_dataset_gen(dataset, ncalib)
             converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]

--- a/export.py
+++ b/export.py
@@ -275,9 +275,9 @@ def export_pb(keras_model, im, file, prefix=colorstr('TensorFlow GraphDef:')):
 def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('TensorFlow Lite:')):
     # YOLOv5 TensorFlow Lite export
     try:
+        if int8:
+            check_requirements(('flatbuffers==1.12',))  # issue https://github.com/ultralytics/yolov5/issues/5707
         import tensorflow as tf
-
-        from models.tf import representative_dataset_gen
 
         LOGGER.info(f'\n{prefix} starting export with tensorflow {tf.__version__}...')
         batch_size, ch, *imgsz = list(im.shape)  # BCHW
@@ -288,7 +288,7 @@ def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('Te
         converter.target_spec.supported_types = [tf.float16]
         converter.optimizations = [tf.lite.Optimize.DEFAULT]
         if int8:
-            check_requirements(('flatbuffers==1.12',))  # issue https://github.com/ultralytics/yolov5/issues/5707
+            from models.tf import representative_dataset_gen
             dataset = LoadImages(check_dataset(data)['train'], img_size=imgsz, auto=False)  # representative data
             converter.representative_dataset = lambda: representative_dataset_gen(dataset, ncalib)
             converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]


### PR DESCRIPTION
Temporary workaround for TFLite INT8 export. 

NOTE: This will install `flatbuffers==1.12` automatically but you will need to **restart your environment for change to take effect**.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of TensorFlow Lite (TFLite) export process in YOLOv5 repository.

### 📊 Key Changes
- Removed the upfront import of `representative_dataset_gen` from the TensorFlow models directory.
- Conditionally imported `representative_dataset_gen` only when int8 quantization is used.
- Added a requirement check for `flatbuffers==1.12` in the int8 quantization conditional block to resolve a specific issue linked in a GitHub issue (#5707).

### 🎯 Purpose & Impact
- The main purpose of these changes is to streamline the export script by reducing unnecessary imports and ensuring additional requirements are met only when required for a specific export case.
- This has the potential impact of reducing initial load time/memory usage when exporting models to TFLite format and avoiding import errors for users who aren't using int8 quantization.
- Additionally, by adding a version check for `flatbuffers`, the PR aims to prevent compatibility issues that users might encounter when exporting int8 TFLite models, thus improving the reliability of the export process. 🚀