### PR TITLE
Fix TF exports >= 2GB

### DIFF
--- a/export.py
+++ b/export.py
@@ -247,7 +247,7 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
 
 def export_saved_model(model, im, file, dynamic,
                        tf_nms=False, agnostic_nms=False, topk_per_class=100, topk_all=100, iou_thres=0.45,
-                       conf_thres=0.25, use_keras=False, prefix=colorstr('TensorFlow SavedModel:')):
+                       conf_thres=0.25, keras=False, prefix=colorstr('TensorFlow SavedModel:')):
     # YOLOv5 TensorFlow SavedModel export
     try:
         import tensorflow as tf
@@ -267,7 +267,7 @@ def export_saved_model(model, im, file, dynamic,
         keras_model = tf.keras.Model(inputs=inputs, outputs=outputs)
         keras_model.trainable = False
         keras_model.summary()
-        if use_keras:
+        if keras:
             keras_model.save(f, save_format='tf')
         else:
             m = tf.function(lambda x: keras_model(x))  # full model

--- a/export.py
+++ b/export.py
@@ -280,7 +280,7 @@ def export_saved_model(model, im, file, dynamic,
             tfm,
             f,
             options=tf.saved_model.SaveOptions() if parse_version(tf.__version__) < parse_version("2.6") else
-                tf.saved_model.SaveOptions(experimental_custom_gradients=False))
+            tf.saved_model.SaveOptions(experimental_custom_gradients=False))
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')
         return keras_model, f
     except Exception as e:

--- a/export.py
+++ b/export.py
@@ -253,8 +253,8 @@ def export_saved_model(model, im, file, dynamic,
     try:
         import tensorflow as tf
         from tensorflow import keras
-        from tensorflow.python.saved_model import signature_constants, tag_constants
         from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
+        from tensorflow.python.saved_model import signature_constants, tag_constants
 
         from models.tf import TFDetect, TFModel
 

--- a/export.py
+++ b/export.py
@@ -273,7 +273,7 @@ def export_saved_model(model, im, file, dynamic,
         m = m.get_concrete_function(tf.TensorSpec(keras_model.inputs[0].shape, keras_model.inputs[0].dtype))
         frozen_func = convert_variables_to_constants_v2(m)
         tfm = tf.Module()
-        tfm.__call__ = tf.function(lambda x: frozen_func(x),
+        tfm.__call__ = tf.function(frozen_func,
                                    [tf.TensorSpec(keras_model.inputs[0].shape, keras_model.inputs[0].dtype)])
         tfm.__call__(im)
         tf.saved_model.save(

--- a/export.py
+++ b/export.py
@@ -52,11 +52,11 @@ import sys
 import time
 import warnings
 from pathlib import Path
-from packaging.version import parse as parse_version
 
 import pandas as pd
 import torch
 import torch.nn as nn
+from packaging.version import parse as parse_version
 from torch.utils.mobile_optimizer import optimize_for_mobile
 
 FILE = Path(__file__).resolve()

--- a/export.py
+++ b/export.py
@@ -273,7 +273,7 @@ def export_saved_model(model, im, file, dynamic,
         m = m.get_concrete_function(tf.TensorSpec(keras_model.inputs[0].shape, keras_model.inputs[0].dtype))
         frozen_func = convert_variables_to_constants_v2(m)
         tfm = tf.Module()
-        tfm.__call__ = tf.function(frozen_func,
+        tfm.__call__ = tf.function(lambda x: frozen_func(x),
                                    [tf.TensorSpec(keras_model.inputs[0].shape, keras_model.inputs[0].dtype)])
         tfm.__call__(im)
         tf.saved_model.save(

--- a/export.py
+++ b/export.py
@@ -46,7 +46,6 @@ import argparse
 import json
 import os
 import platform
-import shutil
 import subprocess
 import sys
 import time
@@ -255,7 +254,6 @@ def export_saved_model(model, im, file, dynamic,
         import tensorflow as tf
         from tensorflow import keras
         from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
-        from tensorflow.python.saved_model import signature_constants, tag_constants
 
         from models.tf import TFDetect, TFModel
 

--- a/models/common.py
+++ b/models/common.py
@@ -360,11 +360,11 @@ class DetectMultiBackend(nn.Module):
                 LOGGER.info(f'Loading {w} for TensorFlow SavedModel inference...')
                 import tensorflow as tf
                 try:
-                    model = tf.keras.models.load_model(w)
-                    keras = True
-                except Exception:
                     model = tf.saved_model.load(w)
                     keras = False
+                except Exception:
+                    model = tf.keras.models.load_model(w)
+                    keras = True
             elif pb:  # GraphDef https://www.tensorflow.org/guide/migrate#a_graphpb_or_graphpbtxt
                 LOGGER.info(f'Loading {w} for TensorFlow GraphDef inference...')
                 import tensorflow as tf
@@ -436,7 +436,7 @@ class DetectMultiBackend(nn.Module):
         else:  # TensorFlow (SavedModel, GraphDef, Lite, Edge TPU)
             im = im.permute(0, 2, 3, 1).cpu().numpy()  # torch BCHW to numpy BHWC shape(1,320,192,3)
             if self.saved_model:  # SavedModel
-                y = (self.model(im, training=False) if self.keras else self.model(x=self.tf.constant(im))[0]).numpy()
+                y = (self.model(im, training=False) if self.keras else self.model(im)[0]).numpy()
             elif self.pb:  # GraphDef
                 y = self.frozen_func(x=self.tf.constant(im)).numpy()
             elif self.tflite:  # Lite

--- a/models/common.py
+++ b/models/common.py
@@ -359,7 +359,6 @@ class DetectMultiBackend(nn.Module):
             if saved_model:  # SavedModel
                 LOGGER.info(f'Loading {w} for TensorFlow SavedModel inference...')
                 import tensorflow as tf
-                from tensorflow.python.saved_model import tag_constants
                 model = tf.saved_model.load(w)
             elif pb:  # GraphDef https://www.tensorflow.org/guide/migrate#a_graphpb_or_graphpbtxt
                 LOGGER.info(f'Loading {w} for TensorFlow GraphDef inference...')

--- a/models/common.py
+++ b/models/common.py
@@ -431,7 +431,7 @@ class DetectMultiBackend(nn.Module):
         else:  # TensorFlow (SavedModel, GraphDef, Lite, Edge TPU)
             im = im.permute(0, 2, 3, 1).cpu().numpy()  # torch BCHW to numpy BHWC shape(1,320,192,3)
             if self.saved_model:  # SavedModel
-                y = self.model(im)[0].numpy()
+                y = self.model(x=self.tf.constant(im))[0].numpy()
             elif self.pb:  # GraphDef
                 y = self.frozen_func(x=self.tf.constant(im)).numpy()
             elif self.tflite:  # Lite

--- a/models/common.py
+++ b/models/common.py
@@ -360,8 +360,7 @@ class DetectMultiBackend(nn.Module):
                 LOGGER.info(f'Loading {w} for TensorFlow SavedModel inference...')
                 import tensorflow as tf
                 from tensorflow.python.saved_model import tag_constants
-                model = tf.saved_model.load(w, tags=tag_constants.SERVING)
-                model = model.prune('x:0', 'Identity:0')
+                model = tf.saved_model.load(w)
             elif pb:  # GraphDef https://www.tensorflow.org/guide/migrate#a_graphpb_or_graphpbtxt
                 LOGGER.info(f'Loading {w} for TensorFlow GraphDef inference...')
                 import tensorflow as tf
@@ -433,7 +432,7 @@ class DetectMultiBackend(nn.Module):
         else:  # TensorFlow (SavedModel, GraphDef, Lite, Edge TPU)
             im = im.permute(0, 2, 3, 1).cpu().numpy()  # torch BCHW to numpy BHWC shape(1,320,192,3)
             if self.saved_model:  # SavedModel
-                y = self.model(x=self.tf.constant(im)).numpy()
+                y = self.model(x=self.tf.constant(im))[0].numpy()
             elif self.pb:  # GraphDef
                 y = self.frozen_func(x=self.tf.constant(im)).numpy()
             elif self.tflite:  # Lite

--- a/models/common.py
+++ b/models/common.py
@@ -359,7 +359,12 @@ class DetectMultiBackend(nn.Module):
             if saved_model:  # SavedModel
                 LOGGER.info(f'Loading {w} for TensorFlow SavedModel inference...')
                 import tensorflow as tf
-                model = tf.saved_model.load(w)
+                try:
+                    model = tf.keras.models.load_model(w)
+                    keras = True
+                except Exception:
+                    model = tf.saved_model.load(w)
+                    keras = False
             elif pb:  # GraphDef https://www.tensorflow.org/guide/migrate#a_graphpb_or_graphpbtxt
                 LOGGER.info(f'Loading {w} for TensorFlow GraphDef inference...')
                 import tensorflow as tf
@@ -431,7 +436,7 @@ class DetectMultiBackend(nn.Module):
         else:  # TensorFlow (SavedModel, GraphDef, Lite, Edge TPU)
             im = im.permute(0, 2, 3, 1).cpu().numpy()  # torch BCHW to numpy BHWC shape(1,320,192,3)
             if self.saved_model:  # SavedModel
-                y = self.model(x=self.tf.constant(im))[0].numpy()
+                y = (self.model(im, training=False) if self.keras else self.model(x=self.tf.constant(im))[0]).numpy()
             elif self.pb:  # GraphDef
                 y = self.frozen_func(x=self.tf.constant(im)).numpy()
             elif self.tflite:  # Lite

--- a/models/common.py
+++ b/models/common.py
@@ -431,7 +431,7 @@ class DetectMultiBackend(nn.Module):
         else:  # TensorFlow (SavedModel, GraphDef, Lite, Edge TPU)
             im = im.permute(0, 2, 3, 1).cpu().numpy()  # torch BCHW to numpy BHWC shape(1,320,192,3)
             if self.saved_model:  # SavedModel
-                y = self.model(x=self.tf.constant(im))[0].numpy()
+                y = self.model(im)[0].numpy()
             elif self.pb:  # GraphDef
                 y = self.frozen_func(x=self.tf.constant(im)).numpy()
             elif self.tflite:  # Lite

--- a/models/common.py
+++ b/models/common.py
@@ -359,12 +359,8 @@ class DetectMultiBackend(nn.Module):
             if saved_model:  # SavedModel
                 LOGGER.info(f'Loading {w} for TensorFlow SavedModel inference...')
                 import tensorflow as tf
-                try:
-                    model = tf.saved_model.load(w)
-                    keras = False
-                except Exception:
-                    model = tf.keras.models.load_model(w)
-                    keras = True
+                keras = False  # assume TF1 saved_model
+                model = tf.keras.models.load_model(w) if keras else tf.saved_model.load(w)
             elif pb:  # GraphDef https://www.tensorflow.org/guide/migrate#a_graphpb_or_graphpbtxt
                 LOGGER.info(f'Loading {w} for TensorFlow GraphDef inference...')
                 import tensorflow as tf


### PR DESCRIPTION
In this PR, keras saved_models are replaced with the TensorFlow v1.x saved model format so that it won't generate protobuf larger than 2GB. The exported saved models have the same sizes as the pb models of the same structure. This resolve https://github.com/ultralytics/yolov5/issues/6262, yet breaks backward compatibility with saved models exported by the previous commits of yolov5 master branch.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced TensorFlow SavedModel support with additional export and inference pathways.

### 📊 Key Changes
- Introduced a `keras` flag to toggle between Keras model and TensorFlow raw model saving.
- Changed TensorFlow model saving to use `convert_variables_to_constants_v2` for non-Keras models.
- Modified model loading to handle TensorFlow models differently when the `keras` flag is `False`.
- Updated model inference code to accommodate the new `keras` flag during predictions.

### 🎯 Purpose & Impact
- 💡 **Purpose**: To provide flexibility in exporting models to TensorFlow SavedModel format and to support legacy TensorFlow models that do not leverage Keras.
- 🎉 **Impact**: Users have the ability to choose how to save and load their TensorFlow models, improving compatibility with different TensorFlow versions and use cases. This change may also improve performance and reduce issues during model conversion and inference.