### PR TITLE
Add `--cache val` option

### DIFF
--- a/train.py
+++ b/train.py
@@ -221,8 +221,9 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
     # Trainloader
     train_loader, dataset = create_dataloader(train_path, imgsz, batch_size // WORLD_SIZE, gs, single_cls,
-                                              hyp=hyp, augment=True, cache=opt.cache, rect=opt.rect, rank=LOCAL_RANK,
-                                              workers=workers, image_weights=opt.image_weights, quad=opt.quad,
+                                              hyp=hyp, augment=True, cache=None if opt.cache == 'val' else opt.cache,
+                                              rect=opt.rect, rank=LOCAL_RANK, workers=workers,
+                                              image_weights=opt.image_weights, quad=opt.quad,
                                               prefix=colorstr('train: '), shuffle=True)
     mlc = int(np.concatenate(dataset.labels, 0)[:, 0].max())  # max label class
     nb = len(train_loader)  # number of batches
@@ -231,8 +232,8 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     # Process 0
     if RANK in [-1, 0]:
         val_loader = create_dataloader(val_path, imgsz, batch_size // WORLD_SIZE * 2, gs, single_cls,
-                                       hyp=hyp, cache=None if noval else opt.cache, rect=True, rank=-1,
-                                       workers=workers * 2, pad=0.5,
+                                       hyp=hyp, cache=None if noval else opt.cache,
+                                       rect=True, rank=-1, workers=workers * 2, pad=0.5,
                                        prefix=colorstr('val: '))[0]
 
         if not resume:


### PR DESCRIPTION
New `--cache val` argument will cache val set only into RAM. Should help multi-GPU training speeds without consuming as much RAM as full `--cache ram` which does both train and val sets.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements made to caching behavior in YOLOv5's training script for more flexible data handling.

### 📊 Key Changes
- Adjusted the `cache` parameter in `create_dataloader` function calls.
- For the training data loader, cache is now disabled when `opt.cache` is set to 'val'.
- Removed unnecessary `cache` parameter adjustment for the validation data loader.

### 🎯 Purpose & Impact
- Provides more control over how data is cached during training, which can affect memory usage and training speed. 🚀
- Prevents potential confusion or errors related to caching, leading to smoother development and training experiences. ✨
- The changes impact users by potentially improving the efficiency of data loading during model training, depending on their specific setup and needs. 🔄