### PR TITLE
Fix `select_device()` for Multi-GPU

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -36,7 +36,7 @@ HELP_URL = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
 IMG_FORMATS = ['bmp', 'dng', 'jpeg', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp']  # include image suffixes
 VID_FORMATS = ['asf', 'avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'wmv']  # include video suffixes
 # DEVICE_COUNT = max(torch.cuda.device_count(), 1)
-DEVICE_COUNT = max(torch.cuda.device_count(), 1)
+DEVICE_COUNT = max(len(os.getenv('CUDA_VISIBLE_DEVICES', '').replace(',', '')), 1)  # known issue with cuda.device_count
 
 # Get orientation exif tag
 for orientation in ExifTags.TAGS.keys():

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -36,7 +36,7 @@ HELP_URL = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
 IMG_FORMATS = ['bmp', 'dng', 'jpeg', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp']  # include image suffixes
 VID_FORMATS = ['asf', 'avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'wmv']  # include video suffixes
 # DEVICE_COUNT = max(torch.cuda.device_count(), 1)
-DEVICE_COUNT = max(8, 1)
+DEVICE_COUNT = max(torch.cuda.device_count(), 1)
 
 # Get orientation exif tag
 for orientation in ExifTags.TAGS.keys():

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -29,14 +29,13 @@ from tqdm import tqdm
 from utils.augmentations import Albumentations, augment_hsv, copy_paste, letterbox, mixup, random_perspective
 from utils.general import (LOGGER, NUM_THREADS, check_dataset, check_requirements, check_yaml, clean_str,
                            segments2boxes, xyn2xy, xywh2xyxy, xywhn2xyxy, xyxy2xywhn)
-from utils.torch_utils import torch_distributed_zero_first
+from utils.torch_utils import device_count, torch_distributed_zero_first
 
 # Parameters
 HELP_URL = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
 IMG_FORMATS = ['bmp', 'dng', 'jpeg', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp']  # include image suffixes
 VID_FORMATS = ['asf', 'avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'wmv']  # include video suffixes
-# DEVICE_COUNT = max(torch.cuda.device_count(), 1)
-DEVICE_COUNT = max(len(os.getenv('CUDA_VISIBLE_DEVICES', '').replace(',', '')), 1)  # known issue with cuda.device_count
+DEVICE_COUNT = max(device_count(), 1)  # number of CUDA devices
 
 # Get orientation exif tag
 for orientation in ExifTags.TAGS.keys():

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -35,7 +35,8 @@ from utils.torch_utils import torch_distributed_zero_first
 HELP_URL = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
 IMG_FORMATS = ['bmp', 'dng', 'jpeg', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp']  # include image suffixes
 VID_FORMATS = ['asf', 'avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'wmv']  # include video suffixes
-DEVICE_COUNT = max(torch.cuda.device_count(), 1)
+# DEVICE_COUNT = max(torch.cuda.device_count(), 1)
+DEVICE_COUNT = max(8, 1)
 
 # Get orientation exif tag
 for orientation in ExifTags.TAGS.keys():

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -61,7 +61,7 @@ def select_device(device='', batch_size=0, newline=True):
     if cpu:
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
-        nd = torch.cuda.device_count()  # number of CUDA devices
+        nd = len(os.getenv('CUDA_VISIBLE_DEVICES', '').replace(',',''))  # number of CUDA devices
         assert torch.cuda.is_available(), 'CUDA is not available, use `--device cpu` or do not pass a --device'
         assert nd > int(max(device.split(','))), f'Invalid `--device {device}` request, valid devices are 0 - {nd - 1}'
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable (must be after asserts)

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -62,9 +62,9 @@ def select_device(device='', batch_size=0, newline=True):
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
         nd = len(os.getenv('CUDA_VISIBLE_DEVICES', '').replace(',',''))  # number of CUDA devices
-        assert torch.cuda.is_available(), 'CUDA is not available, use `--device cpu` or do not pass a --device'
         assert nd > int(max(device.split(','))), f'Invalid `--device {device}` request, valid devices are 0 - {nd - 1}'
-        os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable (must be after asserts)
+        os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable (before assert cuda.is_available)
+        assert torch.cuda.is_available(), 'CUDA is not available, use `--device cpu` or do not pass a --device'
 
     cuda = not cpu and torch.cuda.is_available()
     if cuda:

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -61,7 +61,7 @@ def select_device(device='', batch_size=0, newline=True):
     if cpu:
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
-        nd = len(os.getenv('CUDA_VISIBLE_DEVICES', '').replace(',',''))  # number of CUDA devices
+        nd = torch.cuda.device_count()  # number of CUDA devices
         assert nd > int(max(device.split(','))), f'Invalid `--device {device}` request, valid devices are 0 - {nd - 1}'
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable (before assert cuda.is_available)
         assert torch.cuda.is_available(), 'CUDA is not available, use `--device cpu` or do not pass a --device'

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -61,10 +61,10 @@ def select_device(device='', batch_size=0, newline=True):
     if cpu:
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
+        os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable
+        assert torch.cuda.is_available(), f'CUDA unavailable, invalid device {device} requested'  # check availability
         # nd = torch.cuda.device_count()  # number of CUDA devices
         # assert nd > int(max(device.split(','))), f'Invalid `--device {device}` request, valid devices are 0 - {nd - 1}'
-        # assert torch.cuda.is_available(), 'CUDA is not available, use `--device cpu` or do not pass a --device'
-        os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable (before assert cuda.is_available)
 
     cuda = not cpu and torch.cuda.is_available()
     if cuda:

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -71,9 +71,9 @@ def select_device(device='', batch_size=0, newline=True):
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
         nd = device_count()  # number of CUDA devices
-        assert torch.cuda.is_available(), 'CUDA is not available, use `--device cpu` or do not pass a --device'
         assert nd > int(max(device.split(','))), f'Invalid `--device {device}` request, valid devices are 0 - {nd - 1}'
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable
+        assert torch.cuda.is_available(), 'CUDA is not available, use `--device cpu` or do not pass a --device'
 
     cuda = not cpu and torch.cuda.is_available()
     if cuda:

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -72,7 +72,7 @@ def select_device(device='', batch_size=0, newline=True):
     elif device:  # non-cpu device requested
         nd = device_count()  # number of CUDA devices
         assert nd > int(max(device.split(','))), f'Invalid `--device {device}` request, valid devices are 0 - {nd - 1}'
-        os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable
+        os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable - must be before assert is_available()
         assert torch.cuda.is_available(), 'CUDA is not available, use `--device cpu` or do not pass a --device'
 
     cuda = not cpu and torch.cuda.is_available()

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -63,8 +63,8 @@ def select_device(device='', batch_size=0, newline=True):
     elif device:  # non-cpu device requested
         # nd = torch.cuda.device_count()  # number of CUDA devices
         # assert nd > int(max(device.split(','))), f'Invalid `--device {device}` request, valid devices are 0 - {nd - 1}'
+        # assert torch.cuda.is_available(), 'CUDA is not available, use `--device cpu` or do not pass a --device'
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable (before assert cuda.is_available)
-        assert torch.cuda.is_available(), 'CUDA is not available, use `--device cpu` or do not pass a --device'
 
     cuda = not cpu and torch.cuda.is_available()
     if cuda:

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -61,8 +61,8 @@ def select_device(device='', batch_size=0, newline=True):
     if cpu:
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
-        nd = torch.cuda.device_count()  # number of CUDA devices
-        assert nd > int(max(device.split(','))), f'Invalid `--device {device}` request, valid devices are 0 - {nd - 1}'
+        # nd = torch.cuda.device_count()  # number of CUDA devices
+        # assert nd > int(max(device.split(','))), f'Invalid `--device {device}` request, valid devices are 0 - {nd - 1}'
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable (before assert cuda.is_available)
         assert torch.cuda.is_available(), 'CUDA is not available, use `--device cpu` or do not pass a --device'
 

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -63,8 +63,6 @@ def select_device(device='', batch_size=0, newline=True):
     elif device:  # non-cpu device requested
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable
         assert torch.cuda.is_available(), f'CUDA unavailable, invalid device {device} requested'  # check availability
-        # nd = torch.cuda.device_count()  # number of CUDA devices
-        # assert nd > int(max(device.split(','))), f'Invalid `--device {device}` request, valid devices are 0 - {nd - 1}'
 
     cuda = not cpu and torch.cuda.is_available()
     if cuda:

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -61,8 +61,10 @@ def select_device(device='', batch_size=0, newline=True):
     if cpu:
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
-        os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable
-        assert torch.cuda.is_available(), f'CUDA unavailable, invalid device {device} requested'  # check availability
+        nd = len(os.getenv('CUDA_VISIBLE_DEVICES', '').replace(',', ''))  # number of CUDA devices
+        assert nd > int(max(device.split(','))), f'Invalid `--device {device}` request, valid devices are 0 - {nd - 1}'
+        assert torch.cuda.is_available(), 'CUDA is not available, use `--device cpu` or do not pass a --device'
+        os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable (before assert cuda.is_available)
 
     cuda = not cpu and torch.cuda.is_available()
     if cuda:


### PR DESCRIPTION
Possible fix for https://github.com/ultralytics/yolov5/issues/6431

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced CUDA device detection in YOLOv5's utility functions.

### 📊 Key Changes
- Implemented a safer version of `torch.cuda.device_count()` named `device_count()`.
- Replaced the direct call to `torch.cuda.device_count()` with the new `device_count()` in `datasets.py` and `torch_utils.py`.
- Adjusted the order of operations in `select_device()` to set `CUDA_VISIBLE_DEVICES` before asserting CUDA availability.

### 🎯 Purpose & Impact
- The purpose of these changes is to provide a more robust way of counting CUDA devices that avoids potential exceptions.
- The impact for users is an improvement in the reliability of YOLOv5 when it initializes CUDA devices, especially in systems with complex setup or permission issues.
- The new `device_count()` function should make the tool more resilient to errors, leading to smoother setup and training processes for users with compatible CUDA devices. 🖥️🚀