### PR TITLE
Update sweep.yaml

### DIFF
--- a/utils/loggers/wandb/sweep.yaml
+++ b/utils/loggers/wandb/sweep.yaml
@@ -87,8 +87,8 @@ parameters:
     max: 8.0
   fl_gamma:
     distribution: uniform
-    min: 0.0
-    max: 0.1
+    min: 1.0
+    max: 4.0
   hsv_h:
     distribution: uniform
     min: 0.0

--- a/utils/loggers/wandb/sweep.yaml
+++ b/utils/loggers/wandb/sweep.yaml
@@ -87,7 +87,7 @@ parameters:
     max: 8.0
   fl_gamma:
     distribution: uniform
-    min: 1.0
+    min: 0.0
     max: 4.0
   hsv_h:
     distribution: uniform


### PR DESCRIPTION
Changed focal loss gamma search range between 1 and 4. Values between 0 and 0.1 yield no results.

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjustment to hyperparameter sweep range in YOLOv5's Weights & Biases configuration.

### 📊 Key Changes
- Increased the maximum value of the `fl_gamma` hyperparameter from `0.1` to `4.0` in the Weights & Biases sweep configuration.

### 🎯 Purpose & Impact
- 🎛️ This change allows for a broader exploration of the `fl_gamma` parameter when running hyperparameter sweeps, potentially leading to better model performance.
- 🧠 It could help in discovering new optimal settings during automated hyperparameter tuning, which may improve object detection results for users.
- 🚀 Users leveraging Weights & Biases for hyperparameter tuning will experience more versatile sweep configurations, enhancing the opportunity for model optimization.