### PR TITLE
Fix export for 1-channel images

### DIFF
--- a/export.py
+++ b/export.py
@@ -260,9 +260,9 @@ def export_saved_model(model, im, file, dynamic,
         batch_size, ch, *imgsz = list(im.shape)  # BCHW
 
         tf_model = TFModel(cfg=model.yaml, model=model, nc=model.nc, imgsz=imgsz)
-        im = tf.zeros((batch_size, *imgsz, 3))  # BHWC order for TensorFlow
+        im = tf.zeros((batch_size, *imgsz, ch))  # BHWC order for TensorFlow
         _ = tf_model.predict(im, tf_nms, agnostic_nms, topk_per_class, topk_all, iou_thres, conf_thres)
-        inputs = tf.keras.Input(shape=(*imgsz, 3), batch_size=None if dynamic else batch_size)
+        inputs = tf.keras.Input(shape=(*imgsz, ch), batch_size=None if dynamic else batch_size)
         outputs = tf_model.predict(inputs, tf_nms, agnostic_nms, topk_per_class, topk_all, iou_thres, conf_thres)
         keras_model = tf.keras.Model(inputs=inputs, outputs=outputs)
         keras_model.trainable = False


### PR DESCRIPTION
Export failed for 1-channel input shape, 1-liner fix

Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced TensorFlow export compatibility for different image channel sizes.

### 📊 Key Changes
- Changed hard-coded color channels from 3 to a variable `ch` for image input in TensorFlow model format.
- Adjusted the TensorFlow model input shape to be dynamic based on the actual image channels.

### 🎯 Purpose & Impact
- 🎨 Allows for more flexible model exports with support for images that are not strictly three channels (e.g., grayscale or RGBA).
- 🔧 Improves compatibility and potentially reduces issues when working with non-RGB datasets.
- 🚀 Could benefit users working with specialized imaging data, expanding YOLOv5's applicability.