### PR TITLE
Update P2-P7 `models/hub` variants

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -306,7 +306,7 @@ class DetectMultiBackend(nn.Module):
 
         if pt:  # PyTorch
             model = attempt_load(weights if isinstance(weights, list) else w, map_location=device)
-            stride = int(model.stride.max())  # model stride
+            stride = max(int(model.stride.max()), 32)  # model stride
             names = model.module.names if hasattr(model, 'module') else model.names  # get class names
             self.model = model  # explicitly assign for to(), cpu(), cuda(), half()
         elif jit:  # TorchScript

--- a/models/hub/yolov5-p2.yaml
+++ b/models/hub/yolov5-p2.yaml
@@ -4,7 +4,7 @@
 nc: 80  # number of classes
 depth_multiple: 1.0  # model depth multiple
 width_multiple: 1.0  # layer channel multiple
-anchors: 3  # auto-anchor evolves 3 anchors per P output layer
+anchors: 3  # AutoAnchor evolves 3 anchors per P output layer
 
 # YOLOv5 v6.0 backbone
 backbone:
@@ -21,7 +21,7 @@ backbone:
    [-1, 1, SPPF, [1024, 5]],  # 9
   ]
 
-# YOLOv5 v6.0 head
+# YOLOv5 v6.0 head with (P2, P3, P4, P5) outputs
 head:
   [[-1, 1, Conv, [512, 1, 1]],
    [-1, 1, nn.Upsample, [None, 2, 'nearest']],

--- a/models/hub/yolov5-p34.yaml
+++ b/models/hub/yolov5-p34.yaml
@@ -1,0 +1,41 @@
+# YOLOv5 🚀 by Ultralytics, GPL-3.0 license
+
+# Parameters
+nc: 80  # number of classes
+depth_multiple: 0.33  # model depth multiple
+width_multiple: 0.50  # layer channel multiple
+anchors: 3  # AutoAnchor evolves 3 anchors per P output layer
+
+# YOLOv5 v6.0 backbone
+backbone:
+  # [from, number, module, args]
+  [ [ -1, 1, Conv, [ 64, 6, 2, 2 ] ],  # 0-P1/2
+    [ -1, 1, Conv, [ 128, 3, 2 ] ],  # 1-P2/4
+    [ -1, 3, C3, [ 128 ] ],
+    [ -1, 1, Conv, [ 256, 3, 2 ] ],  # 3-P3/8
+    [ -1, 6, C3, [ 256 ] ],
+    [ -1, 1, Conv, [ 512, 3, 2 ] ],  # 5-P4/16
+    [ -1, 9, C3, [ 512 ] ],
+    [ -1, 1, Conv, [ 1024, 3, 2 ] ],  # 7-P5/32
+    [ -1, 3, C3, [ 1024 ] ],
+    [ -1, 1, SPPF, [ 1024, 5 ] ],  # 9
+  ]
+
+# YOLOv5 v6.0 head with (P3, P4) outputs
+head:
+  [ [ -1, 1, Conv, [ 512, 1, 1 ] ],
+    [ -1, 1, nn.Upsample, [ None, 2, 'nearest' ] ],
+    [ [ -1, 6 ], 1, Concat, [ 1 ] ],  # cat backbone P4
+    [ -1, 3, C3, [ 512, False ] ],  # 13
+
+    [ -1, 1, Conv, [ 256, 1, 1 ] ],
+    [ -1, 1, nn.Upsample, [ None, 2, 'nearest' ] ],
+    [ [ -1, 4 ], 1, Concat, [ 1 ] ],  # cat backbone P3
+    [ -1, 3, C3, [ 256, False ] ],  # 17 (P3/8-small)
+
+    [ -1, 1, Conv, [ 256, 3, 2 ] ],
+    [ [ -1, 14 ], 1, Concat, [ 1 ] ],  # cat head P4
+    [ -1, 3, C3, [ 512, False ] ],  # 20 (P4/16-medium)
+
+    [ [ 17, 20 ], 1, Detect, [ nc, anchors ] ],  # Detect(P3, P4)
+  ]

--- a/models/hub/yolov5-p6.yaml
+++ b/models/hub/yolov5-p6.yaml
@@ -4,7 +4,7 @@
 nc: 80  # number of classes
 depth_multiple: 1.0  # model depth multiple
 width_multiple: 1.0  # layer channel multiple
-anchors: 3  # auto-anchor 3 anchors per P output layer
+anchors: 3  # AutoAnchor evolves 3 anchors per P output layer
 
 # YOLOv5 v6.0 backbone
 backbone:
@@ -23,7 +23,7 @@ backbone:
    [-1, 1, SPPF, [1024, 5]],  # 11
   ]
 
-# YOLOv5 v6.0 head
+# YOLOv5 v6.0 head with (P3, P4, P5, P6) outputs
 head:
   [[-1, 1, Conv, [768, 1, 1]],
    [-1, 1, nn.Upsample, [None, 2, 'nearest']],

--- a/models/hub/yolov5-p7.yaml
+++ b/models/hub/yolov5-p7.yaml
@@ -4,7 +4,7 @@
 nc: 80  # number of classes
 depth_multiple: 1.0  # model depth multiple
 width_multiple: 1.0  # layer channel multiple
-anchors: 3  # auto-anchor 3 anchors per P output layer
+anchors: 3  # AutoAnchor evolves 3 anchors per P output layer
 
 # YOLOv5 v6.0 backbone
 backbone:
@@ -25,7 +25,7 @@ backbone:
    [-1, 1, SPPF, [1280, 5]],  # 13
   ]
 
-# YOLOv5 head
+# YOLOv5 v6.0 head with (P3, P4, P5, P6, P7) outputs
 head:
   [[-1, 1, Conv, [1024, 1, 1]],
    [-1, 1, nn.Upsample, [None, 2, 'nearest']],

--- a/train.py
+++ b/train.py
@@ -461,7 +461,7 @@ def parse_opt(known=False):
     parser.add_argument('--resume', nargs='?', const=True, default=False, help='resume most recent training')
     parser.add_argument('--nosave', action='store_true', help='only save final checkpoint')
     parser.add_argument('--noval', action='store_true', help='only validate final epoch')
-    parser.add_argument('--noautoanchor', action='store_true', help='disable autoanchor check')
+    parser.add_argument('--noautoanchor', action='store_true', help='disable AutoAnchor')
     parser.add_argument('--evolve', type=int, nargs='?', const=300, help='evolve hyperparameters for x generations')
     parser.add_argument('--bucket', type=str, default='', help='gsutil bucket')
     parser.add_argument('--cache', type=str, nargs='?', const='ram', help='--cache images in "ram" (default) or "disk"')

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -777,7 +777,7 @@
             "\u001b[34m\u001b[1mval: \u001b[0mCaching images (0.1GB ram): 100% 128/128 [00:01<00:00, 121.58it/s]\n",
             "Plotting labels... \n",
             "\n",
-            "\u001b[34m\u001b[1mautoanchor: \u001b[0mAnalyzing anchors... anchors/target = 4.27, Best Possible Recall (BPR) = 0.9935\n",
+            "\u001b[34m\u001b[1mAutoAnchor: \u001b[0mAnalyzing anchors... anchors/target = 4.27, Best Possible Recall (BPR) = 0.9935\n",
             "Image sizes 640 train, 640 val\n",
             "Using 2 dataloader workers\n",
             "Logging results to \u001b[1mruns/train/exp\u001b[0m\n",


### PR DESCRIPTION
Also create new P3, P4 output model `yolov5-p34.yaml`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced YOLOv5 models and training features to improve performance and consistency.

### 📊 Key Changes
- 🛠 Adjusted model stride calculation to ensure a minimum stride of 32.
- 📝 Standardized comment formatting for 'anchors' across multiple YAML configuration files.
- 📐 Introduced a new model configuration file `models/hub/yolov5-p34.yaml` with specific depth and width multiples and layers.
- 🤖 Clarified output layer descriptions in YAML files to showcase the specific outputs (e.g., P2, P3, P4, P5) of each YOLOv5 model version.
- ✏️ Renamed command-line arguments and tutorial documentation for consistency, changing 'autoanchor' to 'AutoAnchor'.

### 🎯 Purpose & Impact
- 🏃 Ensuring a standard stride improves the model's capability to handle varying input sizes and could lead to more stable performance across devices.
- 🧐 Standardizing documentation and comments improves the readability and understanding of the codebase for developers and users.
- 👁️‍🗨️ Adding a new model configuration allows for more variety in model selection, catering to different performance and resource requirements.
- 🧑‍🏫 Renaming 'autoanchor' to 'AutoAnchor' makes the training process descriptions and logs more clear and professional, reducing potential confusion.