### PR TITLE
FROM nvcr.io/nvidia/pytorch:21.10-py3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # YOLOv5 🚀 by Ultralytics, GPL-3.0 license
 
 # Start FROM Nvidia PyTorch image https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
-FROM nvcr.io/nvidia/pytorch:22.01-py3
+FROM nvcr.io/nvidia/pytorch:21.10-py3
 
 # Install linux packages
 RUN apt update && apt install -y zip htop screen libgl1-mesa-glx
@@ -10,8 +10,8 @@ RUN apt update && apt install -y zip htop screen libgl1-mesa-glx
 COPY requirements.txt .
 RUN python -m pip install --upgrade pip
 RUN pip uninstall -y torch torchvision torchtext
-RUN pip install --no-cache torch==1.10.2+cu113 torchvision==0.11.3+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
-RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook
+RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook \
+    torch==1.10.2+cu113 torchvision==0.11.3+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
 # RUN pip install --no-cache -U torch torchvision
 
 # Create working directory


### PR DESCRIPTION
Revert to 21.10 on autobuild fail

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated Docker base image and installation order for PyTorch and dependencies.

### 📊 Key Changes
- 🔄 Base image in Dockerfile changed from `nvcr.io/nvidia/pytorch:22.01-py3` to `nvcr.io/nvidia/pytorch:21.10-py3`.
- 📦 Reordered installation of PyTorch and dependencies by combining into a single `RUN pip install` command.

### 🎯 Purpose & Impact
- 🔒 The base image rollback is likely for compatibility or stability with certain dependencies or systems.
- 🚀 Combining installation steps streamlines the Docker build process, potentially resulting in faster build times and clearer Dockerfile structure.
- 👥 Users can expect the Docker container to potentially have better support or performance for their tasks after these changes.