### PR TITLE
Model `ema` key backward compatibility fix

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -94,7 +94,7 @@ def attempt_load(weights, map_location=None, inplace=True, fuse=True):
     model = Ensemble()
     for w in weights if isinstance(weights, list) else [weights]:
         ckpt = torch.load(attempt_download(w), map_location=map_location)  # load
-        ckpt = (ckpt['ema'] or ckpt['model']).float()  # FP32 model
+        ckpt = (ckpt.get('ema') or ckpt['model']).float()  # FP32 model
         model.append(ckpt.fuse().eval() if fuse else ckpt.eval())  # fused or un-fused model in eval mode
 
     # Compatibility updates


### PR DESCRIPTION
Fix for older model loading issue in https://github.com/ultralytics/yolov5/commit/d3d9cbce221b2ced46dde374f24fde72c8e71c37#commitcomment-68622388


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in loading model weights in `ultralytics/yolov5`.

### 📊 Key Changes
- Modified weight loading mechanism to use `.get()` method for accessing 'ema' key in the checkpoint dictionary.

### 🎯 Purpose & Impact
- **Purpose:** The change ensures that loading the model does not break if the 'ema' (Exponential Moving Average) key is missing in the checkpoint dictionary.
- **Impact:** Enhanced robustness and reduces potential errors during weight loading, thereby improving user experience when working with different types of model checkpoints. It's especially beneficial for users who might have checkpoints without the 'ema' key. 🛠️✨