### PR TITLE
Fixing minor multi-streaming issues with TensoRT engine

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -110,7 +110,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
     vid_path, vid_writer = [None] * bs, [None] * bs
 
     # Run inference
-    model.warmup(imgsz=(1, 3, *imgsz), half=half)  # warmup
+    model.warmup(imgsz=(bs, 3, *imgsz), half=half)  # warmup
     dt, seen = [0.0, 0.0, 0.0], 0
     for path, im, im0s, vid_cap, s in dataset:
         t1 = time_sync()
@@ -175,9 +175,6 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
                         if save_crop:
                             save_one_box(xyxy, imc, file=save_dir / 'crops' / names[c] / f'{p.stem}.jpg', BGR=True)
 
-            # Print time (inference-only)
-            LOGGER.info(f'{s}Done. ({t3 - t2:.3f}s)')
-
             # Stream results
             im0 = annotator.result()
             if view_img:
@@ -202,6 +199,9 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
                         save_path = str(Path(save_path).with_suffix('.mp4'))  # force *.mp4 suffix on results videos
                         vid_writer[i] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
                     vid_writer[i].write(im0)
+
+        # Print time (inference-only)
+        LOGGER.info(f'{s}Done. ({t3 - t2:.3f}s)')
 
     # Print results
     t = tuple(x / seen * 1E3 for x in dt)  # speeds per image

--- a/detect.py
+++ b/detect.py
@@ -110,7 +110,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
     vid_path, vid_writer = [None] * bs, [None] * bs
 
     # Run inference
-    model.warmup(imgsz=(bs, 3, *imgsz), half=half)  # warmup
+    model.warmup(imgsz=(1 if pt else bs, 3, *imgsz), half=half)  # warmup
     dt, seen = [0.0, 0.0, 0.0], 0
     for path, im, im0s, vid_cap, s in dataset:
         t1 = time_sync()

--- a/val.py
+++ b/val.py
@@ -162,7 +162,7 @@ def run(data,
 
     # Dataloader
     if not training:
-        model.warmup(imgsz=(1 if pt else batch_size, 3, imgsz, imgsz), half=half)  # warmup 
+        model.warmup(imgsz=(1 if pt else batch_size, 3, imgsz, imgsz), half=half)  # warmup
         pad = 0.0 if task == 'speed' else 0.5
         task = task if task in ('train', 'val', 'test') else 'val'  # path to train/val/test images
         dataloader = create_dataloader(data[task], imgsz, batch_size, stride, single_cls, pad=pad, rect=pt,

--- a/val.py
+++ b/val.py
@@ -162,7 +162,7 @@ def run(data,
 
     # Dataloader
     if not training:
-        model.warmup(imgsz=(1, 3, imgsz, imgsz), half=half)  # warmup
+        model.warmup(imgsz=(1 if pt else batch_size, 3, imgsz, imgsz), half=half)  # warmup 
         pad = 0.0 if task == 'speed' else 0.5
         task = task if task in ('train', 'val', 'test') else 'val'  # path to train/val/test images
         dataloader = create_dataloader(data[task], imgsz, batch_size, stride, single_cls, pad=pad, rect=pt,


### PR DESCRIPTION
# Multiple Streaming with TensorRT engine issues

While working with multiple input streams with a TensorRT exported engine, I've noticed one bug and one fix.

I'll first state these issues, and then give steps to reproduce.

## 1. Incorrect batch-size in model.warmup() (BUG)

As batch-size is fixed in some TensorRT engine, when it is not 1, the following instruction triggers an AssertionError.

<pre>python detect.py --source streams.txt --weights merged.engine</pre>

it is because of this particular line:

```python
# Run inference
model.warmup(imgsz=(1, 3, *imgsz), half=half)  # warmup
```

My TensorRT engine is built for batch-size 6, and i'm streaming 6 inputs at a time.

<pre>python detect.py --source streams.txt --weights merged.engine
<font color="#3465A4"><b>detect: </b></font>weights=[&apos;merged.engine&apos;], source=streams.txt, data=data/coco128.yaml, imgsz=[640, 640], conf_thres=0.25, iou_thres=0.45, max_det=1000, device=, view_img=False, save_txt=False, save_conf=False, save_crop=False, nosave=False, classes=None, agnostic_nms=False, augment=False, visualize=False, update=False, project=runs/detect, name=exp, exist_ok=False, line_thickness=3, hide_labels=False, hide_conf=False, half=False, dnn=False
YOLOv5 🚀 v6.0-224-g4c40933 torch 1.10.0+cu113 CUDA:0 (NVIDIA GeForce GTX 1650 Ti with Max-Q Design, 3914MiB)

Loading merged.engine for TensorRT inference...
[02/02/2022-10:00:48] [TRT] [I] [MemUsageChange] Init CUDA: CPU +320, GPU +0, now: CPU 421, GPU 627 (MiB)
[02/02/2022-10:00:48] [TRT] [I] Loaded engine size: 80 MiB
[02/02/2022-10:00:48] [TRT] [I] [MemUsageSnapshot] deserializeCudaEngine begin: CPU 501 MiB, GPU 627 MiB
[02/02/2022-10:00:49] [TRT] [I] [MemUsageChange] Init cuBLAS/cuBLASLt: CPU +508, GPU +224, now: CPU 1024, GPU 931 (MiB)
[02/02/2022-10:00:49] [TRT] [I] [MemUsageChange] Init cuDNN: CPU +114, GPU +52, now: CPU 1138, GPU 983 (MiB)
[02/02/2022-10:00:49] [TRT] [I] [MemUsageSnapshot] deserializeCudaEngine end: CPU 1138 MiB, GPU 965 MiB
[02/02/2022-10:00:54] [TRT] [I] [MemUsageSnapshot] ExecutionContext creation begin: CPU 4021 MiB, GPU 2296 MiB
[02/02/2022-10:00:54] [TRT] [I] [MemUsageChange] Init cuBLAS/cuBLASLt: CPU +0, GPU +10, now: CPU 4021, GPU 2306 (MiB)
[02/02/2022-10:00:54] [TRT] [I] [MemUsageChange] Init cuDNN: CPU +0, GPU +8, now: CPU 4021, GPU 2314 (MiB)
[02/02/2022-10:00:54] [TRT] [I] [MemUsageSnapshot] ExecutionContext creation end: CPU 4022 MiB, GPU 2498 MiB
1/6: ../data/ShipSpotting1.mp4...  Success (525 frames 640x360 at 25.00 FPS)
2/6: ../data/ShipSpotting2.mp4...  Success (600 frames 640x360 at 25.00 FPS)
3/6: ../data/ShipSpotting3.mp4...  Success (1525 frames 640x360 at 25.00 FPS)
4/6: ../data/ShipSpottingbis1.mp4...  Success (525 frames 640x360 at 25.00 FPS)
5/6: ../data/ShipSpottingbis2.mp4...  Success (600 frames 640x360 at 25.00 FPS)
6/6: ../data/ShipSpottingbis3.mp4...  Success (1525 frames 640x360 at 25.00 FPS)

Traceback (most recent call last):
  File &quot;detect.py&quot;, line 257, in &lt;module&gt;
    main(opt)
  File &quot;detect.py&quot;, line 252, in main
    run(**vars(opt))
  File &quot;/home/grego/Documents/envs/cv_inference/lib/python3.8/site-packages/torch/autograd/grad_mode.py&quot;, line 28, in decorate_context
    return func(*args, **kwargs)
  File &quot;detect.py&quot;, line 113, in run
    model.warmup(imgsz=(1, 3, *imgsz), half=half)  # warmup
  File &quot;/home/grego/Documents/yolov5/models/common.py&quot;, line 459, in warmup
    self.forward(im)  # warmup
  File &quot;/home/grego/Documents/yolov5/models/common.py&quot;, line 416, in forward
    assert im.shape == self.bindings[&apos;images&apos;].shape, (im.shape, self.bindings[&apos;images&apos;].shape)
AssertionError: (torch.Size([1, 3, 640, 640]), (6, 3, 640, 640))
</pre>

An easy way to fix is to modify this line by:

```python
# Run inference
model.warmup(imgsz=(bs, 3, *imgsz), half=half)  # warmup
```
as bs is defined just before and perfectly matches the input batch size.

## 2. Incorrect indent when logging results (FIX)

After debugging the first issue, I noticed this peculiar logging output as the inference happened :

<pre>python detect.py --source streams.txt --weights merged.engine
<font color="#3465A4"><b>detect: </b></font>weights=[&apos;merged.engine&apos;], source=streams.txt, data=data/coco128.yaml, imgsz=[640, 640], conf_thres=0.25, iou_thres=0.45, max_det=1000, device=, view_img=False, save_txt=False, save_conf=False, save_crop=False, nosave=False, classes=None, agnostic_nms=False, augment=False, visualize=False, update=False, project=runs/detect, name=exp, exist_ok=False, line_thickness=3, hide_labels=False, hide_conf=False, half=False, dnn=False
YOLOv5 🚀 v6.0-224-g4c40933 torch 1.10.0+cu113 CUDA:0 (NVIDIA GeForce GTX 1650 Ti with Max-Q Design, 3914MiB)

Loading merged.engine for TensorRT inference...
[02/02/2022-10:01:53] [TRT] [I] [MemUsageChange] Init CUDA: CPU +320, GPU +0, now: CPU 421, GPU 646 (MiB)
[02/02/2022-10:01:53] [TRT] [I] Loaded engine size: 80 MiB
[02/02/2022-10:01:53] [TRT] [I] [MemUsageSnapshot] deserializeCudaEngine begin: CPU 501 MiB, GPU 646 MiB
[02/02/2022-10:01:54] [TRT] [I] [MemUsageChange] Init cuBLAS/cuBLASLt: CPU +508, GPU +224, now: CPU 1024, GPU 950 (MiB)
[02/02/2022-10:01:54] [TRT] [I] [MemUsageChange] Init cuDNN: CPU +114, GPU +52, now: CPU 1138, GPU 1002 (MiB)
[02/02/2022-10:01:54] [TRT] [I] [MemUsageSnapshot] deserializeCudaEngine end: CPU 1138 MiB, GPU 984 MiB
[02/02/2022-10:01:57] [TRT] [I] [MemUsageSnapshot] ExecutionContext creation begin: CPU 4021 MiB, GPU 2306 MiB
[02/02/2022-10:01:57] [TRT] [I] [MemUsageChange] Init cuBLAS/cuBLASLt: CPU +0, GPU +10, now: CPU 4021, GPU 2316 (MiB)
[02/02/2022-10:01:57] [TRT] [I] [MemUsageChange] Init cuDNN: CPU +0, GPU +8, now: CPU 4021, GPU 2324 (MiB)
[02/02/2022-10:01:57] [TRT] [I] [MemUsageSnapshot] ExecutionContext creation end: CPU 4022 MiB, GPU 2508 MiB
1/6: ../data/ShipSpotting1.mp4...  Success (525 frames 640x360 at 25.00 FPS)
2/6: ../data/ShipSpotting2.mp4...  Success (600 frames 640x360 at 25.00 FPS)
3/6: ../data/ShipSpotting3.mp4...  Success (1525 frames 640x360 at 25.00 FPS)
4/6: ../data/ShipSpottingbis1.mp4...  Success (525 frames 640x360 at 25.00 FPS)
5/6: ../data/ShipSpottingbis2.mp4...  Success (600 frames 640x360 at 25.00 FPS)
6/6: ../data/ShipSpottingbis3.mp4...  Success (1525 frames 640x360 at 25.00 FPS)

0: 640x640 Done. (0.059s)
0: 640x640 1: 640x640 Done. (0.059s)
0: 640x640 1: 640x640 2: 640x640 Done. (0.059s)
0: 640x640 1: 640x640 2: 640x640 3: 640x640 Done. (0.059s)
0: 640x640 1: 640x640 2: 640x640 3: 640x640 4: 640x640 Done. (0.059s)
0: 640x640 1: 640x640 2: 640x640 3: 640x640 4: 640x640 5: 640x640 Done. (0.059s)
0: 640x640 Done. (0.045s)
0: 640x640 1: 640x640 Done. (0.045s)
0: 640x640 1: 640x640 2: 640x640 Done. (0.045s)
0: 640x640 1: 640x640 2: 640x640 3: 640x640 Done. (0.045s)
0: 640x640 1: 640x640 2: 640x640 3: 640x640 4: 640x640 Done. (0.045s)
0: 640x640 1: 640x640 2: 640x640 3: 640x640 4: 640x640 5: 640x640 Done. (0.045s)
0: 640x640 Done. (0.044s)
0: 640x640 1: 640x640 Done. (0.044s)
0: 640x640 1: 640x640 2: 640x640 Done. (0.044s)
0: 640x640 1: 640x640 2: 640x640 3: 640x640 Done. (0.044s)
0: 640x640 1: 640x640 2: 640x640 3: 640x640 4: 640x640 Done. (0.044s)
0: 640x640 1: 640x640 2: 640x640 3: 640x640 4: 640x640 5: 640x640 Done. (0.044s)
</pre>

The logging happens in a "stair" manner. For each stream we log the results but we keep the results of precedent streams, which is a mistake.

Two fixes are possible:

1. Re-initialize the logging string in the loop: 
<pre>
0: 640x640 Done. (0.059s)
1: 640x640 Done. (0.059s)
2: 640x640 Done. (0.059s)
3: 640x640 Done. (0.059s)
4: 640x640 Done. (0.059s)
5: 640x640 Done. (0.059s)
</pre>

2. Log only the last one: 
<pre>0: 640x640 1: 640x640 2: 640x640 3: 640x640 4: 640x640 5: 640x640 Done. (0.059s)
</pre>

I've favored the second option, which requires very little modification (identation in the double for loop of detect.py)

## To reproduce

You need two things:

1. A `model.engine` TensorRT engine with fixed batch-size > 1
2. A `streams.txt` text file with multiple streaming input (matching the chosen batch-size)

### 1. Creating a TensorRT engine

Assuming you have configured your machine to work with TensorRT, and that you achieved to previously export a TensorRT engine for yoloV5 with `export.py`, just type the following command:

```sh
python export.py --weights 'yolov5s.pt' --batch-size 3 --device 0 --include engine
```

After a while, you should obtain a `yolov5s.engine` file in the same directory as `yolov5s.pt`.

### 2. Creating a multiple streams input file

With the editor of your choice, create a `streams.txt` text file containing this:

```txt
0
0
0
```

If you don't have a webcam, i recommend replacing 0 with a path to a video file you have locally.

### 3. Running multiple streams inference

Once previous steps are done, and assuming generated files are in the yolov5 directory, just type:

```sh
python detect.py --weights yolov5s.engine --source streams.txt
```
This should output this error : 

<pre>AssertionError: (torch.Size([1, 3, 640, 640]), (3, 3, 640, 640))
</pre>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to model warmup and inference logging in YOLOv5.

### 📊 Key Changes
- Changed the warmup image size logic to depend on whether a pre-trained (*.pt) model is used.
- Moved inference time logging to print after batch processing to clean up the output.

### 🎯 Purpose & Impact
- 💡 Ensures model warmup uses batch size when not using pretrained models, potentially improving warmup effectiveness.
- 🧹 Streamlines logging by reducing clutter, making it easier for users to read and interpret inference times.