### PR TITLE
Update min warmup iterations from 1k to 100

### DIFF
--- a/train.py
+++ b/train.py
@@ -268,7 +268,7 @@ def train(hyp,  # path/to/hyp.yaml or hyp dictionary
 
     # Start training
     t0 = time.time()
-    nw = max(round(hyp['warmup_epochs'] * nb), 1000)  # number of warmup iterations, max(3 epochs, 1k iterations)
+    nw = max(round(hyp['warmup_epochs'] * nb), 100)  # number of warmup iterations, max(3 epochs, 100 iterations)
     # nw = min(nw, (epochs - start_epoch) / 2 * nb)  # limit warmup to < 1/2 of training
     last_opt_step = -1
     maps = np.zeros(nc)  # mAP per class


### PR DESCRIPTION
Based on VOC results at larger batch sizes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Reduced the minimum number of warmup iterations from 1,000 to 100 in the YOLOv5 training process.

### 📊 Key Changes
- The minimum warmup iterations (`nw`) is modified from `max(3 epochs, 1k iterations)` to `max(3 epochs, 100 iterations)` in the training script (`train.py`).

### 🎯 Purpose & Impact
- **Purpose**: To adjust the warmup strategy by decreasing the minimum number of iterations, possibly improving the adaptability for different dataset sizes and training durations.
- **Impact**: This could lead to faster convergence during training on smaller datasets or less compute-intensive scenarios, with potential benefits for users who perform numerous experiments or have limited resources. 🚀 However, there may be a need to monitor the influence on model accuracy and training stability, as warmup plays a crucial role in preparing the model for effective learning. 🧐