### PR TITLE
Update hyp.scratch-high.yaml `lrf: 0.1`

### DIFF
--- a/data/hyps/hyp.scratch-high.yaml
+++ b/data/hyps/hyp.scratch-high.yaml
@@ -4,7 +4,7 @@
 # See tutorials for hyperparameter evolution https://github.com/ultralytics/yolov5#tutorials
 
 lr0: 0.01  # initial learning rate (SGD=1E-2, Adam=1E-3)
-lrf: 0.2  # final OneCycleLR learning rate (lr0 * lrf)
+lrf: 0.1  # final OneCycleLR learning rate (lr0 * lrf)
 momentum: 0.937  # SGD momentum/Adam beta1
 weight_decay: 0.0005  # optimizer weight decay 5e-4
 warmup_epochs: 3.0  # warmup epochs (fractions ok)


### PR DESCRIPTION
Update `lrf: 0.1`, tested on YOLOv5x6 to 55.0 mAP@0.5:0.95, slightly higher than current.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of learning rate schedule in YOLOv5 training configuration.

### 📊 Key Changes
- Decreased the final OneCycleLR learning rate (`lrf`) from 0.2 to 0.1 in the training hyperparameters.

### 🎯 Purpose & Impact
- 🔄 This change aims to enhance the model training stability and performance by adjusting the learning rate schedule.
- 📈 Potential impact includes improved convergence during training and possibly better model accuracy, benefiting users by potentially enhancing model performance on a variety of tasks.