### PR TITLE
Prefer `tflite_runtime` for TFLite inference if installed

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -374,20 +374,19 @@ class DetectMultiBackend(nn.Module):
                 graph_def.ParseFromString(open(w, 'rb').read())
                 frozen_func = wrap_frozen_graph(gd=graph_def, inputs="x:0", outputs="Identity:0")
             elif tflite:  # https://www.tensorflow.org/lite/guide/python#install_tensorflow_lite_for_python
-                if 'edgetpu' in w.lower():  # Edge TPU
+                try:
+                    import tflite_runtime.interpreter as tfl  # prefer tflite_runtime if installed
+                except ImportError:
+                    import tensorflow.lite as tfl
+                if 'edgetpu' in w.lower():  # Edge TPU https://coral.ai/software/#edgetpu-runtime
                     LOGGER.info(f'Loading {w} for TensorFlow Lite Edge TPU inference...')
-                    import tflite_runtime.interpreter as tfli  # install https://coral.ai/software/#edgetpu-runtime
                     delegate = {'Linux': 'libedgetpu.so.1',
                                 'Darwin': 'libedgetpu.1.dylib',
                                 'Windows': 'edgetpu.dll'}[platform.system()]
-                    interpreter = tfli.Interpreter(model_path=w, experimental_delegates=[tfli.load_delegate(delegate)])
+                    interpreter = tfl.Interpreter(model_path=w, experimental_delegates=[tfl.load_delegate(delegate)])
                 else:  # Lite
                     LOGGER.info(f'Loading {w} for TensorFlow Lite inference...')
-                    try:
-                        import tensorflow.lite as tfli
-                    except ImportError:
-                        import tflite_runtime.interpreter as tfli
-                    interpreter = tfli.Interpreter(model_path=w)  # load TFLite model
+                    interpreter = tfl.Interpreter(model_path=w)  # load TFLite model
                 interpreter.allocate_tensors()  # allocate
                 input_details = interpreter.get_input_details()  # inputs
                 output_details = interpreter.get_output_details()  # outputs

--- a/models/common.py
+++ b/models/common.py
@@ -384,10 +384,10 @@ class DetectMultiBackend(nn.Module):
                 else:  # Lite
                     LOGGER.info(f'Loading {w} for TensorFlow Lite inference...')
                     try:
-                        import tensorflow.lite as tflite
+                        import tensorflow.lite as tfli
                     except ImportError:
-                        import tflite_runtime.interpreter as tflite
-                    interpreter = tflite.Interpreter(model_path=w)  # load TFLite model
+                        import tflite_runtime.interpreter as tfli
+                    interpreter = tfli.Interpreter(model_path=w)  # load TFLite model
                 interpreter.allocate_tensors()  # allocate
                 input_details = interpreter.get_input_details()  # inputs
                 output_details = interpreter.get_output_details()  # outputs

--- a/models/common.py
+++ b/models/common.py
@@ -383,8 +383,11 @@ class DetectMultiBackend(nn.Module):
                     interpreter = tfli.Interpreter(model_path=w, experimental_delegates=[tfli.load_delegate(delegate)])
                 else:  # Lite
                     LOGGER.info(f'Loading {w} for TensorFlow Lite inference...')
-                    import tensorflow as tf
-                    interpreter = tf.lite.Interpreter(model_path=w)  # load TFLite model
+                    try:
+                        import tensorflow.lite as tflite
+                    except ImportError:
+                        import tflite_runtime.interpreter as tflite
+                    interpreter = tflite.Interpreter(model_path=w)  # load TFLite model
                 interpreter.allocate_tensors()  # allocate
                 input_details = interpreter.get_input_details()  # inputs
                 output_details = interpreter.get_output_details()  # outputs


### PR DESCRIPTION
This PR imports the `tflite_runtime` package if `tensorflow` is not installed when running the .tflite model.
This is useful when running .tflite models on edge devices such as RPi, which have small disk space and cannot have large tensorflow library.

https://www.tensorflow.org/lite/guide/python?hl=en

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced TensorFlow Lite (TFLite) model loading with better package management and Edge TPU support.

### 📊 Key Changes
- Unified import statements for TensorFlow Lite (TFLite) to gracefully handle when `tflite_runtime` package is available.
- Simplified importing TFLite Edge TPU support with platform-specific dynamic loading of the appropriate delegate library.
- Cleaned up the code by removing redundant imports and comments.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: The update aims to improve the compatibility with TensorFlow Lite on systems where `tflite_runtime` is installed, and streamline the process of running models on the Edge TPU.
- ⚙️ **Impact**: Users will experience a more reliable and flexible inference process for TFLite and Edge TPU models, potentially resulting in faster setup times and broader device support.