### PR TITLE
Attempt `edgetpu-compiler` autoinstall

### DIFF
--- a/export.py
+++ b/export.py
@@ -311,16 +311,14 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
         cmd = 'edgetpu_compiler --version'
         help_url = 'https://coral.ai/docs/edgetpu/compiler/'
         assert platform.system() == 'Linux', f'export only supported on Linux. See {help_url}'
-        # assert subprocess.run(cmd, shell=True).returncode == 0, f'export requires edgetpu-compiler. {help}'
         if subprocess.run(cmd, shell=True).returncode != 0:
-            LOGGER.info(f'\n{prefix} export requires edgetpu-compiler. Installing from {help_url} ...')
+            LOGGER.info(f'\n{prefix} export requires Edge TPU compiler. Attempting install from {help_url}')
             cmds = ['curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -',
                     'echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list',
                     'sudo apt-get update',
                     'sudo apt-get install edgetpu-compiler']
             for c in cmds:
                 subprocess.run(c, shell=True, check=True)
-            LOGGER.info(f'\n{prefix} edgetpu-compiler install complete.')
         ver = subprocess.run(cmd, shell=True, capture_output=True, check=True).stdout.decode().split()[-1]
 
         LOGGER.info(f'\n{prefix} starting export with Edge TPU compiler {ver}...')

--- a/export.py
+++ b/export.py
@@ -309,11 +309,19 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
     # YOLOv5 Edge TPU export https://coral.ai/docs/edgetpu/models-intro/
     try:
         cmd = 'edgetpu_compiler --version'
-        help = 'See https://coral.ai/docs/edgetpu/compiler/'
-        assert platform.system() == 'Linux', f'export only supported on Linux. {help}'
-        assert subprocess.run(cmd, shell=True).returncode == 0, f'export requires edgetpu-compiler. {help}'
-        out = subprocess.run(cmd, shell=True, capture_output=True, check=True)
-        ver = out.stdout.decode().split()[-1]
+        help_url = 'https://coral.ai/docs/edgetpu/compiler/'
+        assert platform.system() == 'Linux', f'export only supported on Linux. See {help_url}'
+        # assert subprocess.run(cmd, shell=True).returncode == 0, f'export requires edgetpu-compiler. {help}'
+        if subprocess.run(cmd, shell=True).returncode != 0:
+            LOGGER.info(f'\n{prefix} export requires edgetpu-compiler. Installing from {help_url} ...')
+            cmds = ['curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -',
+                    'echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list',
+                    'sudo apt-get update',
+                    'sudo apt-get install edgetpu-compiler']
+            for c in cmds:
+                subprocess.run(c, shell=True, check=True)
+            LOGGER.info(f'\n{prefix} edgetpu-compiler install complete.')
+        ver = subprocess.run(cmd, shell=True, capture_output=True, check=True).stdout.decode().split()[-1]
 
         LOGGER.info(f'\n{prefix} starting export with Edge TPU compiler {ver}...')
         f = str(file).replace('.pt', '-int8_edgetpu.tflite')  # Edge TPU model

--- a/export.py
+++ b/export.py
@@ -313,11 +313,10 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
         assert platform.system() == 'Linux', f'export only supported on Linux. See {help_url}'
         if subprocess.run(cmd, shell=True).returncode != 0:
             LOGGER.info(f'\n{prefix} export requires Edge TPU compiler. Attempting install from {help_url}')
-            cmds = ['curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -',
-                    'echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list',
-                    'sudo apt-get update',
-                    'sudo apt-get install edgetpu-compiler']
-            for c in cmds:
+            for c in ['curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -',
+                      'echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list',
+                      'sudo apt-get update',
+                      'sudo apt-get install edgetpu-compiler']:
                 subprocess.run(c, shell=True, check=True)
         ver = subprocess.run(cmd, shell=True, capture_output=True, check=True).stdout.decode().split()[-1]
 


### PR DESCRIPTION
This PR enables automatic installation of Edge TPU compiler if required during export of Edge TPU models:
```bash
python export.py --weights yolov5s.pt --include edgetpu
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Edge TPU export reliability with automated compiler installation in YOLOv5.

### 📊 Key Changes
- Added checks to ensure the environment is Linux before attempting Edge TPU export.
- Automated the installation of the Edge TPU compiler if it's not already installed.
- Improved help messages with a URL to the Edge TPU compiler documentation.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To streamline the process of exporting YOLOv5 models to Edge TPU by making sure the required compiler is installed, thereby removing a manual step for users.
- 🌍 **Impact**: Users can export their models to Edge TPU more smoothly, particularly those who may not have been familiar with the necessary setup steps. This lowers the barrier to entry for deploying YOLOv5 models on Edge TPU devices.