### PR TITLE
Fix mAP bug at a higher conf

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -57,17 +57,17 @@ def ap_per_class(tp, conf, pred_cls, target_cls, plot=False, save_dir='.', names
 
             # Recall
             recall = tpc / (n_l + eps)  # recall curve
-            r[ci] = np.interp(-px, -conf[i], recall[:, 0], left=0)  # negative x, xp because xp decreases
+            r[ci] = np.interp(-px, -conf[i], recall[:, 0], left=0, right=0)  # negative x, xp because xp decreases
 
             # Precision
             precision = tpc / (tpc + fpc)  # precision curve
-            p[ci] = np.interp(-px, -conf[i], precision[:, 0], left=1)  # p at pr_score
+            p[ci] = np.interp(-px, -conf[i], precision[:, 0], left=1, right=0)  # p at pr_score
 
             # AP from recall-precision curve
             for j in range(tp.shape[1]):
                 ap[ci, j], mpre, mrec = compute_ap(recall[:, j], precision[:, j])
                 if plot and j == 0:
-                    py.append(np.interp(px, mrec, mpre))  # precision at mAP@0.5
+                    py.append(np.interp(px, mrec, mpre, right=0))  # precision at mAP@0.5
 
     # Compute F1 (harmonic mean of precision and recall)
     f1 = 2 * p * r / (p + r + eps)
@@ -101,12 +101,14 @@ def compute_ap(recall, precision):
 
     # Compute the precision envelope
     mpre = np.flip(np.maximum.accumulate(np.flip(mpre)))
+    mrec = mrec[:-1]
+    mpre = mpre[:-1]
 
     # Integrate area under curve
     method = 'interp'  # methods: 'continuous', 'interp'
     if method == 'interp':
         x = np.linspace(0, 1, 101)  # 101-point interp (COCO)
-        ap = np.trapz(np.interp(x, mrec, mpre), x)  # integrate
+        ap = np.trapz(np.interp(x, mrec, mpre, right=0), x)  # integrate
     else:  # 'continuous'
         i = np.where(mrec[1:] != mrec[:-1])[0]  # points where x axis (recall) changes
         ap = np.sum((mrec[i + 1] - mrec[i]) * mpre[i + 1])  # area under curve


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->
In #1466, when the conf is high, the difference between yolov5's mAP and coco mAP is very large. This is because the integrate from the last recall value to 1 is added to mAP calculation. And the recall, precission and recall-precision plot are also modified accordingly. I have tested the mAP on yolov5s and yolov5l model. The results are below:
yolov5s:
| conf | 0.001 | 0.7 |
| ----- | ---- | ---- |      
| yolov5 mAP(before) |   0.361       |   0.469    | 
| yolov5 mAP(after)|    0.358      |    0.204   |
| coco mAP |       0.375      |   0.207   |

yolov5l:
| conf | 0.001 | 0.7 |
| ----- | ---- | ---- |      
| yolov5 mAP(before) |    0.479      |    0.555   |
| yolov5 mAP(after) |     0.475     |   0.332   |
| coco mAP |       0.490      |   0.335   |

At the conf of 0.001, the differences between yolov5 mAP(after) and coco mAP are 0.017 and 0.015, compared to 0.014 and 0.011. It becomes a little large.
At the conf of 0.7, yolov5 mAP(after) is almost same to coco mAP.

The following are the recall, precission and recall-precision plot of yolov5l at the conf of 0.001:
![R_curve](https://user-images.githubusercontent.com/30900020/156143116-99a28e7d-56b7-4e10-b132-f41c93674c87.png)
![P_curve](https://user-images.githubusercontent.com/30900020/156143271-d3c26701-6a07-4190-a177-fa25f723d0c0.png)
![PR_curve](https://user-images.githubusercontent.com/30900020/156143346-239f86d2-8ec4-40c0-93ca-c52fe6732a07.png)

The following are the recall, precission and recall-precision plot of yolov5l at the conf of 0.7:
![R_curve](https://user-images.githubusercontent.com/30900020/156143534-83157573-6674-445c-8dfa-67a70212dbcf.png)
![P_curve](https://user-images.githubusercontent.com/30900020/156143596-19d28afa-4104-40d1-be39-0304d6ec90dd.png)
![PR_curve](https://user-images.githubusercontent.com/30900020/156143640-b47805c5-8b63-4ab7-9cda-2dee081b9ff3.png)



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in precision-recall curve handling for object detection metrics.

### 📊 Key Changes
- Modified the numpy `interp` function calls to include a `right=0` argument when interpolating recall and precision in `ap_per_class`.
- Ensured that the interpolated precision at mAP@0.5 also considers `right=0`.
- Adjusted the area under the curve computation in `compute_ap` by excluding the last point before integrating, ensuring that precision does not improperly influence the AP calculation.

### 🎯 Purpose & Impact
- These changes are intended to correct the interpolation behavior when calculating average precision (AP), resulting in more accurate performance metrics.
- By excluding the tail of the precision-recall curve, the metrics better reflect the typical scenario where precision drops to zero when recall reaches one.
- Users can benefit from a more precise measure of their object detection models' performance, leading to better model evaluation and tuning. 📈