### PR TITLE
Fix `cmd` string on `tfjs` export

### DIFF
--- a/export.py
+++ b/export.py
@@ -346,7 +346,7 @@ def export_tfjs(keras_model, im, file, prefix=colorstr('TensorFlow.js:')):
         f_json = f + '/model.json'  # *.json path
 
         cmd = f"tensorflowjs_converter --input_format=tf_frozen_model " \
-              f"--output_node_names='Identity,Identity_1,Identity_2,Identity_3' {f_pb} {f}"
+              f"--output_node_names=\"Identity,Identity_1,Identity_2,Identity_3\" {f_pb} {f}"
         subprocess.run(cmd, shell=True)
 
         json = open(f_json).read()

--- a/export.py
+++ b/export.py
@@ -345,8 +345,8 @@ def export_tfjs(keras_model, im, file, prefix=colorstr('TensorFlow.js:')):
         f_pb = file.with_suffix('.pb')  # *.pb path
         f_json = f + '/model.json'  # *.json path
 
-        cmd = f"tensorflowjs_converter --input_format=tf_frozen_model " \
-              f"--output_node_names=\"Identity,Identity_1,Identity_2,Identity_3\" {f_pb} {f}"
+        cmd = f'tensorflowjs_converter --input_format=tf_frozen_model ' \
+              f'--output_node_names="Identity,Identity_1,Identity_2,Identity_3" {f_pb} {f}'
         subprocess.run(cmd, shell=True)
 
         json = open(f_json).read()


### PR DESCRIPTION
I tried to export my `best.pt` to tfjs model.
But, in windows system occured in `subprocess.run(cmd, shell=True)`

Error content
```
...
KeyError: 'The name "\'Identity" refers to an Operation not in the graph.'
```

I think it occured by os differences like `' ' , " "`

This error can be seen here #5941 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to TensorFlow.js export command in Ultralytics YOLOv5.

### 📊 Key Changes
- Modified the command used for converting TensorFlow models to TensorFlow.js format.
- Changed single quotes to double quotes around the `--output_node_names` parameter in the `tensorflowjs_converter` command.

### 🎯 Purpose & Impact
- Ensures compatibility with shell commands on different operating systems.
- 🛠️ Fixes potential issues with command execution that could affect users trying to export their models to TensorFlow.js.
- 🌐 Helps maintain a smooth user experience for developers working on web and JavaScript applications using YOLOv5 models.