### PR TITLE
Add minimum detections required to save the image

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -74,7 +74,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
         hide_conf=False,  # hide confidences
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
-        min_detections=0 # minimum number of detections required per image to save
+        min_detections=0  # minimum number of detections required per image to save
         ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added feature to conditionally save images/videos based on the minimum number of detections.

### 📊 Key Changes
- 🔑 Introduced a new parameter `min_detections` that allows users to set a threshold for the minimum number of detections required to save an image or video.
- 💾 Modified the `cv2.imwrite` and `vid_writer.write` functions to check for the `min_detections` condition before saving images or videos.

### 🎯 Purpose & Impact
- 🎛️ This change gives users greater control over the output of their object detection tasks by allowing them to specify a minimum number of detections for saving results, which can save storage space and reduce clutter.
- 🚀 Potential impact includes streamlined workflows for users who only want results where a certain number of objects have been detected, thus enhancing the usability and efficiency of the YOLOv5 detection pipeline.