### PR TITLE
`export.py` return exported files/dirs

### DIFF
--- a/export.py
+++ b/export.py
@@ -434,16 +434,17 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
     LOGGER.info(f"\n{colorstr('PyTorch:')} starting from {file} ({file_size(file):.1f} MB)")
 
     # Exports
+    f = [''] * 10  # exported filenames
     if 'torchscript' in include:
-        f = export_torchscript(model, im, file, optimize)
+        f[0] = export_torchscript(model, im, file, optimize)
     if 'engine' in include:  # TensorRT required before ONNX
-        f = export_engine(model, im, file, train, half, simplify, workspace, verbose)
+        f[1] = export_engine(model, im, file, train, half, simplify, workspace, verbose)
     if ('onnx' in include) or ('openvino' in include):  # OpenVINO requires ONNX
-        f = export_onnx(model, im, file, opset, train, dynamic, simplify)
+        f[2] = export_onnx(model, im, file, opset, train, dynamic, simplify)
     if 'openvino' in include:
-        f = export_openvino(model, im, file)
+        f[3] = export_openvino(model, im, file)
     if 'coreml' in include:
-        _, f = export_coreml(model, im, file)
+        _, f[4] = export_coreml(model, im, file)
 
     # TensorFlow Exports
     if any(tf_exports):
@@ -451,25 +452,27 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
         if int8 or edgetpu:  # TFLite --int8 bug https://github.com/ultralytics/yolov5/issues/5707
             check_requirements(('flatbuffers==1.12',))  # required before `import tensorflow`
         assert not (tflite and tfjs), 'TFLite and TF.js models must be exported separately, please pass only one type.'
-        model, f = export_saved_model(model, im, file, dynamic, tf_nms=nms or agnostic_nms or tfjs,
-                                      agnostic_nms=agnostic_nms or tfjs, topk_per_class=topk_per_class,
-                                      topk_all=topk_all, conf_thres=conf_thres, iou_thres=iou_thres)  # keras model
+        model, f[5] = export_saved_model(model, im, file, dynamic, tf_nms=nms or agnostic_nms or tfjs,
+                                         agnostic_nms=agnostic_nms or tfjs, topk_per_class=topk_per_class,
+                                         topk_all=topk_all, conf_thres=conf_thres, iou_thres=iou_thres)  # keras model
         if pb or tfjs:  # pb prerequisite to tfjs
-            f = export_pb(model, im, file)
+            f[6] = export_pb(model, im, file)
         if tflite or edgetpu:
-            f = export_tflite(model, im, file, int8=int8 or edgetpu, data=data, ncalib=100)
+            f[7] = export_tflite(model, im, file, int8=int8 or edgetpu, data=data, ncalib=100)
         if edgetpu:
-            f = export_edgetpu(model, im, file)
+            f[8] = export_edgetpu(model, im, file)
         if tfjs:
-            f = export_tfjs(model, im, file)
+            f[9] = export_tfjs(model, im, file)
 
     # Finish
+    f = [x for x in f if x]  # filter out '' and None
     LOGGER.info(f'\nExport complete ({time.time() - t:.2f}s)'
                 f"\nResults saved to {colorstr('bold', file.parent.resolve())}"
                 f"\nVisualize with https://netron.app"
-                f"\nDetect with `python detect.py --weights {f}`"
-                f" or `model = torch.hub.load('ultralytics/yolov5', 'custom', '{f}')"
-                f"\nValidate with `python val.py --weights {f}`")
+                f"\nDetect with `python detect.py --weights {f[-1]}`"
+                f" or `model = torch.hub.load('ultralytics/yolov5', 'custom', '{f[-1]}')"
+                f"\nValidate with `python val.py --weights {f[-1]}`")
+    return f  # return list of exported files/dirs
 
 
 def parse_opt():

--- a/export.py
+++ b/export.py
@@ -465,7 +465,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
             f[9] = export_tfjs(model, im, file)
 
     # Finish
-    f = [x for x in f if x]  # filter out '' and None
+    f = [str(x) for x in f if x]  # filter out '' and None
     LOGGER.info(f'\nExport complete ({time.time() - t:.2f}s)'
                 f"\nResults saved to {colorstr('bold', file.parent.resolve())}"
                 f"\nVisualize with https://netron.app"


### PR DESCRIPTION
@kalenmike updates export.py's `run()` function to return an array of all exported files, i.e.:

```python
python export.py --include torchscript onnx

Out[4]: 
['yolov5s.torchscript', 'yolov5s.onnx']
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model export file management in Ultralytics YOLOv5.

### 📊 Key Changes
- Introduced an array `f` to store exported filenames for different model formats.
- Assigned export function outputs for TorchScript, TensorRT, ONNX, OpenVINO, CoreML, TensorFlow SavedModel, TensorFlow Lite, Edge TPU, and TensorFlow.js to specific indices in `f`.
- Updated file path management to filter out empty or None values, ensuring only valid paths are processed.
- Changed the detection and validation command outputs to use the last exported model file.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: To streamline the handling of multiple model exports by organizing the exported filenames into a structured array, making the process more robust and maintainable. 
- 📈 **Impact**: Users will experience more clarity on the output of exported files and benefit from a simpler way to reference these files for subsequent tasks like detection and validation. It reduces the potential for errors and confusion when working with multiple export formats.