### PR TITLE
Allow 3-point segments

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -906,7 +906,7 @@ def verify_image_label(args):
             nf = 1  # label found
             with open(lb_file) as f:
                 lb = [x.split() for x in f.read().strip().splitlines() if len(x)]
-                if any([len(x) > 8 for x in lb]):  # is segment
+                if any(len(x) > 6 for x in lb):  # is segment
                     classes = np.array([x[0] for x in lb], dtype=np.float32)
                     segments = [np.array(x[1:], dtype=np.float32).reshape(-1, 2) for x in lb]  # (cls, xy1...)
                     lb = np.concatenate((classes.reshape(-1, 1), segments2boxes(segments)), 1)  # (cls, xywh)


### PR DESCRIPTION
May resolve https://github.com/ultralytics/yolov5/issues/6931



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to label verification in YOLOv5 dataset loading.

### 📊 Key Changes
- Reduced the condition check for a segment from `len(x) > 8` to `len(x) > 6`.

### 🎯 Purpose & Impact
- 🎯 **Purpose:** The change ensures that the code correctly identifies segmentation data in the dataset. Segmentation data points with a length greater than 6 are acknowledged, rather than the previous length of greater than 8.
- 🔍 **Impact:** This impacts how the model processes different types of labeled data, possibly leading to more accurate training and validation results when segmentation data is present. Users can expect a more robust recognition of various data label formats.