### PR TITLE
Added and option to pass customer confidence and IoU params 

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -11,7 +11,7 @@ Usage:
 import torch
 
 
-def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbose=True, device=None):
+def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbose=True, device=None, conf=0.25, iou=0.45):
     """Creates or loads a YOLOv5 model
 
     Arguments:
@@ -65,9 +65,9 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
         raise Exception(s) from e
 
 
-def custom(path='path/to/model.pt', autoshape=True, verbose=True, device=None):
+def custom(path='path/to/model.pt', autoshape=True, verbose=True, device=None, conf=0.25,iou=0.45):
     # YOLOv5 custom or local model
-    return _create(path, autoshape=autoshape, verbose=verbose, device=device)
+    return _create(path, autoshape=autoshape, verbose=verbose, device=device,conf=conf,iou=iou)
 
 
 def yolov5n(pretrained=True, channels=3, classes=80, autoshape=True, verbose=True, device=None):

--- a/models/common.py
+++ b/models/common.py
@@ -464,16 +464,16 @@ class DetectMultiBackend(nn.Module):
 
 class AutoShape(nn.Module):
     # YOLOv5 input-robust model wrapper for passing cv2/np/PIL/torch inputs. Includes preprocessing, inference and NMS
-    conf = 0.25  # NMS confidence threshold
-    iou = 0.45  # NMS IoU threshold
     agnostic = False  # NMS class-agnostic
     multi_label = False  # NMS multiple labels per box
     classes = None  # (optional list) filter by class, i.e. = [0, 15, 16] for COCO persons, cats and dogs
     max_det = 1000  # maximum number of detections per image
     amp = False  # Automatic Mixed Precision (AMP) inference
 
-    def __init__(self, model):
+    def __init__(self, model,conf = 0.25, iou=0.45):
         super().__init__()
+        self.conf = conf
+        self.iou = iou
         LOGGER.info('Adding AutoShape... ')
         copy_attr(self, model, include=('yaml', 'nc', 'hyp', 'names', 'stride', 'abc'), exclude=())  # copy attributes
         self.dmb = isinstance(model, DetectMultiBackend)  # DetectMultiBackend() instance

--- a/models/common.py
+++ b/models/common.py
@@ -470,7 +470,7 @@ class AutoShape(nn.Module):
     max_det = 1000  # maximum number of detections per image
     amp = False  # Automatic Mixed Precision (AMP) inference
 
-    def __init__(self, model,conf = 0.25, iou=0.45):
+    def __init__(self, model,conf=0.25, iou=0.45):
         super().__init__()
         self.conf = conf
         self.iou = iou


### PR DESCRIPTION
While serving custom model via torchhub it would be very useful to have a option to pass also custom confidence and IoU params, which are currently hardcoded. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to YOLOv5 model creation and custom model loading with configurable NMS thresholds.

### 📊 Key Changes
- Introduced `conf` and `iou` parameters in the `_create` and `custom` functions.
- Adjusted `AutoShape` class to accept custom NMS confidence (`conf`) and IoU (`iou`) thresholds upon initialization.

### 🎯 Purpose & Impact
- ⚙️ **Purpose**: Allows users to specify their own values for NMS confidence and IoU thresholds when creating or loading models, enabling more flexibility and fine-tuning based on specific use cases.
- 🎨 **Impact**: Users can now customize the sensitivity of their model's detection capabilities, potentially improving accuracy and reducing false positives depending on the context of the application.