### PR TITLE
GH: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+# Before submitting
+
+- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
+- [ ] Did you make sure to update the docs?
+- [ ] Did you write any new necessary tests?
+
+## What does this PR do?
+
+Fixes # (issue).
+
+## PR review
+
+Anyone in the community is free to review the PR once the tests have passed.
+If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,5 @@ Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributin
 - Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
 - Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).
 
-Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for a full guide on YOLOv5 PR best practices.
+Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
 --->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,5 @@ Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributin
 - Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
 - Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).
 
-Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for a detailed guide on PRs. 
+Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for a detailed guide on PRs.
 --->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-<!--
 Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:
 
 - Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
@@ -6,4 +5,3 @@ Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributin
 - Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).
 
 Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
---->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,9 @@
-# Before submitting
+<!--
+Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to help get your work merged with YOLOv5:
 
-- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
-- [ ] Did you make sure to update the docs?
-- [ ] Did you write any new necessary tests?
+- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
+- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
+- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).
 
-## What does this PR do?
-
-Fixes # (issue).
-
-## PR review
-
-Anyone in the community is free to review the PR once the tests have passed.
-If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
+Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for a detailed guide on PRs. 
+--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,5 @@ Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributin
 - Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
 - Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).
 
-Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for a detailed guide on PRs.
+Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for a full guide on YOLOv5 PR best practices.
 --->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to help get your work merged with YOLOv5:
+Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:
 
 - Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
 - Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,17 +42,17 @@ changes** button. All done, your PR is now submitted to YOLOv5 for review and ap
 To allow your work to be integrated as seamlessly as possible, we advise you to:
 
 - ✅ Verify your PR is **up-to-date with upstream/master.** If your PR is behind upstream/master an
-  automatic [GitHub actions](https://github.com/ultralytics/yolov5/blob/master/.github/workflows/rebase.yml) rebase may
-  be attempted by including the /rebase command in a comment body, or by running the following code, replacing 'feature'
-  with the name of your local branch:
+  automatic [GitHub Actions](https://github.com/ultralytics/yolov5/blob/master/.github/workflows/rebase.yml) merge may
+  be attempted by writing /rebase in a new comment, or by running the following code, replacing 'feature' with the name
+  of your local branch:
 
-  ```bash
-  git remote add upstream https://github.com/ultralytics/yolov5.git
-  git fetch upstream
-  git checkout feature  # <----- replace 'feature' with local branch name
-  git merge upstream/master
-  git push -u origin -f
-  ```
+```bash
+git remote add upstream https://github.com/ultralytics/yolov5.git
+git fetch upstream
+# git checkout feature  # <--- replace 'feature' with local branch name
+git merge upstream/master
+git push -u origin -f
+```
 
 - ✅ Verify all Continuous Integration (CI) **checks are passing**.
 - ✅ Reduce changes to the absolute **minimum** required for your bug fix or feature addition. _"It is not daily increase


### PR DESCRIPTION
Just to have some structure on open PRs, but feel free to adjust it as you want :]

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Implementing a PR template and updating contribution guidelines for YOLOv5 repository.

### 📊 Key Changes
- Added a new Pull Request (PR) template to the repository.
- Updated the contributing guidelines with a revised code block for rebasing.

### 🎯 Purpose & Impact
- **PR Template:** Ensures contributors check for existing PRs and link their submissions to relevant issues. Plus, encourages sharing of results demonstrating the PR's effectiveness.
  - 🚀 **Benefit**: Streamlines the review process and contributes to better documentation of changes and their ramifications.
  - 🔍 **Impact**: Contributors can provide more detailed and organized information, aiding both maintainers and users in understanding the changes.
  
- **Contributing Guidelines:** Clarifies the /rebase command and provides a cleaner code snippet for rebasing.
  - 🛠️ **Benefit**: Simplifies the rebase process, making it more accessible to contributors.
  - ⚙️ **Impact**: Encourages keeping branches up to date with the base branch, which can result in fewer merge conflicts and smoother integrations.