### PR TITLE
Validate with 2x `--workers` single-GPU/CPU fix

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -110,7 +110,7 @@ def create_dataloader(path, imgsz, batch_size, stride, single_cls=False, hyp=Non
 
     batch_size = min(batch_size, len(dataset))
     nd = torch.cuda.device_count()  # number of CUDA devices
-    nw = min([2 * os.cpu_count() // max(nd, 1), batch_size if batch_size > 1 else 0, workers])  # number of workers
+    nw = min([os.cpu_count() // max(nd / 2, 1), batch_size if batch_size > 1 else 0, workers])  # number of workers
     sampler = None if rank == -1 else distributed.DistributedSampler(dataset, shuffle=shuffle)
     loader = DataLoader if image_weights else InfiniteDataLoader  # only DataLoader allows for attribute updates
     return loader(dataset,


### PR DESCRIPTION
Fix for #6658 for single-GPU and CPU training use cases

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in data loading efficiency for GPU environments.

### 📊 Key Changes
- Altered the calculation of the number of worker threads used in data loading to better optimize for multi-GPU setups.

### 🎯 Purpose & Impact
- The change aims to enhance the performance of data loading by better aligning the number of worker threads with the number of available GPU cores.
- Users with multiple GPUs might see improved data throughput and potentially faster training times, leading to a more efficient experience when training models with the YOLOv5 framework. 🚀