### PR TITLE
Update CI to python 3.10

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.9 ]
+        python-version: [ 3.10 ]
         model: [ 'yolov5n' ]  # models to test
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.10 ]
+        python-version: [ 3.10.2 ]
         model: [ 'yolov5n' ]  # models to test
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgraded Python version in CI testing workflow.

### 📊 Key Changes
- Altered the Python version used in Continuous Integration (CI) tests from 3.9 to 3.10.2

### 🎯 Purpose & Impact
- **Purpose:** Ensure compatibility and performance with the latest Python 3.10.2.
- **Impact:** Developers and users can expect more up-to-date testing, potentially catching issues that are specific to newer Python versions. This change guarantees that YOLOv5 remains robust on newer Python environments.