### PR TITLE
Rename logger from 'utils.logger' to 'yolov5'

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -65,7 +65,7 @@ def set_logging(name=None, verbose=VERBOSE):
     return logging.getLogger(name)
 
 
-LOGGER = set_logging("yolov5")  # define globally (used in train.py, val.py, detect.py, etc.)
+LOGGER = set_logging('yolov5')  # define globally (used in train.py, val.py, detect.py, etc.)
 
 
 class Profile(contextlib.ContextDecorator):

--- a/utils/general.py
+++ b/utils/general.py
@@ -65,7 +65,7 @@ def set_logging(name=None, verbose=VERBOSE):
     return logging.getLogger(name)
 
 
-LOGGER = set_logging(__name__)  # define globally (used in train.py, val.py, detect.py, etc.)
+LOGGER = set_logging("yolov5")  # define globally (used in train.py, val.py, detect.py, etc.)
 
 
 class Profile(contextlib.ContextDecorator):


### PR DESCRIPTION
As discussed in #2862, the log level can be changed using `logging` even when the logger is not yet registered which allows to hide any output from yolov5 or to get the level of output as required.

Before calling any script from this repository, you can define the log level. For instance:

```
import torch
import logging
import cv2

if __name__ == '__main__':
    logging.getLogger("utils.general").setLevel(logging.WARNING)
    model = torch.hub.load('ultralytics/yolov5', 'custom', path="path/to/yolov5s.pt")
    img = cv2.imread("path/to/image.png)[..., ::-1]
    results = model(img)
    results.print()
    results.show()
```

Instead of getting the logger named `utils.general`, I gave a more explicit name to the logger and renamed it as `yolov5`.
Thereby, the logger name can be found more easily like it can be done for package such as Tensorflow:

```
    logging.getLogger("yolov5").setLevel(logging.WARNING)
    logging.getLogger("tensorflow").setLevel(logging.WARNING)
```

As asked by @glenn-jocher, I checked that it doesn't alter the current output of the logger by using this line above in `detect.py`. It indeed keeps the same information if the logger is set to INFO and hides everything with WARNING (as there is no warning 😉). If you feel it's not sufficient, don't hesitate to tell me.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of global logger name in the YOLOv5 codebase.

### 📊 Key Changes
- Changed the global logger name from `__name__` to a fixed string `'yolov5'`

### 🎯 Purpose & Impact
- This change standardizes the logger name across various scripts for uniformity.
- Impact-wise, the users will see consistent naming in logging outputs, which can make it easier to filter logs by source when debugging or monitoring the system.