### PR TITLE
Update README speed reproduction command

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ We are super excited about our first-ever Ultralytics YOLOv5 🚀 EXPORT Competi
 
 * All checkpoints are trained to 300 epochs with default settings and hyperparameters.
 * **mAP<sup>val</sup>** values are for single-model single-scale on [COCO val2017](http://cocodataset.org) dataset.<br>Reproduce by `python val.py --data coco.yaml --img 640 --conf 0.001 --iou 0.65`
-* **Speed** averaged over COCO val images using a [AWS p3.2xlarge](https://aws.amazon.com/ec2/instance-types/p3/) instance. NMS times (~1 ms/img) not included.<br>Reproduce by `python val.py --data coco.yaml --img 640 --conf 0.25 --iou 0.45`
+* **Speed** averaged over COCO val images using a [AWS p3.2xlarge](https://aws.amazon.com/ec2/instance-types/p3/) instance. NMS times (~1 ms/img) not included.<br>Reproduce by `python val.py --data coco.yaml --img 640 --task speed --batch 1`
 * **TTA** [Test Time Augmentation](https://github.com/ultralytics/yolov5/issues/303) includes reflection and scale augmentations.<br>Reproduce by `python val.py --data coco.yaml --img 1536 --iou 0.7 --augment`
 
 </details>


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved command instructions for measuring model inference speed in YOLOv5 README.

### 📊 Key Changes
- Updated the command to reproduce speed benchmarks for YOLOv5 models.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To provide clearer instructions on how to benchmark the speed of YOLOv5 models on the COCO dataset.
- 🚀 **Impact**: Users will benefit from an updated and more straightforward command to measure the inference speed of models, resulting in easier and more consistent speed testing.