### PR TITLE
Add TorchScript export quantization option

### DIFF
--- a/export.py
+++ b/export.py
@@ -72,7 +72,7 @@ from utils.general import (LOGGER, check_dataset, check_img_size, check_requirem
 from utils.torch_utils import select_device
 
 
-def export_torchscript(model, im, file, torchscript_quantize,  optimize, prefix=colorstr('TorchScript:')):
+def export_torchscript(model, im, file, torchscript_quantize, optimize, prefix=colorstr('TorchScript:')):
     # YOLOv5 TorchScript model export
     try:
         LOGGER.info(f'\n{prefix} starting export with torch {torch.__version__}...')


### PR DESCRIPTION
Closes https://github.com/ultralytics/yolov5/issues/6609

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added TorchScript quantization support for model export.

### 📊 Key Changes
- 🛠 New argument `torchscript_quantize` in `export_torchscript` and `run` functions.
- 👨‍💻 Quantization code added within `export_torchscript` to perform model quantization.
- 🔄 Use of `torch.quantization` to quantize and prepare the model if `torchscript_quantize` is True.

### 🎯 Purpose & Impact
- 🚀 The option to quantize models during TorchScript export aims to reduce model size and possibly increase inference speed, which can be especially beneficial for deploying models on mobile devices or edge computing platforms.
- 👍 Users now have the flexibility to export their models with quantization, making the application of YOLOv5 more versatile in resource-constrained environments.