### PR TITLE
FROM nvcr.io/nvidia/pytorch:21.10-py3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # YOLOv5 🚀 by Ultralytics, GPL-3.0 license
 
 # Start FROM Nvidia PyTorch image https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
-FROM nvcr.io/nvidia/pytorch:22.01-py3
+FROM nvcr.io/nvidia/pytorch:21.10-py3
 
 # Install linux packages
 RUN apt update && apt install -y zip htop screen libgl1-mesa-glx


### PR DESCRIPTION
22.10 returns 'no space left on device' error message.

Seems like a bug at docker. Raised issue in https://github.com/docker/hub-feedback/issues/2209

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update of base Docker image to a different version.

### 📊 Key Changes
- Changed the base Docker image from `nvcr.io/nvidia/pytorch:22.01-py3` to `nvcr.io/nvidia/pytorch:21.10-py3`.

### 🎯 Purpose & Impact
- 🔄 This change possibly addresses compatibility or specific feature requirements that align better with the `21.10-py3` version of the NVIDIA PyTorch container.
- ⚖️ May impact users by altering the behavior or performance of applications built with this Docker image due to differences between the PyTorch versions.
- 🔧 Users may need to adjust their own code or environment setup to ensure compatibility with the new base image version.