### PR TITLE
Fix `plot_labels()` colored histogram bug

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -340,8 +340,8 @@ def plot_labels(labels, names=(), save_dir=Path('')):
     matplotlib.use('svg')  # faster
     ax = plt.subplots(2, 2, figsize=(8, 8), tight_layout=True)[1].ravel()
     y = ax[0].hist(c, bins=np.linspace(0, nc, nc + 1) - 0.5, rwidth=0.8)
-    try:
-        [y[2].patches[i].set_color([x / 255 for x in colors(i)]) for i in range(nc)]  # update colors bug #3195
+    try:  # color histogram bars by class
+        [y[2].patches[i].set_color([x / 255 for x in colors(i)]) for i in range(nc)]  # known issue #3195
     except Exception:
         pass
     ax[0].set_ylabel('instances')

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -340,7 +340,10 @@ def plot_labels(labels, names=(), save_dir=Path('')):
     matplotlib.use('svg')  # faster
     ax = plt.subplots(2, 2, figsize=(8, 8), tight_layout=True)[1].ravel()
     y = ax[0].hist(c, bins=np.linspace(0, nc, nc + 1) - 0.5, rwidth=0.8)
-    [y[2].patches[i].set_color([x / 255 for x in colors(i)]) for i in range(nc)]  # update colors bug #3195
+    try:
+        [y[2].patches[i].set_color([x / 255 for x in colors(i)]) for i in range(nc)]  # update colors bug #3195
+    except Exception:
+        pass
     ax[0].set_ylabel('instances')
     if 0 < len(names) < 30:
         ax[0].set_xticks(range(len(names)))


### PR DESCRIPTION
Try color except pass

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved robustness in label plotting for YOLOv5 by handling potential exceptions.

### 📊 Key Changes
- Wrapped the color assignment code for histogram bars in a `try` block.
- Added an `except` clause to gracefully handle exceptions that may occur during color assignment.

### 🎯 Purpose & Impact
- **Purpose:** This change aims to address a known issue (#3195) where applying colors to histogram bars could fail, possibly causing the entire label plotting function to malfunction.
- **Impact:** This adds error handling to ensure that plotting continues without interruption, even if bar coloring fails. Users will experience more consistent behavior when visualizing label distributions across classes, which is particularly useful for understanding the dataset and the model's performance. 📈👀