### PR TITLE
Add `*.ts` to `VID_FORMATS`

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -33,8 +33,8 @@ from utils.torch_utils import torch_distributed_zero_first
 
 # Parameters
 HELP_URL = 'https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
-IMG_FORMATS = ['bmp', 'dng', 'jpeg', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp']  # include image suffixes
-VID_FORMATS = ['asf', 'avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'wmv']  # include video suffixes
+IMG_FORMATS = 'bmp', 'dng', 'jpeg', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp'  # include image suffixes
+VID_FORMATS = 'asf', 'avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'ts', 'wmv'  # include video suffixes
 
 # Get orientation exif tag
 for orientation in ExifTags.TAGS.keys():


### PR DESCRIPTION
Resolves #6855 by @apiszcz adding transport stream format


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced media support for YOLOv5 training and inference.

### 📊 Key Changes
- Simplified the format definitions for image and video files by removing brackets.
- Added support for the 'ts' video file format.

### 🎯 Purpose & Impact
- The change in format definitions aims to tidy up the codebase.
- Including the 'ts' format extends the range of video inputs that YOLOv5 can handle, allowing users to feed in Transport Stream video files commonly used for storing video on DVDs. This enhances the versatility and usability of the model for a broader range of video data.