### PR TITLE
Validate with 2x `--workers`

### DIFF
--- a/train.py
+++ b/train.py
@@ -232,7 +232,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     if RANK in [-1, 0]:
         val_loader = create_dataloader(val_path, imgsz, batch_size // WORLD_SIZE * 2, gs, single_cls,
                                        hyp=hyp, cache=None if noval else opt.cache, rect=True, rank=-1,
-                                       workers=workers, pad=0.5,
+                                       workers=workers * 2, pad=0.5,
                                        prefix=colorstr('val: '))[0]
 
         if not resume:

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -110,7 +110,7 @@ def create_dataloader(path, imgsz, batch_size, stride, single_cls=False, hyp=Non
 
     batch_size = min(batch_size, len(dataset))
     nd = torch.cuda.device_count()  # number of CUDA devices
-    nw = min([os.cpu_count() // max(nd, 1), batch_size if batch_size > 1 else 0, workers])  # number of workers
+    nw = min([2 * os.cpu_count() // max(nd, 1), batch_size if batch_size > 1 else 0, workers])  # number of workers
     sampler = None if rank == -1 else distributed.DistributedSampler(dataset, shuffle=shuffle)
     loader = DataLoader if image_weights else InfiniteDataLoader  # only DataLoader allows for attribute updates
     return loader(dataset,


### PR DESCRIPTION
Should improve validation speed and correspond to the 2x val batch size multiple.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved data loading performance for validation datasets in YOLOv5 training.

### 📊 Key Changes
- 🚀 Increased the number of workers for the validation data loader in `train.py` from `workers` to `workers * 2`.
- ✅ Tweaked the computation of the number of workers in `utils/datasets.py` to use `2 * os.cpu_count()` instead of `os.cpu_count()` when determining the maximum number of workers.

### 🎯 Purpose & Impact
- 💡 The purpose of these changes is to enhance the data loading speed during the validation phase of training, potentially reducing the time it takes to train YOLOv5 models.
- 🏃‍♂️ The impact on users should be faster validation steps, leading to quicker overall training runs, especially beneficial when using machines with multiple CPU cores.