### PR TITLE
Load checkpoint on CPU instead of on GPU

### DIFF
--- a/train.py
+++ b/train.py
@@ -120,9 +120,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     if pretrained:
         with torch_distributed_zero_first(LOCAL_RANK):
             weights = attempt_download(weights)  # download if not found locally
-        ckpt = torch.load(
-            weights, map_location=lambda storage, _: storage
-        )  # Load all tensors onto the CPU, using a function to avoid memory leak
+        ckpt = torch.load(weights, map_location=torch.device("cpu"))  # load all tensors onto the CPU to avoid memory leak
         model = Model(cfg or ckpt['model'].yaml, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
         exclude = ['anchor'] if (cfg or hyp.get('anchors')) and not resume else []  # exclude keys
         csd = ckpt['model'].float().state_dict()  # checkpoint state_dict as FP32

--- a/train.py
+++ b/train.py
@@ -120,7 +120,9 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     if pretrained:
         with torch_distributed_zero_first(LOCAL_RANK):
             weights = attempt_download(weights)  # download if not found locally
-        ckpt = torch.load(weights, map_location=device)  # load checkpoint
+        ckpt = torch.load(
+            weights, map_location=lambda storage, _: storage
+        )  # Load all tensors onto the CPU, using a function to avoid memory leak
         model = Model(cfg or ckpt['model'].yaml, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
         exclude = ['anchor'] if (cfg or hyp.get('anchors')) and not resume else []  # exclude keys
         csd = ckpt['model'].float().state_dict()  # checkpoint state_dict as FP32

--- a/train.py
+++ b/train.py
@@ -120,7 +120,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     if pretrained:
         with torch_distributed_zero_first(LOCAL_RANK):
             weights = attempt_download(weights)  # download if not found locally
-        ckpt = torch.load(weights, map_location='cpu')  # load to CPU to avoid CUDA memory leak
+        ckpt = torch.load(weights, map_location='cpu')  # load checkpoint to CPU to avoid CUDA memory leak
         model = Model(cfg or ckpt['model'].yaml, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
         exclude = ['anchor'] if (cfg or hyp.get('anchors')) and not resume else []  # exclude keys
         csd = ckpt['model'].float().state_dict()  # checkpoint state_dict as FP32

--- a/train.py
+++ b/train.py
@@ -120,7 +120,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     if pretrained:
         with torch_distributed_zero_first(LOCAL_RANK):
             weights = attempt_download(weights)  # download if not found locally
-        ckpt = torch.load(weights, map_location=torch.device("cpu"))  # load all tensors onto the CPU to avoid memory leak
+        ckpt = torch.load(weights, map_location='cpu')  # load to CPU to avoid CUDA memory leak
         model = Model(cfg or ckpt['model'].yaml, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
         exclude = ['anchor'] if (cfg or hyp.get('anchors')) and not resume else []  # exclude keys
         csd = ckpt['model'].float().state_dict()  # checkpoint state_dict as FP32


### PR DESCRIPTION
close #6515 

## What I Tested

- [x] check using less GPU memory after code fixed (Table 1)

**Table1. memory consumption**

|weight/location|GPU (current code)|CPU (after fixed)|
|---|---|---|
|yolov5l|14773 MiB|14603 MiB (-170 MiB)|
|pretrained.pt|14795 MiB|14635 MiB (-160 MiB)|

Comparing the pre-trained weights (*.pt) with the default weights (yolov5l), there is an increase in memory consumption of about 20-30 MiB.
Therefore another leak might still exist, but at least this fix improves memory consumption of GPU.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to checkpoint loading for better memory management.

### 📊 Key Changes
- Changed checkpoint loading to use CPU instead of the current device.

### 🎯 Purpose & Impact
- 🛠 Fixes potential CUDA memory leak during the training process.
- 🚀 Enhances memory utilization which can lead to improved performance and stability when training models.
- 👍 Users may experience more efficient use of their GPU memory, ultimately enabling them to run larger models or multiple tasks concurrently.