### PR TITLE
[ICIoU]: Improved CIoU loss

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -132,7 +132,7 @@ class ComputeLoss:
                 pxy = ps[:, :2].sigmoid() * 2 - 0.5
                 pwh = (ps[:, 2:4].sigmoid() * 2) ** 2 * anchors[i]
                 pbox = torch.cat((pxy, pwh), 1)  # predicted box
-                iou = bbox_iou(pbox.T, tbox[i], x1y1x2y2=False, CIoU=True)  # iou(prediction, target)
+                iou = bbox_iou(pbox.T, tbox[i], x1y1x2y2=False, ICIoU=True)  # iou(prediction, target)
                 lbox += (1.0 - iou).mean()  # iou loss
 
                 # Objectness

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -199,7 +199,8 @@ class ConfusionMatrix:
             print(' '.join(map(str, self.matrix[i])))
 
 
-def bbox_iou(box1, box2, x1y1x2y2=True, GIoU=False, DIoU=False, CIoU=False, eps=1e-7):
+def bbox_iou(box1, box2, x1y1x2y2=True, GIoU=False, DIoU=False,
+             CIoU=False, ICIoU=False, eps=1e-7):
     # Returns the IoU of box1 to box2. box1 is 4, box2 is nx4
     box2 = box2.T
 
@@ -218,23 +219,35 @@ def bbox_iou(box1, box2, x1y1x2y2=True, GIoU=False, DIoU=False, CIoU=False, eps=
             (torch.min(b1_y2, b2_y2) - torch.max(b1_y1, b2_y1)).clamp(0)
 
     # Union Area
-    w1, h1 = b1_x2 - b1_x1, b1_y2 - b1_y1 + eps
-    w2, h2 = b2_x2 - b2_x1, b2_y2 - b2_y1 + eps
+    if ICIoU:
+        w1, h1 = b1_x2 - b1_x1 + eps, b1_y2 - b1_y1 + eps
+        w2, h2 = b2_x2 - b2_x1, b2_y2 - b2_y1
+    else:
+        w1, h1 = b1_x2 - b1_x1, b1_y2 - b1_y1 + eps
+        w2, h2 = b2_x2 - b2_x1, b2_y2 - b2_y1 + eps
+
     union = w1 * h1 + w2 * h2 - inter + eps
 
     iou = inter / union
-    if CIoU or DIoU or GIoU:
+    if CIoU or DIoU or GIoU or ICIoU:
         cw = torch.max(b1_x2, b2_x2) - torch.min(b1_x1, b2_x1)  # convex (smallest enclosing box) width
         ch = torch.max(b1_y2, b2_y2) - torch.min(b1_y1, b2_y1)  # convex height
-        if CIoU or DIoU:  # Distance or Complete IoU https://arxiv.org/abs/1911.08287v1
+        if CIoU or DIoU or ICIoU:  # Distance or Complete IoU https://arxiv.org/abs/1911.08287v1
             c2 = cw ** 2 + ch ** 2 + eps  # convex diagonal squared
-            rho2 = ((b2_x1 + b2_x2 - b1_x1 - b1_x2) ** 2 +
-                    (b2_y1 + b2_y2 - b1_y1 - b1_y2) ** 2) / 4  # center distance squared
+            rho2 = ((b2_x1 + b2_x2 - b1_x1 - b1_x2) ** 2
+                    + (b2_y1 + b2_y2 - b1_y1 - b1_y2) ** 2) / 4  # center distance squared
             if CIoU:  # https://github.com/Zzh-tju/DIoU-SSD-pytorch/blob/master/utils/box/box_utils.py#L47
                 v = (4 / math.pi ** 2) * torch.pow(torch.atan(w2 / h2) - torch.atan(w1 / h1), 2)
                 with torch.no_grad():
                     alpha = v / (v - iou + (1 + eps))
                 return iou - (rho2 / c2 + v * alpha)  # CIoU
+            if ICIoU:
+                v = (8 / math.pi ** 2) * (torch.pow(torch.atan(w2 / w1) - math.pi / 4., 2) +
+                                          torch.pow(torch.atan(h2 / h1) - math.pi / 4., 2))
+                with torch.no_grad():
+                    alpha = v / (v - iou + (1 + eps))
+                return iou - (rho2 / c2 + v * alpha)  # ICIoU
+
             return iou - rho2 / c2  # DIoU
         c_area = cw * ch + eps  # convex area
         return iou - (c_area - union) / c_area  # GIoU https://arxiv.org/pdf/1902.09630.pdf

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -234,8 +234,8 @@ def bbox_iou(box1, box2, x1y1x2y2=True, GIoU=False, DIoU=False,
         ch = torch.max(b1_y2, b2_y2) - torch.min(b1_y1, b2_y1)  # convex height
         if CIoU or DIoU or ICIoU:  # Distance or Complete IoU https://arxiv.org/abs/1911.08287v1
             c2 = cw ** 2 + ch ** 2 + eps  # convex diagonal squared
-            rho2 = ((b2_x1 + b2_x2 - b1_x1 - b1_x2) ** 2
-                    + (b2_y1 + b2_y2 - b1_y1 - b1_y2) ** 2) / 4  # center distance squared
+            rho2 = ((b2_x1 + b2_x2 - b1_x1 - b1_x2) ** 2 +
+                    (b2_y1 + b2_y2 - b1_y1 - b1_y2) ** 2) / 4  # center distance squared
             if CIoU:  # https://github.com/Zzh-tju/DIoU-SSD-pytorch/blob/master/utils/box/box_utils.py#L47
                 v = (4 / math.pi ** 2) * torch.pow(torch.atan(w2 / h2) - torch.atan(w1 / h1), 2)
                 with torch.no_grad():


### PR DESCRIPTION
# Improved CIoU loss

This modification is based on the paper: `ICIoU: Improved Loss Based on Complete Intersection Over Union for Bounding Box Regression` [Link](https://www.researchgate.net/publication/353468751_ICIoU_Improved_Loss_Based_on_Complete_Intersection_Over_Union_for_Bounding_Box_Regression)

In CIoU loss, the loss function considers

1. IOU
2. Distance between the centers
3. Aspect ratio of the dimensions (w, h) of the boxes

Aspect ratio part of CIoU loss:
![ciou](https://user-images.githubusercontent.com/980580/158193437-931387d0-2989-4a6f-b5f0-141c8605f5de.png)

if `(Wgt/Hgt)=(W/H)`, CIoU loss degenerates to DIoU loss. In order to address this issue, this  part of the loss function is modified to 

![ICIOU](https://user-images.githubusercontent.com/980580/158193841-1aaf3235-dda9-4ac1-b123-1e2e836f25ac.png)

Since I do not have the resources to run the experiment, I couldn't run the experiments to see if there are any improvements. Let me know what's the best way to do it? 

Thank you!

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introduced ICIoU (Integrating Complete Intersection over Union) in YOLOv5's loss and metrics calculations.

### 📊 Key Changes
- 🧮 Modified the bbox_iou function to include an `ICIoU` boolean parameter.
- 🤖 Changed the loss calculation by using ICIoU instead of CIoU.
- ✅ Added conditional branches in the `bbox_iou` function for calculating box sizes and union area, specifically if ICIoU is enabled.
- 📐 Implemented the ICIoU formula by adding an additional if-statement within the existing IoU types' logic.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To improve the accuracy of bounding box predictions by using a more comprehensive IoU metric during training.
- 🚀 **Impact**: Users may see enhanced model precision and better performance, especially in scenarios where accurately fitting bounding boxes is critical.