### PR TITLE
EdgeTPU optimizations

### DIFF
--- a/export.py
+++ b/export.py
@@ -330,7 +330,7 @@ def export_tflite(keras_model, im, file, int8, data, ncalib, prefix=colorstr('Te
             converter.target_spec.supported_types = []
             converter.inference_input_type = tf.uint8  # or tf.int8
             converter.inference_output_type = tf.uint8  # or tf.int8
-            converter.experimental_new_quantizer = False
+            converter.experimental_new_quantizer = True
             f = str(file).replace('.pt', '-int8.tflite')
 
         tflite_model = converter.convert()

--- a/models/tf.py
+++ b/models/tf.py
@@ -226,10 +226,10 @@ class TFDetect(keras.layers.Layer):
 
             if not self.training:  # inference
                 y = tf.sigmoid(x[i])
-                grid = tf.transpose(self.grid[i], [0, 2, 1, 3])
-                anchor_grid = tf.transpose(self.anchor_grid[i], [0, 2, 1, 3])
-                xy = (y[..., 0:2] * 2 - 0.5 + grid) * self.stride[i]  # xy
-                wh = (y[..., 2:4] * 2) ** 2 * anchor_grid
+                grid = tf.transpose(self.grid[i], [0, 2, 1, 3]) - 0.5
+                anchor_grid = tf.transpose(self.anchor_grid[i], [0, 2, 1, 3]) * 4
+                xy = (y[..., 0:2] * 2 + grid) * self.stride[i]  # xy
+                wh = y[..., 2:4] ** 2 * anchor_grid
                 # Normalize xywh to 0-1 to reduce calibration error
                 xy /= tf.constant([[self.imgsz[1], self.imgsz[0]]], dtype=tf.float32)
                 wh /= tf.constant([[self.imgsz[1], self.imgsz[0]]], dtype=tf.float32)

--- a/models/tf.py
+++ b/models/tf.py
@@ -236,7 +236,7 @@ class TFDetect(keras.layers.Layer):
                 y = tf.concat([xy, wh, y[..., 4:]], -1)
                 z.append(tf.reshape(y, [-1, self.na * ny * nx, self.no]))
 
-        return x if self.training else (tf.concat(z, 1), x)
+        return tf.transpose(x, [0, 2, 1, 3]) if self.training else (tf.concat(z, 1), x)
 
     @staticmethod
     def _make_grid(nx=20, ny=20):

--- a/models/tf.py
+++ b/models/tf.py
@@ -222,12 +222,14 @@ class TFDetect(keras.layers.Layer):
             x.append(self.m[i](inputs[i]))
             # x(bs,20,20,255) to x(bs,3,20,20,85)
             ny, nx = self.imgsz[0] // self.stride[i], self.imgsz[1] // self.stride[i]
-            x[i] = tf.transpose(tf.reshape(x[i], [-1, ny * nx, self.na, self.no]), [0, 2, 1, 3])
+            x[i] = tf.reshape(x[i], [-1, ny * nx, self.na, self.no])
 
             if not self.training:  # inference
                 y = tf.sigmoid(x[i])
-                xy = (y[..., 0:2] * 2 - 0.5 + self.grid[i]) * self.stride[i]  # xy
-                wh = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]
+                grid = tf.transpose(self.grid[i], [0, 2, 1, 3])
+                anchor_grid = tf.transpose(self.anchor_grid[i], [0, 2, 1, 3])
+                xy = (y[..., 0:2] * 2 - 0.5 + grid) * self.stride[i]  # xy
+                wh = (y[..., 2:4] * 2) ** 2 * anchor_grid
                 # Normalize xywh to 0-1 to reduce calibration error
                 xy /= tf.constant([[self.imgsz[1], self.imgsz[0]]], dtype=tf.float32)
                 wh /= tf.constant([[self.imgsz[1], self.imgsz[0]]], dtype=tf.float32)


### PR DESCRIPTION
The EdgeTPU compiler seems to have issues with the transpose operation. This pull request removes this op by applying it to the constant weights of the subsequent add and mul ops. As a result, more operations can be mapped onto the EdgeTPU. Reducing the imgsz parameter for the export script to 160 will lead to a model which is mapped entirely. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements in TensorFlow Lite quantization and output transformations for YOLOv5.

### 📊 Key Changes
- Enabled the new TensorFlow Lite (TFLite) quantizer by setting `experimental_new_quantizer` to `True`.
- Modified the YOLOv5 TensorFlow model output processing, including a new grid and anchor grid calculations, and changed the order of tensor dimensions during training.

### 🎯 Purpose & Impact
- The enabling of the new quantizer could lead to better performance and possibly higher accuracy in TFLite models due to improved quantization methods.
- Changes to output processing and tensor manipulation aim to optimize the model's inference process, potentially increasing efficiency and reducing errors in predictions for users.
- Both updates likely improve the usability and accuracy of YOLOv5 in TensorFlow environments, benefiting developers deploying machine learning models on edge devices or in resource-constrained environments. 🚀💡