### PR TITLE
Fix ConfusionMatrix scale `vmin=0.0`

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -175,15 +175,16 @@ class ConfusionMatrix:
         try:
             import seaborn as sn
 
-            array = self.matrix / ((self.matrix.sum(0).reshape(1, -1) + 1E-6) if normalize else 1)  # normalize columns
+            array = self.matrix / ((self.matrix.sum(0).reshape(1, -1) + 1E-9) if normalize else 1)  # normalize columns
             array[array < 0.005] = np.nan  # don't annotate (would appear as 0.00)
 
             fig = plt.figure(figsize=(12, 9), tight_layout=True)
-            sn.set(font_scale=1.0 if self.nc < 50 else 0.8)  # for label size
-            labels = (0 < len(names) < 99) and len(names) == self.nc  # apply names to ticklabels
+            nc, nn = self.nc, len(names)  # number of classes, names
+            sn.set(font_scale=1.0 if nc < 50 else 0.8)  # for label size
+            labels = (0 < nn < 99) and (nn == nc)  # apply names to ticklabels
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore')  # suppress empty matrix RuntimeWarning: All-NaN slice encountered
-                sn.heatmap(array, annot=self.nc < 30, annot_kws={"size": 8}, cmap='Blues', fmt='.2f', square=True,
+                sn.heatmap(array, annot=nc < 30, annot_kws={"size": 8}, cmap='Blues', fmt='.2f', square=True, vmin=0.0,
                            xticklabels=names + ['background FP'] if labels else "auto",
                            yticklabels=names + ['background FN'] if labels else "auto").set_facecolor((1, 1, 1))
             fig.axes[0].set_xlabel('True')


### PR DESCRIPTION
Fix attempt for https://github.com/ultralytics/yolov5/issues/6626

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved clarity and correctness in confusion matrix visualization.

### 📊 Key Changes
- Normalization value changed from `1E-6` to `1E-9` to improve matrix accuracy.
- Added clarity to the code by using more descriptive variable naming for class numbers and names.
- Ensured the heatmap starts at 0.0 for better visual representation of the data.

### 🎯 Purpose & Impact
- **Accuracy**: Helps in preventing mathematical distortions in confusion matrix calculations.
- **Code Clarity**: Makes it easier for developers to understand and maintain the code.
- **Visualization Quality**: Improves readability of the heatmap for users, enabling them to interpret results correctly, particularly beneficial for classes with a large number of labels. 👀📈