### PR TITLE
Fix `train.py` parameter groups desc error

### DIFF
--- a/train.py
+++ b/train.py
@@ -172,7 +172,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     optimizer.add_param_group({'params': g1, 'weight_decay': hyp['weight_decay']})  # add g1 with weight_decay
     optimizer.add_param_group({'params': g2})  # add g2 (biases)
     LOGGER.info(f"{colorstr('optimizer:')} {type(optimizer).__name__} with parameter groups "
-                f"{len(g0)} weight (no decay), {len(g1)} weight , {len(g2)} bias")
+                f"{len(g0)} weight (no decay), {len(g1)} weight, {len(g2)} bias")
     del g0, g1, g2
 
     # Scheduler

--- a/train.py
+++ b/train.py
@@ -172,7 +172,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     optimizer.add_param_group({'params': g1, 'weight_decay': hyp['weight_decay']})  # add g1 with weight_decay
     optimizer.add_param_group({'params': g2})  # add g2 (biases)
     LOGGER.info(f"{colorstr('optimizer:')} {type(optimizer).__name__} with parameter groups "
-                f"{len(g0)} weight, {len(g1)} weight (no decay), {len(g2)} bias")
+                f"{len(g0)} weight (no decay), {len(g1)} weight , {len(g2)} bias")
     del g0, g1, g2
 
     # Scheduler


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved clarity in optimizer group logging during training within YOLOv5.

### 📊 Key Changes
- Modified a logging statement in `train.py` to more accurately represent the parameter groups.

### 🎯 Purpose & Impact
- This change clarifies the role of each parameter group in the optimizer:
  - `g0` now correctly labeled as weight (no decay) rather than just weight.
  - `g1` now correctly labeled as weight, where previously it was mislabeled as having no decay.
- Impact:
  - Enhances understanding for developers looking at the logs, ensuring they have correct information about how weights and biases are treated in optimization.
  - Users observing the training process will have a clearer insight into the training dynamics and parameter handling. 🧠
- No impact on model performance or training efficiency; purely an informational and quality-of-life improvement. 👍