### PR TITLE
W&B: don't log media in evolve

### DIFF
--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -252,6 +252,8 @@ class WandbLogger():
                 self.map_val_table_path()
         if opt.bbox_interval == -1:
             self.bbox_interval = opt.bbox_interval = (opt.epochs // 10) if opt.epochs > 10 else 1
+            if opt.evolve:
+                self.bbox_interval = opt.bbox_interval = opt.epochs + 1
         train_from_artifact = self.train_artifact_path is not None and self.val_artifact_path is not None
         # Update the the data_dict to point to local artifacts dir
         if train_from_artifact:


### PR DESCRIPTION
Attempts to fix https://github.com/ultralytics/yolov5/issues/6389

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging strategy for bounding box intervals during model evolution in WandB.

### 📊 Key Changes
- Introduced a conditional check for `opt.evolve` within the bounding box interval setup logic. 
- When model evolution is enabled, the bounding box interval is set to `opt.epochs + 1`.

### 🎯 Purpose & Impact
- The adjustment ensures that bounding box visualization does not interfere with the evolution process, making it more efficient.
- This change impacts users who leverage WandB for visualization and are using the evolve feature to optimize their models. Users will experience cleaner evolution runs without intermediate bounding box logs cluttering their WandB reports. 🚀📈