### PR TITLE
opencv-python fails to import skbuild without scikit-build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # Base ----------------------------------------
 matplotlib>=3.2.2
 numpy>=1.18.5
+scikit-build>=0.7.1
 opencv-python>=4.1.2
 Pillow>=7.1.2
 PyYAML>=5.3.1


### PR DESCRIPTION
Collecting opencv-python>=4.1.2 (from -r requirements.txt (line 6))
  Downloading https://files.pythonhosted.org/packages/c4/e2/27a153e27b98410cf5a871096a8baf98dd642e6685d3ebe7abd9edc8d51a/opencv-python-4.5.5.62.tar.gz (89.9MB)
    100% |████████████████████████████████| 89.9MB 10kB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-lfq37uhk/opencv-python/setup.py", line 10, in <module>
        import skbuild
    ModuleNotFoundError: No module named 'skbuild'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-lfq37uhk/opencv-python/

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced `yolov5` build dependencies with the addition of `scikit-build`.

### 📊 Key Changes
- Added `scikit-build` as a new requirement in `requirements.txt`.

### 🎯 Purpose & Impact
- 🛠 **Purpose**: This addition is typically meant to improve the build process for native extensions, suggesting that `yolov5` might be planning for, or currently includes, components that require compilation.
- ⚙️ **Impact**: Users might experience a more streamlined installation process with fewer hiccups when building from the source.
- 🧩 Developers looking to contribute to the project may find it easier to set up their development environment for advanced contributions that imply building C/C++ extensions.