### PR TITLE
Fix TRT `max_workspace_size` deprecation notice

### DIFF
--- a/export.py
+++ b/export.py
@@ -217,7 +217,7 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
 
         builder = trt.Builder(logger)
         config = builder.create_builder_config()
-        config.set_memory_pool_limit = workspace << 30  # max_workspace_size deprecated replacement
+        config.set_memory_pool_limit(workspace << 30)  # max_workspace_size deprecated replacement
 
         flag = (1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
         network = builder.create_network(flag)

--- a/export.py
+++ b/export.py
@@ -217,7 +217,8 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
 
         builder = trt.Builder(logger)
         config = builder.create_builder_config()
-        config.set_memory_pool_limit(workspace << 30)  # max_workspace_size deprecated replacement
+        config.max_workspace_size = workspace * 1 << 30
+        # config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace << 30)  # fix TRT 8.4 deprecation notice
 
         flag = (1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
         network = builder.create_network(flag)

--- a/export.py
+++ b/export.py
@@ -217,7 +217,7 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
 
         builder = trt.Builder(logger)
         config = builder.create_builder_config()
-        config.max_workspace_size = workspace * 1 << 30
+        config.set_memory_pool_limit = workspace << 30  # max_workspace_size deprecated replacement
 
         flag = (1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
         network = builder.create_network(flag)


### PR DESCRIPTION

<img width="1020" alt="Screenshot 2022-03-04 at 12 29 57" src="https://user-images.githubusercontent.com/26833433/156756032-6e68420c-61b2-400e-8777-1698a89b3239.png">



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of the TensorRT export functionality in the YOLOv5 codebase.

### 📊 Key Changes
- Commented out a line in `export.py` that fixes a deprecation notice for TensorRT 8.4.

### 🎯 Purpose & Impact 
- 🛠️ Maintains compatibility with TensorRT 8.4 by addressing deprecation warnings.
- 🚀 Helps ensure smooth upgrading for developers using TensorRT for better performance optimization in their YOLOv5 deployments.
- Users might not notice immediate changes, but this update helps to future-proof the deployment process of YOLOv5 models.