### PR TITLE
Default FP16 TensorRT export

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -94,13 +94,13 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
     imgsz = check_img_size(imgsz, s=stride)  # check image size
 
     # Half
-    if engine and model.trt_fp16_input != half:
-        LOGGER.info('model ' + (
-            'requires' if model.trt_fp16_input else 'incompatible with') + ' --half. Adjusting automatically.')
-        half = model.trt_fp16_input
     half &= (pt or jit or onnx or engine) and device.type != 'cpu'  # FP16 supported on limited backends with CUDA
     if pt or jit:
         model.model.half() if half else model.model.float()
+    elif engine and model.trt_fp16_input != half:
+        LOGGER.info('model ' + (
+            'requires' if model.trt_fp16_input else 'incompatible with') + ' --half. Adjusting automatically.')
+        half = model.trt_fp16_input
 
     # Dataloader
     if webcam:

--- a/detect.py
+++ b/detect.py
@@ -94,9 +94,10 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
     imgsz = check_img_size(imgsz, s=stride)  # check image size
 
     # Half
+    if engine and model.trt_fp16_input != half:
+        LOGGER.info('model ' + ('requires' if model.trt_fp16_input else 'incompatible with') + ' --half. Adjusting automatically.')
+        half = model.trt_fp16_input
     half &= (pt or jit or onnx or engine) and device.type != 'cpu'  # FP16 supported on limited backends with CUDA
-    if engine:
-        assert (model.trt_fp16_input == half), 'model ' + ('requires' if model.trt_fp16_input else 'incompatible with') + ' --half'
     if pt or jit:
         model.model.half() if half else model.model.float()
 

--- a/detect.py
+++ b/detect.py
@@ -95,7 +95,8 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
 
     # Half
     if engine and model.trt_fp16_input != half:
-        LOGGER.info('model ' + ('requires' if model.trt_fp16_input else 'incompatible with') + ' --half. Adjusting automatically.')
+        LOGGER.info('model ' + (
+            'requires' if model.trt_fp16_input else 'incompatible with') + ' --half. Adjusting automatically.')
         half = model.trt_fp16_input
     half &= (pt or jit or onnx or engine) and device.type != 'cpu'  # FP16 supported on limited backends with CUDA
     if pt or jit:

--- a/detect.py
+++ b/detect.py
@@ -95,6 +95,8 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
 
     # Half
     half &= (pt or jit or onnx or engine) and device.type != 'cpu'  # FP16 supported on limited backends with CUDA
+    if engine:
+        assert (model.trt_fp16_input == half), 'model ' + ('requires' if model.trt_fp16_input else 'incompatible with') + ' --half'
     if pt or jit:
         model.model.half() if half else model.model.float()
 

--- a/export.py
+++ b/export.py
@@ -237,9 +237,8 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
         for out in outputs:
             LOGGER.info(f'{prefix}\toutput "{out.name}" with shape {out.shape} and dtype {out.dtype}')
 
-        half &= builder.platform_has_fast_fp16
-        LOGGER.info(f'{prefix} building FP{16 if half else 32} engine in {f}')
-        if half:
+        LOGGER.info(f'{prefix} building FP{16 if builder.platform_has_fast_fp16 else 32} engine in {f}')
+        if builder.platform_has_fast_fp16:
             config.set_flag(trt.BuilderFlag.FP16)
         with builder.build_engine(network, config) as engine, open(f, 'wb') as t:
             t.write(engine.serialize())

--- a/export.py
+++ b/export.py
@@ -229,8 +229,6 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
         outputs = [network.get_output(i) for i in range(network.num_outputs)]
         LOGGER.info(f'{prefix} Network Description:')
         for inp in inputs:
-            # if not half:  # default to FP32 input unless specified otherwise; then let TensorRT decide
-            #     inp.dtype = trt.DataType.FLOAT
             LOGGER.info(f'{prefix}\tinput "{inp.name}" with shape {inp.shape} and dtype {inp.dtype}')
         for out in outputs:
             LOGGER.info(f'{prefix}\toutput "{out.name}" with shape {out.shape} and dtype {out.dtype}')

--- a/export.py
+++ b/export.py
@@ -227,7 +227,6 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
 
         inputs = [network.get_input(i) for i in range(network.num_inputs)]
         outputs = [network.get_output(i) for i in range(network.num_outputs)]
-        network.get_input(0).dtype = trt.DataType.FLOAT
         LOGGER.info(f'{prefix} Network Description:')
         for inp in inputs:
             # default to FP32 input precision unless specified otherwise; then let TensorRT decide

--- a/export.py
+++ b/export.py
@@ -229,9 +229,8 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
         outputs = [network.get_output(i) for i in range(network.num_outputs)]
         LOGGER.info(f'{prefix} Network Description:')
         for inp in inputs:
-            # default to FP32 input precision unless specified otherwise; then let TensorRT decide
-            if not half:
-                inp.dtype = trt.DataType.FLOAT
+            # if not half:  # default to FP32 input unless specified otherwise; then let TensorRT decide
+            #     inp.dtype = trt.DataType.FLOAT
             LOGGER.info(f'{prefix}\tinput "{inp.name}" with shape {inp.shape} and dtype {inp.dtype}')
         for out in outputs:
             LOGGER.info(f'{prefix}\toutput "{out.name}" with shape {out.shape} and dtype {out.dtype}')

--- a/export.py
+++ b/export.py
@@ -227,8 +227,12 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
 
         inputs = [network.get_input(i) for i in range(network.num_inputs)]
         outputs = [network.get_output(i) for i in range(network.num_outputs)]
+        network.get_input(0).dtype = trt.DataType.FLOAT
         LOGGER.info(f'{prefix} Network Description:')
         for inp in inputs:
+            # default to FP32 input precision unless specified otherwise; then let TensorRT decide
+            if not half:
+                inp.dtype = trt.DataType.FLOAT
             LOGGER.info(f'{prefix}\tinput "{inp.name}" with shape {inp.shape} and dtype {inp.dtype}')
         for out in outputs:
             LOGGER.info(f'{prefix}\toutput "{out.name}" with shape {out.shape} and dtype {out.dtype}')

--- a/models/common.py
+++ b/models/common.py
@@ -296,7 +296,6 @@ class DetectMultiBackend(nn.Module):
         w = str(weights[0] if isinstance(weights, list) else weights)
         pt, jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs = self.model_type(w)  # get backend
         stride, names = 64, [f'class{i}' for i in range(1000)]  # assign defaults
-        trt_fp16_input = False
         w = attempt_download(w)  # download if not local
         if data:  # data.yaml path (optional)
             with open(data, errors='ignore') as f:

--- a/models/common.py
+++ b/models/common.py
@@ -338,6 +338,7 @@ class DetectMultiBackend(nn.Module):
             import tensorrt as trt  # https://developer.nvidia.com/nvidia-tensorrt-download
             check_version(trt.__version__, '7.0.0', hard=True)  # require tensorrt>=7.0.0
             Binding = namedtuple('Binding', ('name', 'dtype', 'shape', 'data', 'ptr'))
+            trt_fp16_input = False
             logger = trt.Logger(trt.Logger.INFO)
             with open(w, 'rb') as f, trt.Runtime(logger) as runtime:
                 model = runtime.deserialize_cuda_engine(f.read())
@@ -349,7 +350,7 @@ class DetectMultiBackend(nn.Module):
                 data = torch.from_numpy(np.empty(shape, dtype=np.dtype(dtype))).to(device)
                 bindings[name] = Binding(name, dtype, shape, data, int(data.data_ptr()))
                 if model.binding_is_input(index) and dtype == np.float16:
-                    trt_fp16_input = dtype == np.float16
+                    trt_fp16_input = True
             binding_addrs = OrderedDict((n, d.ptr) for n, d in bindings.items())
             context = model.create_execution_context()
             batch_size = bindings['images'].shape[0]

--- a/val.py
+++ b/val.py
@@ -143,7 +143,7 @@ def run(data,
         if pt or jit:
             model.model.half() if half else model.model.float()
         elif engine:
-            if model.trt_fp16_input != half
+            if model.trt_fp16_input != half:
                 LOGGER.info('model ' + ('requires' if model.trt_fp16_input else 'incompatible with') + ' --half. Adjusting automatically.')
                 half = model.trt_fp16_input
             batch_size = model.batch_size

--- a/val.py
+++ b/val.py
@@ -143,6 +143,7 @@ def run(data,
         if pt or jit:
             model.model.half() if half else model.model.float()
         elif engine:
+            assert (model.trt_fp16_input == half), 'model ' + ('requires' if model.trt_fp16_input else 'incompatible with') + ' --half'
             batch_size = model.batch_size
         else:
             half = False

--- a/val.py
+++ b/val.py
@@ -144,7 +144,8 @@ def run(data,
             model.model.half() if half else model.model.float()
         elif engine:
             if model.trt_fp16_input != half:
-                LOGGER.info('model ' + ('requires' if model.trt_fp16_input else 'incompatible with') + ' --half. Adjusting automatically.')
+                LOGGER.info('model ' + (
+                    'requires' if model.trt_fp16_input else 'incompatible with') + ' --half. Adjusting automatically.')
                 half = model.trt_fp16_input
             batch_size = model.batch_size
         else:

--- a/val.py
+++ b/val.py
@@ -143,7 +143,9 @@ def run(data,
         if pt or jit:
             model.model.half() if half else model.model.float()
         elif engine:
-            assert (model.trt_fp16_input == half), 'model ' + ('requires' if model.trt_fp16_input else 'incompatible with') + ' --half'
+            if model.trt_fp16_input != half
+                LOGGER.info('model ' + ('requires' if model.trt_fp16_input else 'incompatible with') + ' --half. Adjusting automatically.')
+                half = model.trt_fp16_input
             batch_size = model.batch_size
         else:
             half = False

--- a/val.py
+++ b/val.py
@@ -143,11 +143,11 @@ def run(data,
         if pt or jit:
             model.model.half() if half else model.model.float()
         elif engine:
+            batch_size = model.batch_size
             if model.trt_fp16_input != half:
                 LOGGER.info('model ' + (
                     'requires' if model.trt_fp16_input else 'incompatible with') + ' --half. Adjusting automatically.')
                 half = model.trt_fp16_input
-            batch_size = model.batch_size
         else:
             half = False
             batch_size = 1  # export.py models default to batch-size 1


### PR DESCRIPTION
Assert that the `--half` flag fits the precision of the TensorRT engine in `val.py` and `detect.py`.

In addition, make the default TensorRT export use FP16 precision (if available), and set input precision according to `--half` flag

EDIT: Adding justification for update. No mAP penalty and speed improvements:

YOLOv5 🚀 v6.1-13-g601dbb8 torch 1.10.0+cu111 CUDA:0 (Tesla V100-SXM2-16GB, 16160MiB)

```python
!pip install -U nvidia-tensorrt --index-url https://pypi.ngc.nvidia.com  # install

!python export.py --weights yolov5s.pt --include engine --imgsz 640 640 --device 0  # export
%mv yolov5s.engine yolov5s_fp32.engine
!python export.py --weights yolov5s.pt --include engine --imgsz 640 640 --device 0 --half  # export
%mv yolov5s.engine yolov5s_fp16.engine

!python val.py --weights yolov5s.pt --data coco.yaml --img 640 --iou 0.65 --device 0 --batch 1
!python val.py --weights yolov5s.pt --data coco.yaml --img 640 --iou 0.65 --device 0 --batch 1 --half

!python val.py --weights yolov5s_fp32.engine --data coco.yaml --img 640 --iou 0.65 --device 0 --batch 1
!python val.py --weights yolov5s_fp16.engine --data coco.yaml --img 640 --iou 0.65 --device 0 --batch 1 --half
```

YOLOv5s v6.1 |Inference time (ms)    | COCO mAP
---        |---          |---  
PyTorch FP32      |12.5   | 37.5
PyTorch FP16      |10.5  | 37.5
TensorRT FP32      |3.4   | 37.4
TensorRT FP16      |1.9  | 37.4



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved half-precision inference handling for TensorRT models.

### 📊 Key Changes
- Detection, validation, and export scripts now adjust the `half` (FP16) setting based on the model's capabilities when using TensorRT.
- The TensorRT model now has a boolean attribute to indicate if it requires FP16 input.
- Automatic notification and adjustment if the user-specified `half` setting doesn't match the model's TensorRT FP16 input requirement.
- Simplification of FP16 engine building logic in the export script, to rely strictly on the platform's fast FP16 support capability.

### 🎯 Purpose & Impact
- Ensures compatibility between the user's FP16 setting and the model's actual capabilities, avoiding potential errors.
- Provides clearer logging information to the user when an auto-adjustment occurs, improving the user experience.
- Users can expect better reliability and ease of use when exporting and running models with TensorRT, particularly on platforms that support fast FP16 inference. 🚀