### PR TITLE
Fix YouTube dislike button bug in `pafy` package

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -301,7 +301,7 @@ class LoadStreams:
             # Start thread to read frames from video stream
             st = f'{i + 1}/{n}: {s}... '
             if 'youtube.com/' in s or 'youtu.be/' in s:  # if source is YouTube video
-                check_requirements(('pafy', 'youtube_dl'))
+                check_requirements(('git+https://github.com/Cupcakus/pafy', 'youtube_dl'))
                 import pafy
                 s = pafy.new(s).getbest(preftype="mp4").url  # YouTube URL
             s = eval(s) if s.isnumeric() else s  # i.e. s = '0' local webcam


### PR DESCRIPTION
Per https://github.com/ultralytics/yolov5/issues/6583#issuecomment-1034421945 by @alicera

If you are having YouTube issues, `pip uninstall -Y pafy` and re-run your YouTube inference command.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated dependencies for handling YouTube videos in datasets.

### 📊 Key Changes
- Modified the `check_requirements` function call to fetch `pafy` from a specific GitHub repository instead of the default package index.

### 🎯 Purpose & Impact
- 🛠 Ensures continued compatibility with YouTube video streaming as source data by using an updated `pafy` fork.
- 📹 Enhances user experience by maintaining the ability to use YouTube videos for training and inference.
- 🔗 Potential impact includes the need for users to allow installation from a GitHub repository, which some environments may restrict.