### PR TITLE
`DEVICE_COUNT` instead of `WORLD_SIZE` to calculate `nw`

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -35,7 +35,7 @@ from utils.torch_utils import torch_distributed_zero_first
 HELP_URL = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
 IMG_FORMATS = ['bmp', 'jpg', 'jpeg', 'png', 'tif', 'tiff', 'dng', 'webp', 'mpo']  # acceptable image suffixes
 VID_FORMATS = ['mov', 'avi', 'mp4', 'mpg', 'mpeg', 'm4v', 'wmv', 'mkv']  # acceptable video suffixes
-WORLD_SIZE = int(os.getenv('WORLD_SIZE', 1))  # DPP
+DEVICE_COUNT = max(torch.cuda.device_count(), 1)
 
 # Get orientation exif tag
 for orientation in ExifTags.TAGS.keys():
@@ -110,7 +110,7 @@ def create_dataloader(path, imgsz, batch_size, stride, single_cls=False, hyp=Non
                                       prefix=prefix)
 
     batch_size = min(batch_size, len(dataset))
-    nw = min([os.cpu_count() // WORLD_SIZE, batch_size if batch_size > 1 else 0, workers])  # number of workers
+    nw = min([os.cpu_count() // DEVICE_COUNT, batch_size if batch_size > 1 else 0, workers])  # number of workers
     sampler = None if rank == -1 else distributed.DistributedSampler(dataset, shuffle=shuffle)
     loader = DataLoader if image_weights else InfiniteDataLoader  # only DataLoader allows for attribute updates
     return loader(dataset,


### PR DESCRIPTION
https://github.com/ultralytics/yolov5/issues/6298

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced data loader device compatibility in YOLOv5 🤖.

### 📊 Key Changes
- Changed `WORLD_SIZE` to `DEVICE_COUNT` to better reflect the number of available GPU devices.
- The `DEVICE_COUNT` now directly uses `torch.cuda.device_count()` to get the GPU count, ensuring at least one device is accounted for.

### 🎯 Purpose & Impact
- Ensures more accurate determination and utilization of CPU resources relative to the available GPU devices.
- Improves the data loader's performance and efficiency, potentially leading to faster training times and better support for systems with multiple GPUs. 🚀
- Users with different GPU configurations should experience more optimized data loading operations.