### PR TITLE
Add YOLOv5n to Reproduce section

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -983,7 +983,7 @@
       },
       "source": [
         "# Reproduce\n",
-        "for x in 'yolov5s', 'yolov5m', 'yolov5l', 'yolov5x':\n",
+        "for x in 'yolov5n', 'yolov5s', 'yolov5m', 'yolov5l', 'yolov5x':\n",
         "  !python val.py --weights {x}.pt --data coco.yaml --img 640 --task speed  # speed\n",
         "  !python val.py --weights {x}.pt --data coco.yaml --img 640 --conf 0.001 --iou 0.65  # mAP"
       ],


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Expanding tutorial to include the YOLOv5 Nano model (yolov5n) in performance comparison.

### 📊 Key Changes
- Tutorial now includes `yolov5n` in the iteration for model performance reproduction.

### 🎯 Purpose & Impact
- Adds the smallest YOLOv5 model to benchmarks, providing users with a baseline for comparison against other larger models.
- Helps users understand the trade-offs between speed and accuracy, especially on edge devices or applications where model size and speed are critical. 🚀 
- Could increase the accessibility of the YOLOv5 framework for users with limited computational resources. 🌍