### PR TITLE
Suppress `export.run()` `TracerWarning`

### DIFF
--- a/export.py
+++ b/export.py
@@ -16,6 +16,10 @@ TensorFlow Lite             | `tflite`                      | yolov5s.tflite
 TensorFlow Edge TPU         | `edgetpu`                     | yolov5s_edgetpu.tflite
 TensorFlow.js               | `tfjs`                        | yolov5s_web_model/
 
+Requirements:
+    $ pip install -r requirements.txt coremltools onnx onnx-simplifier onnxruntime openvino-dev tensorflow-cpu  # CPU
+    $ pip install -r requirements.txt coremltools onnx onnx-simplifier onnxruntime-gpu openvino-dev tensorflow  # GPU
+
 Usage:
     $ python path/to/export.py --weights yolov5s.pt --include torchscript onnx openvino engine coreml tflite ...
 
@@ -437,6 +441,7 @@ def run(data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
 
     # Exports
     f = [''] * 10  # exported filenames
+    warnings.filterwarnings(action='ignore', category=torch.jit.TracerWarning)  # suppress TracerWarning
     if 'torchscript' in include:
         f[0] = export_torchscript(model, im, file, optimize)
     if 'engine' in include:  # TensorRT required before ONNX
@@ -509,10 +514,8 @@ def parse_opt():
 
 
 def main(opt):
-    with warnings.catch_warnings():
-        warnings.filterwarnings(action='ignore', category=torch.jit.TracerWarning)  # suppress TracerWarning
-        for opt.weights in (opt.weights if isinstance(opt.weights, list) else [opt.weights]):
-            run(**vars(opt))
+    for opt.weights in (opt.weights if isinstance(opt.weights, list) else [opt.weights]):
+        run(**vars(opt))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Suppresses warnings when calling export.run() directly, not just CLI python export.py.

Also adds Requirements examples for CPU and GPU backends

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model export functionality with updated requirements and reduced warning clutter.

### 📊 Key Changes
- Added dependencies installation instructions for CPU and GPU setups in the `export.py` file.
- Suppressed `torch.jit.TracerWarning` globally within the export script, rather than on each model export action.

### 🎯 Purpose & Impact
- 🛠️ **Easier Setup**: Users can now easily find dependency installation commands according to their hardware (CPU or GPU), streamlining the setup process.
- 🧹 **Cleaner Output**: Suppressing tracer warnings by default makes the output less cluttered, allowing users to focus on more important messages and reducing potential confusion from warning messages.
- ✨ **Smoother Experience**: The changes contribute to a smoother user experience when exporting models by simplifying the preparation steps and reducing visual noise during the export process.