### PR TITLE
Fix2 `select_device()` for Multi-GPU

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -65,7 +65,6 @@ def device_count():
 
 
 def select_device(device='', batch_size=0, newline=True):
-    print(device)
     # device = 'cpu' or '0' or '0,1,2,3'
     s = f'YOLOv5 🚀 {git_describe() or date_modified()} torch {torch.__version__} '  # string
     device = str(device).strip().lower().replace('cuda:', '')  # to string, 'cuda:0' to '0'

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -8,7 +8,6 @@ import math
 import os
 import platform
 import subprocess
-import sys
 import time
 from contextlib import contextmanager
 from copy import deepcopy
@@ -56,7 +55,7 @@ def git_describe(path=Path(__file__).parent):  # path must be a directory
 
 def device_count():
     # Returns number of CUDA devices available. Safe version of torch.cuda.device_count(). Only works on Linux.
-    assert sys.platform == 'Linux'
+    assert platform.system() == 'Linux'
     try:
         cmd = 'nvidia-smi -L | wc -l'
         return int(subprocess.run(cmd, shell=True, capture_output=True, check=True).stdout.decode().split()[-1])

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -72,9 +72,8 @@ def select_device(device='', batch_size=0, newline=True):
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable - must be before assert is_available()
-        nd = torch.cuda.device_count()  # number of CUDA devices
-        assert torch.cuda.is_available(), f'CUDA `--device {device}` requested but `torch.cuda.is_available()=False`'
-        assert nd > 0, f'Invalid CUDA `--device {device}` requested, use `--device cpu` or pass valid CUDA device(s)'
+        assert torch.cuda.is_available(), \
+            f"Invalid CUDA '--device {device}' requested, use '--device cpu' or pass valid CUDA device(s)"
 
     cuda = not cpu and torch.cuda.is_available()
     if cuda:

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -72,7 +72,7 @@ def select_device(device='', batch_size=0, newline=True):
         os.environ['CUDA_VISIBLE_DEVICES'] = '-1'  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
         os.environ['CUDA_VISIBLE_DEVICES'] = device  # set environment variable - must be before assert is_available()
-        assert torch.cuda.is_available(), \
+        assert torch.cuda.is_available() and torch.cuda.device_count() >= len(device.replace(',', '')), \
             f"Invalid CUDA '--device {device}' requested, use '--device cpu' or pass valid CUDA device(s)"
 
     cuda = not cpu and torch.cuda.is_available()

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -55,7 +55,7 @@ def git_describe(path=Path(__file__).parent):  # path must be a directory
 
 def device_count():
     # Returns number of CUDA devices available. Safe version of torch.cuda.device_count(). Only works on Linux.
-    assert platform.system() == 'Linux'
+    assert platform.system() == 'Linux', 'device_count() function only works on Linux'
     try:
         cmd = 'nvidia-smi -L | wc -l'
         return int(subprocess.run(cmd, shell=True, capture_output=True, check=True).stdout.decode().split()[-1])


### PR DESCRIPTION
Fix for GPU selection issues on Windows and Jetson in #6456 #6448

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of worker number calculation and stronger GPU device assertion in YOLOv5 data loading.

### 📊 Key Changes
- Removed `DEVICE_COUNT` reliance in `create_dataloader`.
- Directly fetching the number of CUDA devices with `torch.cuda.device_count()`.
- Added an assertion to ensure `device_count()` only operates on Linux.
- Updated `select_device` function to check for valid CUDA devices more robustly.

### 🎯 Purpose & Impact
- 💪 **Efficiency**: The updates improve data loader efficiency by calculating the number of workers in a more straightforward and reliable way.
- 🐧 **OS Specific**: Ensuring `device_count()` only works on Linux prevents possible errors on non-Linux systems.
- 🛠 **Reliability**: Enhanced assertions provide clearer error messages when invalid GPU device requests are made, leading to easier troubleshooting for users setting up their training environments.