### PR TITLE
Add `edgetpu_compiler` checks

### DIFF
--- a/export.py
+++ b/export.py
@@ -311,7 +311,7 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
         cmd = 'edgetpu_compiler --version'
         help = 'See https://coral.ai/docs/edgetpu/compiler/'
         assert platform.system() == 'Linux', f'export only supported on Linux. {help}'
-        assert subprocess.run(cmd + ' &> /dev/null', shell=True).returncode == 0, f'requires edgetpu-compiler. {help}'
+        assert subprocess.run(cmd, shell=True).returncode == 0, f'requires edgetpu-compiler. {help}'
         out = subprocess.run(cmd, shell=True, capture_output=True, check=True)
         ver = out.stdout.decode().split()[-1]
 

--- a/export.py
+++ b/export.py
@@ -311,7 +311,7 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
         cmd = 'edgetpu_compiler --version'
         help = 'See https://coral.ai/docs/edgetpu/compiler/'
         assert platform.system() == 'Linux', f'export only supported on Linux. {help}'
-        assert subprocess.run(cmd, shell=True).returncode == 0, f'requires edgetpu-compiler. {help}'
+        assert subprocess.run(cmd, shell=True).returncode == 0, f'export requires edgetpu-compiler. {help}'
         out = subprocess.run(cmd, shell=True, capture_output=True, check=True)
         ver = out.stdout.decode().split()[-1]
 

--- a/export.py
+++ b/export.py
@@ -309,9 +309,9 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
     # YOLOv5 Edge TPU export https://coral.ai/docs/edgetpu/models-intro/
     try:
         cmd = 'edgetpu_compiler --version'
-        help_url = 'https://coral.ai/docs/edgetpu/compiler/'
-        assert platform.system() == 'Linux', f'export only supported on Linux. See {help_url}'
-        assert subprocess.run(cmd, shell=True, check=True), f'export requires edgetpu-compiler. See {help_url}'
+        help = 'See https://coral.ai/docs/edgetpu/compiler/'
+        assert platform.system() == 'Linux', f'export only supported on Linux. {help}'
+        assert subprocess.run(cmd + ' &> /dev/null', shell=True).returncode == 0, f'requires edgetpu-compiler. {help}'
         out = subprocess.run(cmd, shell=True, capture_output=True, check=True)
         ver = out.stdout.decode().split()[-1]
 

--- a/export.py
+++ b/export.py
@@ -439,7 +439,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
     # TensorFlow Exports
     if any(tf_exports):
         pb, tflite, edgetpu, tfjs = tf_exports[1:]
-        if (tflite or edgetpu) and int8:  # TFLite --int8 bug https://github.com/ultralytics/yolov5/issues/5707
+        if int8 or edgetpu:  # TFLite --int8 bug https://github.com/ultralytics/yolov5/issues/5707
             check_requirements(('flatbuffers==1.12',))  # required before `import tensorflow`
         assert not (tflite and tfjs), 'TFLite and TF.js models must be exported separately, please pass only one type.'
         model = export_saved_model(model, im, file, dynamic, tf_nms=nms or agnostic_nms or tfjs,

--- a/export.py
+++ b/export.py
@@ -41,6 +41,7 @@ TensorFlow.js:
 import argparse
 import json
 import os
+import platform
 import subprocess
 import sys
 import time
@@ -307,9 +308,13 @@ def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('Te
 def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
     # YOLOv5 Edge TPU export https://coral.ai/docs/edgetpu/models-intro/
     try:
-        cmd = 'edgetpu_compiler --version'  # install https://coral.ai/docs/edgetpu/compiler/
+        cmd = 'edgetpu_compiler --version'
+        help_url = 'https://coral.ai/docs/edgetpu/compiler/'
+        assert platform.system() == 'Linux', 'export only supported on Linux'
+        assert subprocess.run(cmd, shell=True, check=True), f'export requires edgetpu-compiler. See {help_url}'
         out = subprocess.run(cmd, shell=True, capture_output=True, check=True)
         ver = out.stdout.decode().split()[-1]
+
         LOGGER.info(f'\n{prefix} starting export with Edge TPU compiler {ver}...')
         f = str(file).replace('.pt', '-int8_edgetpu.tflite')
         f_tfl = str(file).replace('.pt', '-int8.tflite')  # TFLite model

--- a/export.py
+++ b/export.py
@@ -316,7 +316,7 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
         ver = out.stdout.decode().split()[-1]
 
         LOGGER.info(f'\n{prefix} starting export with Edge TPU compiler {ver}...')
-        f = str(file).replace('.pt', '-int8_edgetpu.tflite')
+        f = str(file).replace('.pt', '-int8_edgetpu.tflite')  # Edge TPU model
         f_tfl = str(file).replace('.pt', '-int8.tflite')  # TFLite model
 
         cmd = f"edgetpu_compiler -s {f_tfl}"

--- a/export.py
+++ b/export.py
@@ -310,7 +310,7 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
     try:
         cmd = 'edgetpu_compiler --version'
         help_url = 'https://coral.ai/docs/edgetpu/compiler/'
-        assert platform.system() == 'Linux', 'export only supported on Linux'
+        assert platform.system() == 'Linux', f'export only supported on Linux. See {help_url}'
         assert subprocess.run(cmd, shell=True, check=True), f'export requires edgetpu-compiler. See {help_url}'
         out = subprocess.run(cmd, shell=True, capture_output=True, check=True)
         ver = out.stdout.decode().split()[-1]


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to YOLOv5 Edge TPU export with system compatibility checks and installation guidance.

### 📊 Key Changes
- Added a check to ensure Edge TPU export is only performed on Linux systems.
- Included an assertion to verify that the `edgetpu-compiler` is installed before proceeding.
- Amended the bug condition check for either int8 or Edge TPU to resolve the TFLite `--int8` export issue.

### 🎯 Purpose & Impact
- 🎓 The Linux system check and the `edgetpu-compiler` installation check prevent users from running Edge TPU export on incompatible systems, guiding them on how to set up their environment properly.
- 🐞 Addressing the TFLite `--int8` bug improves the reliability of exporting models to TFLite and Edge TPU, providing users with more stable model conversion options.
- 🛠️ These updates enhance user experience by providing clear error messages and instructions, ensuring that the export process only moves forward on a compatible setup.