### PR TITLE
TensorRT `assert im.device.type != 'cpu'` on export

### DIFF
--- a/export.py
+++ b/export.py
@@ -184,9 +184,10 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
             check_version(trt.__version__, '8.0.0', hard=True)  # require tensorrt>=8.0.0
             export_onnx(model, im, file, 13, train, False, simplify)  # opset 13
         onnx = file.with_suffix('.onnx')
-        assert onnx.exists(), f'failed to export ONNX file: {onnx}'
 
         LOGGER.info(f'\n{prefix} starting export with TensorRT {trt.__version__}...')
+        assert im.device.type != 'cpu', 'export must be done on GPU, i.e. try `python export.py --device 0`'
+        assert onnx.exists(), f'failed to export ONNX file: {onnx}'
         f = file.with_suffix('.engine')  # TensorRT engine file
         logger = trt.Logger(trt.Logger.INFO)
         if verbose:

--- a/export.py
+++ b/export.py
@@ -186,7 +186,7 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
         onnx = file.with_suffix('.onnx')
 
         LOGGER.info(f'\n{prefix} starting export with TensorRT {trt.__version__}...')
-        assert im.device.type != 'cpu', 'export must be done on GPU, i.e. try `python export.py --device 0`'
+        assert im.device.type != 'cpu', 'export running on CPU but must be on GPU, i.e. `python export.py --device 0`'
         assert onnx.exists(), f'failed to export ONNX file: {onnx}'
         f = file.with_suffix('.engine')  # TensorRT engine file
         logger = trt.Logger(trt.Logger.INFO)


### PR DESCRIPTION
More informative TRT error messages on attempted CPU export (indicates to use GPU).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement in TensorRT export validation for GPU usage and ONNX file existence.

### 📊 Key Changes
- Added a check to ensure export is running on GPU, not CPU.
- Moved the assertion for successful ONNX export after initializing TensorRT logger.

### 🎯 Purpose & Impact
- 🛡️ The added check prevents users from running the export on CPUs, which could lead to errors since TensorRT requires a GPU. This will help users avoid making a mistake that would waste time and resources.
- 🔍 By moving the ONNX existence check after the logger initialization, users will receive more informative logging messages if the ONNX file is not created successfully, improving the debugging experience.