### PR TITLE
Add argument to disable plotting per class

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -79,7 +79,6 @@ def ap_per_class(tp, conf, pred_cls, target_cls, plot=False, save_dir='.', names
         plot_mc_curve(px, p, Path(save_dir) / 'P_curve.png', names, ylabel='Precision', plot_per_class=plot_per_class)
         plot_mc_curve(px, r, Path(save_dir) / 'R_curve.png', names, ylabel='Recall', plot_per_class=plot_per_class)
 
-
     i = f1.mean(0).argmax()  # max F1 index
     p, r, f1 = p[:, i], r[:, i], f1[:, i]
     tp = (r * nt).round()  # true positives

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -321,7 +321,7 @@ def plot_pr_curve(px, py, ap, save_dir='pr_curve.png', names=(), plot_per_class=
     plt.close()
 
 
-def plot_mc_curve(px, py, save_dir='mc_curve.png', names=(), xlabel='Confidence', ylabel='Metric'):
+def plot_mc_curve(px, py, save_dir='mc_curve.png', names=(), xlabel='Confidence', ylabel='Metric', plot_per_class=True):
     # Metric-confidence curve
     fig, ax = plt.subplots(1, 1, figsize=(9, 6), tight_layout=True)
 

--- a/val.py
+++ b/val.py
@@ -120,6 +120,7 @@ def run(data,
         plots=True,
         callbacks=Callbacks(),
         compute_loss=None,
+        plot_per_class=True,
         ):
     # Initialize/load model and set device
     training = model is not None
@@ -251,7 +252,7 @@ def run(data,
     # Compute metrics
     stats = [np.concatenate(x, 0) for x in zip(*stats)]  # to numpy
     if len(stats) and stats[0].any():
-        tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats, plot=plots, save_dir=save_dir, names=names)
+        tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats, plot=plots, save_dir=save_dir, names=names, plot_per_class=plot_per_class)
         ap50, ap = ap[:, 0], ap.mean(1)  # AP@0.5, AP@0.5:0.95
         mp, mr, map50, map = p.mean(), r.mean(), ap50.mean(), ap.mean()
         nt = np.bincount(stats[3].astype(np.int64), minlength=nc)  # number of targets per class
@@ -338,6 +339,8 @@ def parse_opt():
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
+    parser.add_argument('--plot-per-class', action='store_true', help='plot graphs individually per class')
+    parser.add_argument('--no-plot-per-class', action='store_false', dest='plot_per_class', help='only plot average across all classes')
     opt = parser.parse_args()
     opt.data = check_yaml(opt.data)  # check YAML
     opt.save_json |= opt.data.endswith('coco.yaml')


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added option to enable/disable per-class plotting in validation metrics.

### 📊 Key Changes
- Introduced `plot_per_class` parameter to `ap_per_class`, `plot_pr_curve`, and `plot_mc_curve` functions.
- Modified the Precision-Recall (PR), F1, Precision, and Recall curve plotting logic to conditionally display per-class results.
- Added `plot_per_class` argument to `run` function in `val.py` to toggle the plotting behavior.
- Introduced command-line arguments `--plot-per-class` and `--no-plot-per-class` to control this feature from the CLI.

### 🎯 Purpose & Impact
- **Customization:** Provides users with the ability to either visualize average metrics across all classes or inspect per-class performance in detail.
- **Usability:** Enhances the interpretability of the model's performance for different use-cases.
- **Impact to users:** Users now have more control over the granularity of the performance plots generated during validation, allowing for better insight and analysis tailored to specific needs. 📈🔍