### PR TITLE
Edge TPU compiler `sudo` fix

### DIFF
--- a/export.py
+++ b/export.py
@@ -325,9 +325,7 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
                       'echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list',
                       'sudo apt-get update',
                       'sudo apt-get install edgetpu-compiler']:
-                c_ = c if sudo else c.replace('sudo ', '')
-                print(c_)
-                subprocess.run(c_, shell=True, check=True)
+                subprocess.run(c if sudo else c.replace('sudo ', ''), shell=True, check=True)
         ver = subprocess.run(cmd, shell=True, capture_output=True, check=True).stdout.decode().split()[-1]
 
         LOGGER.info(f'\n{prefix} starting export with Edge TPU compiler {ver}...')

--- a/export.py
+++ b/export.py
@@ -315,17 +315,19 @@ def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('Te
 def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
     # YOLOv5 Edge TPU export https://coral.ai/docs/edgetpu/models-intro/
     try:
-        cmd = 'edgetpu_compiler --version'
+        cmd = 'edgetpu_compiler --version >/dev/null'
         help_url = 'https://coral.ai/docs/edgetpu/compiler/'
         assert platform.system() == 'Linux', f'export only supported on Linux. See {help_url}'
         if subprocess.run(cmd, shell=True).returncode != 0:
             LOGGER.info(f'\n{prefix} export requires Edge TPU compiler. Attempting install from {help_url}')
-            sudo = subprocess.run('sudo --help', shell=True).returncode == 0  # sudo installed on system
+            sudo = subprocess.run('sudo --version >/dev/null', shell=True).returncode == 0  # sudo installed on system
             for c in ['curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -',
                       'echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list',
                       'sudo apt-get update',
                       'sudo apt-get install edgetpu-compiler']:
-                subprocess.run(c if sudo else c.replace('sudo ', ''), shell=True, check=True)
+                c_ = c if sudo else c.replace('sudo ', '')
+                print(c_)
+                subprocess.run(c_, shell=True, check=True)
         ver = subprocess.run(cmd, shell=True, capture_output=True, check=True).stdout.decode().split()[-1]
 
         LOGGER.info(f'\n{prefix} starting export with Edge TPU compiler {ver}...')

--- a/export.py
+++ b/export.py
@@ -318,9 +318,9 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
         cmd = 'edgetpu_compiler --version'
         help_url = 'https://coral.ai/docs/edgetpu/compiler/'
         assert platform.system() == 'Linux', f'export only supported on Linux. See {help_url}'
-        sudo = subprocess.run('sudo --help', shell=True).returncode == 0  # sudo installed on system
         if subprocess.run(cmd, shell=True).returncode != 0:
             LOGGER.info(f'\n{prefix} export requires Edge TPU compiler. Attempting install from {help_url}')
+            sudo = subprocess.run('sudo --help', shell=True).returncode == 0  # sudo installed on system
             for c in ['curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -',
                       'echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list',
                       'sudo apt-get update',

--- a/export.py
+++ b/export.py
@@ -318,13 +318,14 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
         cmd = 'edgetpu_compiler --version'
         help_url = 'https://coral.ai/docs/edgetpu/compiler/'
         assert platform.system() == 'Linux', f'export only supported on Linux. See {help_url}'
+        sudo = subprocess.run('sudo --help', shell=True).returncode == 0  # sudo installed on system
         if subprocess.run(cmd, shell=True).returncode != 0:
             LOGGER.info(f'\n{prefix} export requires Edge TPU compiler. Attempting install from {help_url}')
             for c in ['curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -',
                       'echo "deb https://packages.cloud.google.com/apt coral-edgetpu-stable main" | sudo tee /etc/apt/sources.list.d/coral-edgetpu.list',
                       'sudo apt-get update',
                       'sudo apt-get install edgetpu-compiler']:
-                subprocess.run(c, shell=True, check=True)
+                subprocess.run(c if sudo else c.replace('sudo ', ''), shell=True, check=True)
         ver = subprocess.run(cmd, shell=True, capture_output=True, check=True).stdout.decode().split()[-1]
 
         LOGGER.info(f'\n{prefix} starting export with Edge TPU compiler {ver}...')


### PR DESCRIPTION
Allows for auto-install of Edge TPU compiler on non-sudo systems like the YOLOv5 Docker image.

@kalenmike

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to the Edge TPU export process in the YOLOv5 repository.

### 📊 Key Changes
- Command outputs during Edge TPU compiler version check are now suppressed (`>/dev/null`).
- Installation commands are adapted to handle systems without `sudo`.
  
### 🎯 Purpose & Impact
- **Reduced Noise:** Suppressing command output helps keep the console output cleaner.
- **Broader Compatibility:** Modifications ensure the Edge TPU export script can run on systems lacking `sudo`, increasing the script's versatility and user-friendliness.