### PR TITLE
Fixing bug multi-gpu training

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -63,7 +63,7 @@ def select_device(device='', batch_size=0, newline=True):
     elif device:  # non-cpu device requested
         assert torch.cuda.is_available(), 'CUDA unavailable'  # check CUDA is available
         device_list = [int(val) for val in device.replace(',', '')]
-        assert all([torch.cuda.device_count() > element for element in device_list])  , f'invalid CUDA device {device} requested'  # check index
+        assert all([torch.cuda.device_count() > element for element in device_list]), f'invalid CUDA device {device} requested'  # check index
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable (must be after asserts)
 
     cuda = not cpu and torch.cuda.is_available()

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -62,7 +62,8 @@ def select_device(device='', batch_size=0, newline=True):
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
         assert torch.cuda.is_available(), 'CUDA unavailable'  # check CUDA is available
-        assert torch.cuda.device_count() > int(device), f'invalid CUDA device {device} requested'  # check index
+        device_list = [int(val) for val in device.replace(',', '')]
+        assert all([torch.cuda.device_count() > element for element in device_list])  , f'invalid CUDA device {device} requested'  # check index
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable (must be after asserts)
 
     cuda = not cpu and torch.cuda.is_available()


### PR DESCRIPTION
This solves this issue: https://github.com/ultralytics/yolov5/issues/6297#issue-1103853348

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced CUDA device selection support in Ultralytics YOLOv5.

### 📊 Key Changes
- Modified the device selection code to support lists of CUDA devices.
- Implemented input parsing to handle comma-separated device indices.
- Added an assertion to ensure each specified device index is valid.

### 🎯 Purpose & Impact
- Allows users to specify multiple CUDA devices for their workloads, providing more versatility in multi-GPU environments.
- Prevents user errors by checking the validity of all provided device indices, potentially avoiding runtime errors.
- Broadens the usability of the model for advanced users who want to utilize multiple GPUs, improving training and inference performance on compatible systems.