### PR TITLE
Improved AutoBatch DDP error message

### DIFF
--- a/train.py
+++ b/train.py
@@ -526,7 +526,7 @@ def main(opt, callbacks=Callbacks()):
         assert not opt.image_weights, f'--image-weights {msg}'
         assert not opt.evolve, f'--evolve {msg}'
         assert opt.batch_size != -1, f'AutoBatch with --batch-size -1 {msg}, please pass a valid --batch-size'
-        assert opt.batch_size % WORLD_SIZE == 0, '--batch-size must be multiple of CUDA device count'
+        assert opt.batch_size % WORLD_SIZE == 0, f'--batch-size {opt.batch_size} must be multiple of WORLD_SIZE'
         assert torch.cuda.device_count() > LOCAL_RANK, 'insufficient CUDA devices for DDP command'
         torch.cuda.set_device(LOCAL_RANK)
         device = torch.device('cuda', LOCAL_RANK)

--- a/train.py
+++ b/train.py
@@ -522,10 +522,12 @@ def main(opt, callbacks=Callbacks()):
     # DDP mode
     device = select_device(opt.device, batch_size=opt.batch_size)
     if LOCAL_RANK != -1:
-        assert torch.cuda.device_count() > LOCAL_RANK, 'insufficient CUDA devices for DDP command'
+        msg = 'is not compatible with YOLOv5 Multi-GPU DDP training'
+        assert not opt.image_weights, f'--image-weights {msg}'
+        assert not opt.evolve, f'--evolve {msg}'
+        assert opt.batch_size != -1, f'AutoBatch with --batch-size -1 {msg}, please pass a valid --batch-size'
         assert opt.batch_size % WORLD_SIZE == 0, '--batch-size must be multiple of CUDA device count'
-        assert not opt.image_weights, '--image-weights argument is not compatible with DDP training'
-        assert not opt.evolve, '--evolve argument is not compatible with DDP training'
+        assert torch.cuda.device_count() > LOCAL_RANK, 'insufficient CUDA devices for DDP command'
         torch.cuda.set_device(LOCAL_RANK)
         device = torch.device('cuda', LOCAL_RANK)
         dist.init_process_group(backend="nccl" if dist.is_nccl_available() else "gloo")


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced validations for Multi-GPU DDP training in YOLOv5.

### 📊 Key Changes
- Added more descriptive error messages for incompatible arguments in Multi-GPU DDP training.
- Introduced a new check to ensure the `--batch-size` argument is provided explicitly.
- Ensured the provided `--batch-size` is divisible by the number of devices available in the distributed setting (`WORLD_SIZE`).

### 🎯 Purpose & Impact
- 🔍 **Clarification**: Improved error messages help users understand why certain options are not allowed during Multi-GPU Distributed Data Parallel (DDP) training.
- 💡 **Explicit Requirements**: Forcing an explicit `--batch-size` prevents unintended consequences of using automated batch sizing (`--batch-size -1`).
- 🛠 **Data Integrity**: Checking for `--batch-size` divisibility ensures even data distribution among GPUs, which can lead to more efficient and stable training.