### PR TITLE
Add `detect.py` GIF video inference

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -199,7 +199,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
                             h = int(vid_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
                         else:  # stream
                             fps, w, h = 30, im0.shape[1], im0.shape[0]
-                        save_path = str(Path(save_path).with_suffix('.mp4'))
+                        save_path = str(Path(save_path).with_suffix('.mp4'))  # force *.mp4 suffix on results videos
                         vid_writer[i] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
                     vid_writer[i].write(im0)
 

--- a/detect.py
+++ b/detect.py
@@ -199,7 +199,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
                             h = int(vid_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
                         else:  # stream
                             fps, w, h = 30, im0.shape[1], im0.shape[0]
-                            save_path += '.mp4'
+                        save_path = str(Path(save_path).with_suffix('.mp4'))
                         vid_writer[i] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
                     vid_writer[i].write(im0)
 

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -33,8 +33,8 @@ from utils.torch_utils import torch_distributed_zero_first
 
 # Parameters
 HELP_URL = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
-IMG_FORMATS = ['bmp', 'jpg', 'jpeg', 'png', 'tif', 'tiff', 'dng', 'webp', 'mpo']  # acceptable image suffixes
-VID_FORMATS = ['mov', 'avi', 'mp4', 'mpg', 'mpeg', 'm4v', 'wmv', 'mkv']  # acceptable video suffixes
+IMG_FORMATS = ['bmp', 'dng', 'jpeg', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp']  # include image suffixes
+VID_FORMATS = ['avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'wmv']  # include video suffixes
 DEVICE_COUNT = max(torch.cuda.device_count(), 1)
 
 # Get orientation exif tag


### PR DESCRIPTION
Add *.gif to the video suffix include list, sort suffix lists, force *.mp4 suffix on all saved inference video formats (required for GIF results writing).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to video saving and expanded file format support in YOLOv5 🚀

### 📊 Key Changes
- 🔧 Modified video result saving to ensure the file extension is `.mp4`.
- 📸 Updated the lists of accepted image and video file formats, reordering them and adding `.gif` to video formats.

### 🎯 Purpose & Impact
- 🎥 Ensures consistent video output formatting, preventing potential issues with video writers across different environments or operating systems.
- 💾 Expands compatibility with a wider range of image and video file types, improving user experience and flexibility when working with various multimedia files.