### PR TITLE
Revert "Remove `dataset_stats()` autodownload capability"

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -936,10 +936,11 @@ def verify_image_label(args):
         return [None, None, None, None, nm, nf, ne, nc, msg]
 
 
-def dataset_stats(path='coco128.yaml', verbose=False, profile=False, hub=False):
+def dataset_stats(path='coco128.yaml', autodownload=False, verbose=False, profile=False, hub=False):
     """ Return dataset statistics dictionary with images and instances counts per split per class
     To run in parent directory: export PYTHONPATH="$PWD/yolov5"
-    Usage: from utils.datasets import *; dataset_stats('../datasets/coco128_with_yaml.zip')
+    Usage1: from utils.datasets import *; dataset_stats('coco128.yaml', autodownload=True)
+    Usage2: from utils.datasets import *; dataset_stats('../datasets/coco128_with_yaml.zip')
     Arguments
         path:           Path to data.yaml or data.zip (with data.yaml inside data.zip)
         autodownload:   Attempt to download dataset if not found locally
@@ -983,7 +984,7 @@ def dataset_stats(path='coco128.yaml', verbose=False, profile=False, hub=False):
         data = yaml.safe_load(f)  # data dict
         if zipped:
             data['path'] = data_dir  # TODO: should this be dir.resolve()?
-    check_dataset(data, autodownload=False)
+    check_dataset(data, autodownload)  # download dataset if missing
     hub_dir = Path(data['path'] + ('-hub' if hub else ''))
     stats = {'nc': data['nc'], 'names': data['names']}  # statistics dictionary
     for split in 'train', 'val', 'test':


### PR DESCRIPTION
Reverts ultralytics/yolov5#6303

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Automatic dataset download support added to `dataset_stats` function.

### 📊 Key Changes
- Added an `autodownload` parameter to the `dataset_stats` function.
- The `check_dataset` function now respects the `autodownload` parameter.

### 🎯 Purpose & Impact
- 🔄 **Purpose**: Streamlines the workflow by automatically downloading the dataset if it's not present, thereby reducing manual steps for users.
- 📈 **Impact**: Users can enable auto-downloading feature to simplify dataset preparation, ensuring a smoother start with YOLOv5 projects.
- 🛠️ **Advantage for developers and users**: Saves time and effort, making the process of using YOLOv5 models for object detection more user-friendly.