### PR TITLE
Suppress `torch` AMP-CPU warnings

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -9,6 +9,7 @@ import os
 import platform
 import subprocess
 import time
+import warnings
 from contextlib import contextmanager
 from copy import deepcopy
 from pathlib import Path
@@ -24,6 +25,9 @@ try:
     import thop  # for FLOPs computation
 except ImportError:
     thop = None
+
+# Suppress PyTorch warnings
+warnings.filterwarnings('ignore', message='User provided device_type of \'cuda\', but CUDA is not available. Disabling')
 
 
 @contextmanager
@@ -293,13 +297,9 @@ class EarlyStopping:
 
 
 class ModelEMA:
-    """ Model Exponential Moving Average from https://github.com/rwightman/pytorch-image-models
-    Keep a moving average of everything in the model state_dict (parameters and buffers).
-    This is intended to allow functionality like
-    https://www.tensorflow.org/api_docs/python/tf/train/ExponentialMovingAverage
-    A smoothed version of the weights is necessary for some training schemes to perform well.
-    This class is sensitive where it is initialized in the sequence of model init,
-    GPU assignment and distributed training wrappers.
+    """ Updated Exponential Moving Average (EMA) from https://github.com/rwightman/pytorch-image-models
+    Keeps a moving average of everything in the model state_dict (parameters and buffers)
+    For EMA details see https://www.tensorflow.org/api_docs/python/tf/train/ExponentialMovingAverage
     """
 
     def __init__(self, model, decay=0.9999, updates=0):


### PR DESCRIPTION
This is a torch bug, but they seem unable or unwilling to fix it so I'm creating a suppression in YOLOv5. 

Resolves https://github.com/ultralytics/yolov5/issues/6692

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of model training stability by suppressing irrelevant PyTorch warnings and refining ModelEMA documentation.

### 📊 Key Changes
- 🚫 Added code to suppress specific PyTorch warnings regarding CUDA availability.
- 📝 Updated comments for the `ModelEMA` class to better explain its purpose and provide references.

### 🎯 Purpose & Impact
- 🔇 Suppressing non-critical warnings helps declutter the command output during training, leading to less confusion for users especially when the warning is not pertinent to their use case.
- 📖 Improved documentation for the `ModelEMA` provides clearer guidance on its use and significance, potentially improving understandability for developers utilizing this module in their training pipelines.