### PR TITLE
Switch default LR scheduler from cos to linear

### DIFF
--- a/train.py
+++ b/train.py
@@ -176,10 +176,10 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     del g0, g1, g2
 
     # Scheduler
-    if opt.linear_lr:
-        lf = lambda x: (1 - x / (epochs - 1)) * (1.0 - hyp['lrf']) + hyp['lrf']  # linear
-    else:
+    if opt.cos_lr:
         lf = one_cycle(1, hyp['lrf'], epochs)  # cosine 1->hyp['lrf']
+    else:
+        lf = lambda x: (1 - x / (epochs - 1)) * (1.0 - hyp['lrf']) + hyp['lrf']  # linear
     scheduler = lr_scheduler.LambdaLR(optimizer, lr_lambda=lf)  # plot_lr_scheduler(optimizer, scheduler, epochs)
 
     # EMA
@@ -479,7 +479,7 @@ def parse_opt(known=False):
     parser.add_argument('--name', default='exp', help='save to project/name')
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     parser.add_argument('--quad', action='store_true', help='quad dataloader')
-    parser.add_argument('--linear-lr', action='store_true', help='linear LR')
+    parser.add_argument('--cos-lr', action='store_true', help='cosine LR scheduler')
     parser.add_argument('--label-smoothing', type=float, default=0.0, help='Label smoothing epsilon')
     parser.add_argument('--patience', type=int, default=100, help='EarlyStopping patience (epochs without improvement)')
     parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')

--- a/train.py
+++ b/train.py
@@ -179,7 +179,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
     if opt.cos_lr:
         lf = one_cycle(1, hyp['lrf'], epochs)  # cosine 1->hyp['lrf']
     else:
-        lf = lambda x: (1 - x / (epochs - 1)) * (1.0 - hyp['lrf']) + hyp['lrf']  # linear
+        lf = lambda x: (1 - x / epochs) * (1.0 - hyp['lrf']) + hyp['lrf']  # linear
     scheduler = lr_scheduler.LambdaLR(optimizer, lr_lambda=lf)  # plot_lr_scheduler(optimizer, scheduler, epochs)
 
     # EMA


### PR DESCRIPTION
Based on empirical results of training both ways on all YOLOv5 models. Before and after (300 epochs):

<img width="598" alt="Screenshot 2022-02-08 at 12 26 11" src="https://user-images.githubusercontent.com/26833433/152978014-7b093865-2c85-478d-b97c-10df99aacba2.png">


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing cosine learning rate scheduling option in YOLOv5 training.

### 📊 Key Changes
- Removed the `linear-lr` scheduler option.
- Added a `cos-lr` scheduler option for cosine learning rate scheduling.
- Adjusted the learning rate function (`lf`) to utilize the cosine schedule when `cos-lr` is enabled.

### 🎯 Purpose & Impact
- **Enhanced Training Customization**: Users now have the option to select a cosine learning rate scheduler, which can potentially improve model convergence and performance.
- **Smoother Learning Rate Transitions**: The cosine scheduler provides smoother transitions in the learning rate, compared to a linear decay, which could lead to better training dynamics.
- **User Flexibility**: This change gives users more flexibility in how they wish to adjust the learning rate over training epochs, potentially accommodating different training scenarios and preferences.