### PR TITLE
Add `*.asf` video support

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -34,7 +34,7 @@ from utils.torch_utils import torch_distributed_zero_first
 # Parameters
 HELP_URL = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
 IMG_FORMATS = ['bmp', 'dng', 'jpeg', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp']  # include image suffixes
-VID_FORMATS = ['avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'wmv']  # include video suffixes
+VID_FORMATS = ['asf', 'avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'wmv']  # include video suffixes
 DEVICE_COUNT = max(torch.cuda.device_count(), 1)
 
 # Get orientation exif tag


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement to video format support in YOLOv5 datasets.

### 📊 Key Changes
- Added 'asf' to the list of supported video formats.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: To allow users to train YOLOv5 models with '.asf' video files, increasing the versatility of the model training process.
- ✅ **Impact**: Users with '.asf' video files can use them directly without needing to convert to a previously supported format, streamlining the training pipeline.