### PR TITLE
YOLOv5 Export Benchmarks for GPU

### DIFF
--- a/export.py
+++ b/export.py
@@ -80,7 +80,7 @@ def export_formats():
          ['ONNX', 'onnx', '.onnx', True],
          ['OpenVINO', 'openvino', '_openvino_model', False],
          ['TensorRT', 'engine', '.engine', True],
-         ['CoreML', 'coreml', '.mlmodel', True],
+         ['CoreML', 'coreml', '.mlmodel', False],
          ['TensorFlow SavedModel', 'saved_model', '_saved_model', True],
          ['TensorFlow GraphDef', 'pb', '.pb', True],
          ['TensorFlow Lite', 'tflite', '.tflite', False],

--- a/export.py
+++ b/export.py
@@ -75,18 +75,18 @@ from utils.torch_utils import select_device
 
 def export_formats():
     # YOLOv5 export formats
-    x = [['PyTorch', '-', '.pt'],
-         ['TorchScript', 'torchscript', '.torchscript'],
-         ['ONNX', 'onnx', '.onnx'],
-         ['OpenVINO', 'openvino', '_openvino_model'],
-         ['TensorRT', 'engine', '.engine'],
-         ['CoreML', 'coreml', '.mlmodel'],
-         ['TensorFlow SavedModel', 'saved_model', '_saved_model'],
-         ['TensorFlow GraphDef', 'pb', '.pb'],
-         ['TensorFlow Lite', 'tflite', '.tflite'],
-         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite'],
-         ['TensorFlow.js', 'tfjs', '_web_model']]
-    return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix'])
+    x = [['PyTorch', '-', '.pt', True],
+         ['TorchScript', 'torchscript', '.torchscript', True],
+         ['ONNX', 'onnx', '.onnx', True],
+         ['OpenVINO', 'openvino', '_openvino_model', False],
+         ['TensorRT', 'engine', '.engine', True],
+         ['CoreML', 'coreml', '.mlmodel', True],
+         ['TensorFlow SavedModel', 'saved_model', '_saved_model', True],
+         ['TensorFlow GraphDef', 'pb', '.pb', True],
+         ['TensorFlow Lite', 'tflite', '.tflite', False],
+         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False],
+         ['TensorFlow.js', 'tfjs', '_web_model', False]]
+    return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'GPU'])
 
 
 def export_torchscript(model, im, file, optimize, prefix=colorstr('TorchScript:')):

--- a/models/common.py
+++ b/models/common.py
@@ -465,7 +465,7 @@ class DetectMultiBackend(nn.Module):
     def warmup(self, imgsz=(1, 3, 640, 640)):
         # Warmup model by running inference once
         if self.pt or self.jit or self.onnx or self.engine:  # warmup types
-            if isinstance(self.device, torch.device) and self.device.type != 'cpu':  # only warmup GPU models
+            if self.device.type != 'cpu':  # only warmup GPU models
                 im = torch.zeros(*imgsz, dtype=torch.half if self.fp16 else torch.float, device=self.device)  # input
                 self.forward(im)  # warmup
 

--- a/models/common.py
+++ b/models/common.py
@@ -467,7 +467,8 @@ class DetectMultiBackend(nn.Module):
         if self.pt or self.jit or self.onnx or self.engine:  # warmup types
             if self.device.type != 'cpu':  # only warmup GPU models
                 im = torch.zeros(*imgsz, dtype=torch.half if self.fp16 else torch.float, device=self.device)  # input
-                self.forward(im)  # warmup
+                for _ in range(2 if self.jit else 1):  #
+                    self.forward(im)  # warmup
 
     @staticmethod
     def model_type(p='path/to/model.pt'):

--- a/models/common.py
+++ b/models/common.py
@@ -464,7 +464,7 @@ class DetectMultiBackend(nn.Module):
 
     def warmup(self, imgsz=(1, 3, 640, 640)):
         # Warmup model by running inference once
-        if self.pt or self.jit or self.onnx or self.engine:  # warmup types
+        if any((self.pt, self.jit, self.onnx, self.engine, self.saved_model, self.pb)):  # warmup types
             if self.device.type != 'cpu':  # only warmup GPU models
                 im = torch.zeros(*imgsz, dtype=torch.half if self.fp16 else torch.float, device=self.device)  # input
                 for _ in range(2 if self.jit else 1):  #

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -55,8 +55,10 @@ def run(weights=ROOT / 'yolov5s.pt',  # weights path
     y, t = [], time.time()
     formats = export.export_formats()
     device = select_device(device)
-    for i, (name, f, suffix) in formats.iterrows():  # index, (name, file, suffix)
+    for i, (name, f, suffix, gpu) in formats.iterrows():  # index, (name, file, suffix, gpu-capable)
         try:
+            if device.type != 'cpu':
+                assert gpu, f'{name} inference not supported on GPU'
             if f == '-':
                 w = weights  # PyTorch format
             else:

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -57,7 +57,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # weights path
         try:
             w = weights if f == '-' else export.run(weights=weights, imgsz=[imgsz], include=[f], device=device)[-1]
             assert suffix in str(w), 'export failed'
-            result = val.run(data, w, batch_size, imgsz=imgsz, plots=False, device=device, task='benchmark')
+            result = val.run(data, w, batch_size, imgsz=imgsz, plots=False, device=device, task='benchmark', half=False)
             metrics = result[0]  # metrics (mp, mr, map50, map, *losses(box, obj, cls))
             speeds = result[2]  # times (preprocess, inference, postprocess)
             y.append([name, metrics[3], speeds[1]])  # mAP, t_inference

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -19,6 +19,7 @@ TensorFlow.js               | `tfjs`                        | yolov5s_web_model/
 Requirements:
     $ pip install -r requirements.txt coremltools onnx onnx-simplifier onnxruntime openvino-dev tensorflow-cpu  # CPU
     $ pip install -r requirements.txt coremltools onnx onnx-simplifier onnxruntime-gpu openvino-dev tensorflow  # GPU
+    $ pip install -U nvidia-tensorrt --index-url https://pypi.ngc.nvidia.com  # TensorRT
 
 Usage:
     $ python utils/benchmarks.py --weights yolov5s.pt --img 640

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -57,10 +57,10 @@ def run(weights=ROOT / 'yolov5s.pt',  # weights path
     device = select_device(device)
     for i, (name, f, suffix) in formats.iterrows():  # index, (name, file, suffix)
         try:
-            if f == '-':  # PyTorch
-                w = weights
+            if f == '-':
+                w = weights  # PyTorch format
             else:
-                w = export.run(weights=weights, imgsz=[imgsz], include=[f], device=device, half=half)[-1]
+                w = export.run(weights=weights, imgsz=[imgsz], include=[f], device=device, half=half)[-1]  # all others
             assert suffix in str(w), 'export failed'
             result = val.run(data, w, batch_size, imgsz, plots=False, device=device, task='benchmark', half=half)
             metrics = result[0]  # metrics (mp, mr, map50, map, *losses(box, obj, cls))

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -55,9 +55,9 @@ def run(weights=ROOT / 'yolov5s.pt',  # weights path
     device = select_device(device)
     for i, (name, f, suffix) in formats.iterrows():  # index, (name, file, suffix)
         try:
-            w = weights if f == '-' else export.run(weights=weights, imgsz=[imgsz], include=[f], device='cpu')[-1]
+            w = weights if f == '-' else export.run(weights=weights, imgsz=[imgsz], include=[f], device=device)[-1]
             assert suffix in str(w), 'export failed'
-            result = val.run(data, w, batch_size, imgsz=imgsz, plots=False, device='cpu', task='benchmark')
+            result = val.run(data, w, batch_size, imgsz=imgsz, plots=False, device=device, task='benchmark')
             metrics = result[0]  # metrics (mp, mr, map50, map, *losses(box, obj, cls))
             speeds = result[2]  # times (preprocess, inference, postprocess)
             y.append([name, metrics[3], speeds[1]])  # mAP, t_inference

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -41,15 +41,18 @@ import export
 import val
 from utils import notebook_init
 from utils.general import LOGGER, print_args
+from utils.torch_utils import select_device
 
 
 def run(weights=ROOT / 'yolov5s.pt',  # weights path
         imgsz=640,  # inference size (pixels)
         batch_size=1,  # batch size
         data=ROOT / 'data/coco128.yaml',  # dataset.yaml path
+        device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
         ):
     y, t = [], time.time()
     formats = export.export_formats()
+    device = select_device(device)
     for i, (name, f, suffix) in formats.iterrows():  # index, (name, file, suffix)
         try:
             w = weights if f == '-' else export.run(weights=weights, imgsz=[imgsz], include=[f], device='cpu')[-1]
@@ -78,6 +81,7 @@ def parse_opt():
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=640, help='inference size (pixels)')
     parser.add_argument('--batch-size', type=int, default=1, help='batch size')
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
+    parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     opt = parser.parse_args()
     print_args(FILE.stem, opt)
     return opt


### PR DESCRIPTION
Run YOLOv5 benchmarks (speed and accuracy) for all supported export formats. This PR adds GPU benchmarking capability following CPU benchmarking PR https://github.com/ultralytics/yolov5/pull/6613.

Format                      | `export.py --include`         | Model
:---                        | --:                           | :--
[PyTorch](https://pytorch.org/)                     | -                             | `yolov5s.pt`
[TorchScript](https://pytorch.org/docs/stable/jit.html)                 | `torchscript`                 | `yolov5s.torchscript`
[ONNX](https://onnx.ai/)                        | `onnx`                        | `yolov5s.onnx`
[OpenVINO](https://docs.openvino.ai/latest/index.html)                    | `openvino`                    | `yolov5s_openvino_model/`
[TensorRT](https://developer.nvidia.com/tensorrt)                    | `engine`                      | `yolov5s.engine`
[CoreML](https://github.com/apple/coremltools)                      | `coreml`                      | `yolov5s.mlmodel`
[TensorFlow SavedModel](https://www.tensorflow.org/guide/saved_model)       | `saved_model`                 | `yolov5s_saved_model/`
[TensorFlow GraphDef](https://www.tensorflow.org/api_docs/python/tf/Graph)         | `pb`                          | `yolov5s.pb`
[TensorFlow Lite](https://www.tensorflow.org/lite)             | `tflite`                      | `yolov5s.tflite`
[TensorFlow Edge TPU](https://coral.ai/docs/edgetpu/models-intro/)         | `edgetpu`                     | `yolov5s_edgetpu.tflite`
[TensorFlow.js](https://www.tensorflow.org/js)               | `tfjs`                        | `yolov5s_web_model/`

Usage: 
```python
git clone https://github.com/ultralytics/yolov5 -b update/bench_gpu  # clone
cd yolov5
pip install -qr requirements.txt coremltools onnx onnxruntime-gpu openvino-dev  # install
pip install -U nvidia-tensorrt --index-url https://pypi.ngc.nvidia.com  # TensorRT

python utils/benchmarks.py --weights yolov5s.pt --img 640 --device 0
```

### Colab Pro+ V100 High-RAM Results

```
benchmarks: weights=/content/yolov5/yolov5s.pt, imgsz=640, batch_size=1, data=/content/yolov5/data/coco128.yaml, device=0, half=False, test=False
Checking setup...
YOLOv5 🚀 v6.1-135-g7926afc torch 1.10.0+cu111 CUDA:0 (Tesla V100-SXM2-16GB, 16160MiB)
Setup complete ✅ (8 CPUs, 51.0 GB RAM, 46.7/166.8 GB disk)

Benchmarks complete (458.07s)
                   Format  mAP@0.5:0.95  Inference time (ms)
0                 PyTorch        0.4623                10.19
1             TorchScript        0.4623                 6.85
2                    ONNX        0.4623                14.63
3                OpenVINO           NaN                  NaN
4                TensorRT        0.4617                 1.89
5                  CoreML           NaN                  NaN
6   TensorFlow SavedModel        0.4623                21.28
7     TensorFlow GraphDef        0.4623                21.22
8         TensorFlow Lite           NaN                  NaN
9     TensorFlow Edge TPU           NaN                  NaN
10          TensorFlow.js           NaN                  NaN
```

### Colab Free T4 Results

```
benchmarks: weights=/content/yolov5/yolov5s.pt, imgsz=640, batch_size=1, data=/content/yolov5/data/coco128.yaml, device=, half=False, test=False
Checking setup...
YOLOv5 🚀 v6.1-135-g7926afc torch 1.10.0+cu111 CUDA:0 (Tesla T4, 15110MiB)
Setup complete ✅ (2 CPUs, 12.7 GB RAM, 45.2/78.2 GB disk)

Benchmarks complete (501.61s)
                   Format  mAP@0.5:0.95  Inference time (ms)
0                 PyTorch        0.4623                11.51
1             TorchScript        0.4623                 8.70
2                    ONNX        0.4623                17.08
3                OpenVINO           NaN                  NaN
4                TensorRT        0.4628                 3.36
5                  CoreML           NaN                  NaN
6   TensorFlow SavedModel        0.4623                25.13
7     TensorFlow GraphDef        0.4623                25.20
8         TensorFlow Lite           NaN                  NaN
9     TensorFlow Edge TPU           NaN                  NaN
10          TensorFlow.js           NaN                  NaN
```

### Ultralytics Hyperplane A100

```
benchmarks: weights=yolov5s.pt, imgsz=640, batch_size=1, data=/usr/src/app/data/coco128.yaml, device=, half=False, test=False, pt_only=False
Checking setup...
YOLOv5 🚀 v6.1-174-gc4cb7c6 torch 1.11.0+cu113 CUDA:0 (A100-SXM-80GB, 81251MiB)
Setup complete ✅ (96 CPUs, 1007.7 GB RAM, 1947.5/3519.3 GB disk)

Benchmarks complete (599.41s)
                   Format  mAP@0.5:0.95  Inference time (ms)
0                 PyTorch        0.4624                 6.83
1             TorchScript        0.4624                 4.63
2                    ONNX        0.4623                43.68
3                OpenVINO           NaN                  NaN
4                TensorRT        0.4629                 1.13
5                  CoreML           NaN                  NaN
6   TensorFlow SavedModel        0.4624                25.24
7     TensorFlow GraphDef        0.4624                23.77
8         TensorFlow Lite           NaN                  NaN
9     TensorFlow Edge TPU           NaN                  NaN
10          TensorFlow.js           NaN                  NaN
```

Note: TensorRT exports are fixed at FP16.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated model export formats, warmup process tweaks, and benchmarking improvements in the YOLOv5 repository.

### 📊 Key Changes
- Enhanced the export formats DataFrame in `export.py` to include a new column indicating which export formats support GPU acceleration.
- Modified the model warmup method to support a broader range of models, including TensorFlow SavedModel and GraphDef.
- Adjusted the benchmarking script in `utils/benchmarks.py` to utilize device selection and FP16 inference if available and supported.

### 🎯 Purpose & Impact
- **GPU Acceleration Visibility**: Users can now easily identify which export formats can take advantage of GPU acceleration, leading to more informed decisions on export formats based on their deployment needs.
- **Enhanced Warmup**: Updated model warmup process that now accounts for more model types, potentially leading to more efficient and reliable model performance post-export.
- **Benchmarking Customization and Accuracy**: With added device and precision flags, users can run benchmarks that more closely represent their production environments, yielding more accurate performance measurements. 

These changes aim to improve the user experience in model exporting and benchmarking, ensuring users can optimize their models based on the specific capabilities of their hardware.