### PR TITLE
FROM nvcr.io/nvidia/pytorch:21.10-py3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # YOLOv5 🚀 by Ultralytics, GPL-3.0 license
 
 # Start FROM Nvidia PyTorch image https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
-FROM nvcr.io/nvidia/pytorch:21.12-py3
+FROM nvcr.io/nvidia/pytorch:21.10-py3
 
 # Install linux packages
 RUN apt update && apt install -y zip htop screen libgl1-mesa-glx
@@ -12,7 +12,7 @@ RUN python -m pip install --upgrade pip
 RUN pip uninstall -y nvidia-tensorboard nvidia-tensorboard-plugin-dlprof
 RUN pip install --no-cache -r requirements.txt coremltools onnx gsutil notebook wandb>=0.12.2
 RUN pip install --no-cache -U torch torchvision numpy Pillow
-# RUN pip install --no-cache torch==1.10.1+cu113 torchvision==0.11.2+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
+RUN pip install --no-cache torch==1.10.1+cu113 torchvision==0.11.2+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
 
 # Create working directory
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
21.12 generates dockerhub errors so rolling back to 21.10 with latest pytorch install. Not sure if this torch install will work on non-GPU dockerhub autobuild so this is an experiment.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to YOLOv5 Docker configuration.

### 📊 Key Changes
- Downgraded the base NVIDIA PyTorch Docker image from version 21.12 to 21.10.
- Un-commented the RUN command to explicitly install PyTorch v1.10.1 and TorchVision v0.11.2 with CUDA 11.3 support.

### 🎯 Purpose & Impact
- The downgrade of the Docker base image may address compatibility or stability issues with the previously used newer version.
- The explicit installation of specific PyTorch and TorchVision versions ensures a stable and consistent environment, which is crucial for reproducibility.
- Users can expect a potentially more reliable Docker environment tailored for YOLOv5's requirements, which could benefit both deployment and development.