### PR TITLE
FROM nvcr.io/nvidia/pytorch:22.01-py3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # YOLOv5 🚀 by Ultralytics, GPL-3.0 license
 
 # Start FROM Nvidia PyTorch image https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
-FROM nvcr.io/nvidia/pytorch:21.10-py3
+FROM nvcr.io/nvidia/pytorch:22.01-py3
 
 # Install linux packages
 RUN apt update && apt install -y zip htop screen libgl1-mesa-glx
@@ -9,7 +9,7 @@ RUN apt update && apt install -y zip htop screen libgl1-mesa-glx
 # Install python dependencies
 COPY requirements.txt .
 RUN python -m pip install --upgrade pip
-RUN pip uninstall -y nvidia-tensorboard nvidia-tensorboard-plugin-dlprof
+RUN pip uninstall -y nvidia-tensorboard nvidia-tensorboard-plugin-dlprof torch torchvision
 RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook
 RUN pip install --no-cache torch==1.10.2+cu113 torchvision==0.11.3+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
 # RUN pip install --no-cache -U torch torchvision


### PR DESCRIPTION
Update NVCR base

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update of the Dockerfile to a newer base image and refinement of PyTorch installation.

### 📊 Key Changes
- The base image in the Dockerfile has been updated from `nvcr.io/nvidia/pytorch:21.10-py3` to `nvcr.io/nvidia/pytorch:22.01-py3`.
- Added explicit uninstallation of `torch` and `torchvision` alongside `nvidia-tensorboard` and `nvidia-tensorboard-plugin-dlprof` that precedes package installations.
- Ensured a specific version of PyTorch (`1.10.2+cu113`) and Torchvision (`0.11.3+cu113`) are installed from a specified PyTorch wheel URL.

### 🎯 Purpose & Impact
- **Modernization**: By updating the base image, users benefit from the latest PyTorch features, enhanced performance, and better security.
- **Dependability**: Explicitly uninstalling PyTorch packages before reinstalling ensures that the desired versions are used, increasing stability and predictability.
- **Compatibility**: Specifying the installation of particular PyTorch and Torchvision versions helps maintain consistency across different environments or docker builds, preventing potential compatibility issues. 🚀