### PR TITLE
add name support in yaml .

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -267,7 +267,7 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
         else:
             if isinstance(f,str):
                 f=namedict[f]
-        
+
         m = eval(m) if isinstance(m, str) else m  # eval strings
         for j, a in enumerate(args):
             try:


### PR DESCRIPTION
I add an optional  name parameter in yaml config files .
eg:
   [-1, 1, Conv, [512, 3, 2],P4],  # 5-P4/16
   [-1, 9, C3, [512],P4_C3],
one can refer to this layer by name,
from :
  [[-1, 6], 1, Concat, [1]],  # cat backbone P4
to :
  [[-1, P4_C3], 1, Concat, [1]],  # cat backbone P4

I think this can made config more clear and readable .