### PR TITLE
Fixed wandb logger `KeyError`

### DIFF
--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -487,7 +487,7 @@ class WandbLogger():
             if self.current_epoch % self.bbox_interval == 0:
                 box_data = [{"position": {"minX": xyxy[0], "minY": xyxy[1], "maxX": xyxy[2], "maxY": xyxy[3]},
                              "class_id": int(cls),
-                             "box_caption": f"{names[cls]} {conf:.3f}",
+                             "box_caption": f"{names[int(cls)]} {conf:.3f}",
                              "scores": {"class_score": conf},
                              "domain": "pixel"} for *xyxy, conf, cls in pred.tolist()]
                 boxes = {"predictions": {"box_data": box_data, "class_labels": names}}  # inference-space


### PR DESCRIPTION
The modified line will try to index the `names` with a float `cls` which will raise a `KeyError`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of bounding box captions in Weights & Biases logging.

### 📊 Key Changes
- Ensured class names are correctly retrieved by casting class indices to integers before accessing the names list for bounding box captions.

### 🎯 Purpose & Impact
- 🎯 Ensures that object detection box captions display the correct class names during visualization on Weights & Biases.
- 🏷 Improves the accuracy of visual debugging and analysis for developers using Weights & Biases for tracking experiments.
- 🚀 Enhances user experience by providing precise and error-free annotations in logged images.