### PR TITLE
Add `stop_training=False` flag to callbacks

### DIFF
--- a/train.py
+++ b/train.py
@@ -383,8 +383,6 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                 best_fitness = fi
             log_vals = list(mloss) + list(results) + lr
             callbacks.run('on_fit_epoch_end', log_vals, epoch, best_fitness, fi)
-            if callbacks.stop_training:
-                return
 
             # Save model
             if (not nosave) or (final_epoch and not evolve):  # if save
@@ -405,8 +403,6 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                     torch.save(ckpt, w / f'epoch{epoch}.pt')
                 del ckpt
                 callbacks.run('on_model_save', last, epoch, final_epoch, best_fitness, fi)
-                if callbacks.stop_training:
-                    return
 
             # Stop Single-GPU
             if RANK == -1 and stopper(epoch=epoch, fitness=fi):
@@ -446,8 +442,6 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
                                             compute_loss=compute_loss)  # val best model with plots
                     if is_coco:
                         callbacks.run('on_fit_epoch_end', list(mloss) + list(results) + lr, epoch, best_fitness, fi)
-                        if callbacks.stop_training:
-                            return
 
         callbacks.run('on_train_end', last, best, plots, epoch, results)
         LOGGER.info(f"Results saved to {colorstr('bold', save_dir)}")

--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -35,9 +35,7 @@ class Callbacks:
             'on_params_update': [],
             'teardown': [],
         }
-
-        # Set this to True in your callback handler to prematurely stop training
-        self.stop_training = False
+        self.stop_training = False  # set True to interrupt training
 
     def register_action(self, hook, name='', callback=None):
         """

--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -36,6 +36,9 @@ class Callbacks:
             'teardown': [],
         }
 
+        # Set this to True in your callback handler to prematurely stop training
+        self.stop_training = False
+
     def register_action(self, hook, name='', callback=None):
         """
         Register a new action to a callback hook


### PR DESCRIPTION
I have added a new flag `stop_training` in `util.callbacks.Callbacks` class, default to `False`.
When subclassing one can set this flag to `True` in a callback handler in order to stop training.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added early stopping capability to YOLOv5 training process. ✋

### 📊 Key Changes
- A check is introduced in `train.py` to assess whether training should be terminated prematurely (early stopping).
- A new variable `stop_training` is added within `utils/callbacks.py` to signal if the training needs to be stopped.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: This allows users or other processes to interrupt training if certain conditions are met (e.g., performance plateaus or begins to degrade).
- 🔍 **Impact**: Users have more control over the training process, potentially saving time and resources by not continuing ineffective training. This can also help in preventing overfitting by stopping a model before it starts to learn noise within the data.