### PR TITLE
Remove `dataset_stats()` autodownload capability

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -936,11 +936,10 @@ def verify_image_label(args):
         return [None, None, None, None, nm, nf, ne, nc, msg]
 
 
-def dataset_stats(path='coco128.yaml', autodownload=False, verbose=False, profile=False, hub=False):
+def dataset_stats(path='coco128.yaml', verbose=False, profile=False, hub=False):
     """ Return dataset statistics dictionary with images and instances counts per split per class
     To run in parent directory: export PYTHONPATH="$PWD/yolov5"
-    Usage1: from utils.datasets import *; dataset_stats('coco128.yaml', autodownload=True)
-    Usage2: from utils.datasets import *; dataset_stats('../datasets/coco128_with_yaml.zip')
+    Usage: from utils.datasets import *; dataset_stats('../datasets/coco128_with_yaml.zip')
     Arguments
         path:           Path to data.yaml or data.zip (with data.yaml inside data.zip)
         autodownload:   Attempt to download dataset if not found locally
@@ -984,7 +983,7 @@ def dataset_stats(path='coco128.yaml', autodownload=False, verbose=False, profil
         data = yaml.safe_load(f)  # data dict
         if zipped:
             data['path'] = data_dir  # TODO: should this be dir.resolve()?
-    check_dataset(data, autodownload)  # download dataset if missing
+    check_dataset(data, autodownload=False)  # download dataset if missing
     hub_dir = Path(data['path'] + ('-hub' if hub else ''))
     stats = {'nc': data['nc'], 'names': data['names']}  # statistics dictionary
     for split in 'train', 'val', 'test':

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -983,7 +983,7 @@ def dataset_stats(path='coco128.yaml', verbose=False, profile=False, hub=False):
         data = yaml.safe_load(f)  # data dict
         if zipped:
             data['path'] = data_dir  # TODO: should this be dir.resolve()?
-    check_dataset(data, autodownload=False)  # download dataset if missing
+    check_dataset(data, autodownload=False)
     hub_dir = Path(data['path'] + ('-hub' if hub else ''))
     stats = {'nc': data['nc'], 'names': data['names']}  # statistics dictionary
     for split in 'train', 'val', 'test':


### PR DESCRIPTION
@kalenmike update per Slack convo

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of dataset statistics function in YOLOv5.

### 📊 Key Changes
- Removed the `autodownload` parameter from the `dataset_stats` function signature.
- `autodownload` is now hardcoded to `False` in the `check_dataset` function call within `dataset_stats`.
- Simplified the usage documentation to reflect the removal of the `autodownload` parameter.

### 🎯 Purpose & Impact
- **Simplicity**: Removal of the `autodownload` feature streamlines the function, making it easier to understand and use.
- **Predictability**: Ensures datasets are not downloaded automatically, preventing unexpected behavior for users working in environments with limited internet access or data policies.
- **Documentation Clarity**: Updates to the usage instructions help users by providing clear and accurate guidance on how to utilize the `dataset_stats` function.