### PR TITLE
Fix `ROOT / data` when running W&B `log_dataset()`

### DIFF
--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -356,6 +356,7 @@ class WandbLogger():
         # create a _wandb.yaml file with artifacts links if both train and test set are logged
         if not log_val_only:
             path = (path.stem if overwrite_config else path.stem + '_wandb') + '.yaml'  # updated data.yaml path
+            os.makedirs('data', exist_ok=True)
             path = Path('data') / path
             data.pop('download', None)
             data.pop('path', None)

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -356,7 +356,7 @@ class WandbLogger():
         # create a _wandb.yaml file with artifacts links if both train and test set are logged
         if not log_val_only:
             path = (path.stem if overwrite_config else path.stem + '_wandb') + '.yaml'  # updated data.yaml path
-            path = ROOT/ 'data' / path
+            path = ROOT / 'data' / path
             data.pop('download', None)
             data.pop('path', None)
             with open(path, 'w') as f:

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -356,8 +356,7 @@ class WandbLogger():
         # create a _wandb.yaml file with artifacts links if both train and test set are logged
         if not log_val_only:
             path = (path.stem if overwrite_config else path.stem + '_wandb') + '.yaml'  # updated data.yaml path
-            os.makedirs('data', exist_ok=True)
-            path = Path('data') / path
+            path = ROOT/ 'data' / path
             data.pop('download', None)
             data.pop('path', None)
             with open(path, 'w') as f:


### PR DESCRIPTION
This solves #6605

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to data artifact path handling in Weights & Biases logging.

### 📊 Key Changes
- Modified the path construction for the `_wandb.yaml` file to use the ROOT directory.

### 🎯 Purpose & Impact
- 🛠 **Purpose:** This change ensures that the path to the `_wandb.yaml` file is correctly formed, especially when configurations are overwritten.
- ✅ **Impact:** Users leveraging Weights & Biases for experiment tracking will benefit from more reliable artifact logging, potentially leading to fewer path-related issues during experiment tracking and reproduction.