### PR TITLE
Optimize PyTorch 1.11.0 compatibility update

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -106,10 +106,10 @@ def attempt_load(weights, map_location=None, inplace=True, fuse=True):
                 if not isinstance(m.anchor_grid, list):  # new Detect Layer compatibility
                     delattr(m, 'anchor_grid')
                     setattr(m, 'anchor_grid', [torch.zeros(1)] * m.nl)
-        elif t is nn.Upsample:
-            m.recompute_scale_factor = None  # torch 1.11.0 compatibility
         elif t is Conv:
             m._non_persistent_buffers_set = set()  # torch 1.6.0 compatibility
+        elif t is nn.Upsample and not hasattr(m, 'recompute_scale_factor'):
+            m.recompute_scale_factor = None  # torch 1.11.0 compatibility
 
     if len(model) == 1:
         return model[-1]  # return model


### PR DESCRIPTION
Speed and future-proof robustness improvements.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model compatibility with PyTorch versions.

### 📊 Key Changes
- Removed always setting `recompute_scale_factor` to `None` in `nn.Upsample`.
- Now, `recompute_scale_factor` is set to `None` only if not already present, ensuring better backward compatibility.

### 🎯 Purpose & Impact
- Ensures that the YOLOv5 model is compatible with multiple versions of the PyTorch library, by addressing changes in the `Upsample` layer behavior from PyTorch 1.11.0.
- Provides smoother user experience by preventing potential issues when switching between different PyTorch versions, especially in setups where manually setting the scale factor is not needed. 🚀