### PR TITLE
Update `nw` to `max(nd, 1)`

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -110,7 +110,7 @@ def create_dataloader(path, imgsz, batch_size, stride, single_cls=False, hyp=Non
 
     batch_size = min(batch_size, len(dataset))
     nd = torch.cuda.device_count()  # number of CUDA devices
-    nw = min([os.cpu_count() // max(nd // 2, 1), batch_size if batch_size > 1 else 0, workers])  # number of workers
+    nw = min([os.cpu_count() // max(nd, 1), batch_size if batch_size > 1 else 0, workers])  # number of workers
     sampler = None if rank == -1 else distributed.DistributedSampler(dataset, shuffle=shuffle)
     loader = DataLoader if image_weights else InfiniteDataLoader  # only DataLoader allows for attribute updates
     return loader(dataset,


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced multi-GPU DataLoader initialization for better performance.

### 📊 Key Changes
- Adjusted DataLoader's worker count calculation for multi-GPU setups.

### 🎯 Purpose & Impact
- **Purpose:** The update aims to optimize the number of DataLoader workers by considering the actual count of CUDA devices (GPUs) rather than limiting it based on a divided count.
- **Impact:** This can lead to improved data loading efficiency in systems with multiple GPUs, potentially speeding up model training and reducing bottlenecks caused by data loading. Users with multi-GPU setups might see a performance boost during training sessions. 🚀🖥️