### PR TITLE
TFLite `--int8` 'flatbuffers==1.12' fix 2

### DIFF
--- a/export.py
+++ b/export.py
@@ -287,7 +287,6 @@ def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('Te
         converter.optimizations = [tf.lite.Optimize.DEFAULT]
         if int8:
             from models.tf import representative_dataset_gen
-            check_requirements(('flatbuffers==1.12',))  # https://github.com/ultralytics/yolov5/issues/5707
             dataset = LoadImages(check_dataset(data)['train'], img_size=imgsz, auto=False)  # representative data
             converter.representative_dataset = lambda: representative_dataset_gen(dataset, ncalib)
             converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
@@ -391,6 +390,8 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
     # Checks
     imgsz *= 2 if len(imgsz) == 1 else 1  # expand
     opset = 12 if ('openvino' in include) else opset  # OpenVINO requires opset <= 12
+    if (('tflite' in include) or ('edgetpu' in include)) and int8:
+        check_requirements(('flatbuffers==1.12',))  # TFLite fix https://github.com/ultralytics/yolov5/issues/5707
 
     # Load PyTorch model
     device = select_device(device)

--- a/export.py
+++ b/export.py
@@ -390,8 +390,6 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
     # Checks
     imgsz *= 2 if len(imgsz) == 1 else 1  # expand
     opset = 12 if ('openvino' in include) else opset  # OpenVINO requires opset <= 12
-    if (('tflite' in include) or ('edgetpu' in include)) and int8:
-        check_requirements(('flatbuffers==1.12',))  # TFLite fix https://github.com/ultralytics/yolov5/issues/5707
 
     # Load PyTorch model
     device = select_device(device)
@@ -436,6 +434,8 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
     # TensorFlow Exports
     if any(tf_exports):
         pb, tflite, edgetpu, tfjs = tf_exports[1:]
+        if (tflite or edgetpu) and int8:  # TFLite --int8 bug https://github.com/ultralytics/yolov5/issues/5707
+            check_requirements(('flatbuffers==1.12',))  # required before `import tensorflow`
         assert not (tflite and tfjs), 'TFLite and TF.js models must be exported separately, please pass only one type.'
         model = export_saved_model(model, im, file, dynamic, tf_nms=nms or agnostic_nms or tfjs,
                                    agnostic_nms=agnostic_nms or tfjs, topk_per_class=topk_per_class, topk_all=topk_all,


### PR DESCRIPTION
Reorganizes #6216 fix to update before `tensorflow` import so no restart required.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improve TensorFlow Lite (TFLite) export process by handling a dependency issue.

### 📊 Key Changes
- Removed `flatbuffers==1.12` check in the TFLite export function.
- Added requirement check for `flatbuffers==1.12` before importing TensorFlow, only when exporting TFLite or EdgeTPU models with INT8 quantization.

### 🎯 Purpose & Impact
- 🛠 The change resolves a dependency issue linked to exporting INT8-quantized TFLite models, as reported in issue #5707.
- 📈 It ensures that the required version of Flatbuffers is installed beforehand, avoiding potential export failures.
- 💡 For users, this adjustment leads to a smoother experience when working with TFLite and Edge TPU exports, particularly when dealing with quantization.