### PR TITLE
Add optional `VERBOSE` environment variable

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -36,6 +36,7 @@ from utils.metrics import box_iou, fitness
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[1]  # YOLOv5 root directory
 NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLOv5 multiprocessing threads
+VERBOSE = str(os.getenv('VERBOSE', True)).lower() == 'true'  # global verbose mode
 
 torch.set_printoptions(linewidth=320, precision=5, profile='long')
 np.set_printoptions(linewidth=320, formatter={'float_kind': '{:11.5g}'.format})  # format short g, %precision=5
@@ -54,7 +55,7 @@ def is_kaggle():
         return False
 
 
-def set_logging(name=None, verbose=True):
+def set_logging(name=None, verbose=VERBOSE):
     # Sets level and returns logger
     if is_kaggle():
         for h in logging.root.handlers:


### PR DESCRIPTION
New environment variable `VERBOSE`. Usage example:

```bash
export VERBOSE=False
python detect.py
```

<img width="1194" alt="Screen Shot 2022-01-20 at 12 26 22 PM" src="https://user-images.githubusercontent.com/26833433/150432134-1025a3b2-83d2-46cf-b4ba-5b138cc9cffc.png">



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of logging verbosity control in Ultralytics YOLOv5.

### 📊 Key Changes
- Environment-aware verbosity: A new global `VERBOSE` variable read from the environment to control verbosity.
- Modification to `set_logging`: The function now uses the `VERBOSE` variable to set logging behavior.

### 🎯 Purpose & Impact
- 🎛 Enhances user's control over log messages, which helps in debugging and monitoring.
- 📈 May improve the user experience by allowing them to specify the verbosity level via an environment variable.
- 🛠 Gives flexibility for adjusting verbosity when using YOLOv5 in different environments, like local development or cloud deployments.