### PR TITLE
Fix floating point in number of workers

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -110,7 +110,7 @@ def create_dataloader(path, imgsz, batch_size, stride, single_cls=False, hyp=Non
 
     batch_size = min(batch_size, len(dataset))
     nd = torch.cuda.device_count()  # number of CUDA devices
-    nw = min([os.cpu_count() // max(nd / 2, 1), batch_size if batch_size > 1 else 0, workers])  # number of workers
+    nw = min([os.cpu_count() // max(nd // 2, 1), batch_size if batch_size > 1 else 0, workers])  # number of workers
     sampler = None if rank == -1 else distributed.DistributedSampler(dataset, shuffle=shuffle)
     loader = DataLoader if image_weights else InfiniteDataLoader  # only DataLoader allows for attribute updates
     return loader(dataset,


### PR DESCRIPTION
Integer division by a float yields a (rounded) float. This causes
the dataloader to crash when creating a range. Here is an output where I printed the number of workers to debug:

```
USING 1.0 workers
Traceback (most recent call last):
  File "train.py", line 643, in <module>
    main(opt)
  File "train.py", line 539, in main
    train(opt.hyp, opt, device, callbacks)
  File "train.py", line 227, in train
    prefix=colorstr('train: '), shuffle=True)
  File "/home/syvon/Documents/yolov5/utils/datasets.py", line 124, in create_dataloader
    collate_fn=LoadImagesAndLabels.collate_fn4 if quad else LoadImagesAndLabels.collate_fn), dataset
  File "/home/syvon/Documents/yolov5/utils/datasets.py", line 136, in __init__
    self.iterator = super().__iter__()
  File "/home/syvon/anaconda3/envs/yolov5/lib/python3.7/site-packages/torch/utils/data/dataloader.py", line 359, in __iter__
    return self._get_iterator()
  File "/home/syvon/anaconda3/envs/yolov5/lib/python3.7/site-packages/torch/utils/data/dataloader.py", line 305, in _get_iterator
    return _MultiProcessingDataLoaderIter(self)
  File "/home/syvon/anaconda3/envs/yolov5/lib/python3.7/site-packages/torch/utils/data/dataloader.py", line 889, in __init__
    self._worker_queue_idx_cycle = itertools.cycle(range(self._num_workers))
TypeError: 'float' object cannot be interpreted as an integer
```



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved data loading efficiency in YOLOv5.

### 📊 Key Changes
- Modified the calculation of the number of worker processes for loading data.

### 🎯 Purpose & Impact
- Ensures the correct number of worker processes by fixing an integer division bug.
- 🚀 This improvement can lead to better utilization of CPU resources, potentially speeding up the data loading process.
- 🛠 Users may notice quicker training start times and possibly reduced overall training time due to more efficient data handling.