### PR TITLE
PyTorch 1.11.0 compatibility updates

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -94,21 +94,22 @@ def attempt_load(weights, map_location=None, inplace=True, fuse=True):
     model = Ensemble()
     for w in weights if isinstance(weights, list) else [weights]:
         ckpt = torch.load(attempt_download(w), map_location=map_location)  # load
-        if fuse:
-            model.append(ckpt['ema' if ckpt.get('ema') else 'model'].float().fuse().eval())  # FP32 model
-        else:
-            model.append(ckpt['ema' if ckpt.get('ema') else 'model'].float().eval())  # without layer fuse
+        ckpt = (ckpt['ema'] or ckpt['model']).float()  # FP32 model
+        model.append(ckpt.fuse().eval() if fuse else ckpt.eval())  # fused or un-fused model in eval mode
 
     # Compatibility updates
     for m in model.modules():
-        if type(m) in [nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6, nn.SiLU, Detect, Model]:
-            m.inplace = inplace  # pytorch 1.7.0 compatibility
-            if type(m) is Detect:
+        t = type(m)
+        if t in (nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6, nn.SiLU, Detect, Model):
+            m.inplace = inplace  # torch 1.7.0 compatibility
+            if t is Detect:
                 if not isinstance(m.anchor_grid, list):  # new Detect Layer compatibility
                     delattr(m, 'anchor_grid')
                     setattr(m, 'anchor_grid', [torch.zeros(1)] * m.nl)
-        elif type(m) is Conv:
-            m._non_persistent_buffers_set = set()  # pytorch 1.6.0 compatibility
+        elif t is nn.Upsample:
+            m.recompute_scale_factor = None  # torch 1.11.0 compatibility
+        elif t is Conv:
+            m._non_persistent_buffers_set = set()  # torch 1.6.0 compatibility
 
     if len(model) == 1:
         return model[-1]  # return model


### PR DESCRIPTION
Resolves `AttributeError: 'Upsample' object has no attribute 'recompute_scale_factor'` first raised in https://github.com/ultralytics/yolov5/issues/5499 and observed in all CI runs on just-released PyTorch 1.11.0.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancing model loading and compatibility in YOLOv5.

### 📊 Key Changes
- Streamlined the model loading process by consolidating steps for checking and loading the exponential moving average (EMA) weights or standard model weights.
- Updated the method of applying layer fusion based on a single `fuse` condition.
- Implemented compatibility adjustments for different PyTorch versions and layers including Hardswish, LeakyReLU, ReLU, ReLU6, SiLU, Detect, Model, Upsample, and Conv.

### 🎯 Purpose & Impact
- The refactoring simplifies and clarifies the logic for loading various weight formats, making the process more maintainable and easier to understand. 🧠
- Compatibility fixes ensure that YOLOv5's model is runnable across different versions of PyTorch, preventing errors related to API changes. 🔧
- Users can expect more robust model loading behavior, with resilient support across multiple PyTorch versions which is vital for diverse development environments. 🤖