### PR TITLE
Default `OMP_NUM_THREADS=8`

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -45,6 +45,7 @@ np.set_printoptions(linewidth=320, formatter={'float_kind': '{:11.5g}'.format}) 
 pd.options.display.max_columns = 10
 cv2.setNumThreads(0)  # prevent OpenCV from multithreading (incompatible with PyTorch DataLoader)
 os.environ['NUMEXPR_MAX_THREADS'] = str(NUM_THREADS)  # NumExpr max threads
+os.environ['OMP_NUM_THREADS'] = str(NUM_THREADS)  # OpenMP max threads (PyTorch and SciPy)
 
 
 def is_kaggle():


### PR DESCRIPTION
Attempt to fix multi-instance anchor evolution oversubscribing threads (caused by SciPy kmeans).

See https://scikit-learn.org/stable/computing/parallelism.html#openmp-based-parallelism

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced support for multi-threading in YOLOv5 🔧

### 📊 Key Changes
- Added an environment variable to control OpenMP's maximum number of threads.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To ensure better thread management by setting the maximum number of threads that OpenMP can utilize, which is relevant when running YOLOv5 along with PyTorch and SciPy.
- 🚀 **Impact**: This change aims to improve the performance and efficiency of YOLOv5 by preventing potential thread contention, which can lead to better resource usage and possibly enhance the speed of operations on multi-core systems.