### PR TITLE
`np.fromfile()` Chinese image paths fix

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -216,7 +216,7 @@ class LoadImages:
         else:
             # Read image
             self.count += 1
-            img0 = cv2.imread(path)  # BGR
+            img0 = cv2.imdecode(np.fromfile(path, np.uint8), cv2.IMREAD_COLOR)  # BGR
             assert img0 is not None, f'Image Not Found {path}'
             s = f'image {self.count}/{self.nf} {path}: '
 
@@ -627,7 +627,7 @@ class LoadImagesAndLabels(Dataset):
             if fn.exists():  # load npy
                 im = np.load(fn)
             else:  # read image
-                im = cv2.imread(f)  # BGR
+                im = cv2.imdecode(np.fromfile(f, np.uint8), cv2.IMREAD_COLOR)  # BGR
                 assert im is not None, f'Image Not Found {f}'
             h0, w0 = im.shape[:2]  # orig hw
             r = self.img_size / max(h0, w0)  # ratio
@@ -643,7 +643,7 @@ class LoadImagesAndLabels(Dataset):
         # Saves an image as an *.npy file for faster loading
         f = self.npy_files[i]
         if not f.exists():
-            np.save(f.as_posix(), cv2.imread(self.im_files[i]))
+            np.save(f.as_posix(), cv2.imdecode(np.fromfile(self.im_files[i], np.uint8), cv2.IMREAD_COLOR))
 
     def load_mosaic(self, index):
         # YOLOv5 4-mosaic loader. Loads 1 image + 3 random images into a 4-image mosaic
@@ -834,7 +834,7 @@ def extract_boxes(path=DATASETS_DIR / 'coco128'):  # from utils.datasets import 
     for im_file in tqdm(files, total=n):
         if im_file.suffix[1:] in IMG_FORMATS:
             # image
-            im = cv2.imread(str(im_file))[..., ::-1]  # BGR to RGB
+            im = cv2.imdecode(np.fromfile(str(im_file), np.uint8), cv2.IMREAD_COLOR)[..., ::-1]  # BGR to RGB
             h, w = im.shape[:2]
 
             # labels
@@ -971,7 +971,7 @@ def dataset_stats(path='coco128.yaml', autodownload=False, verbose=False, profil
             im.save(f_new, 'JPEG', quality=75, optimize=True)  # save
         except Exception as e:  # use OpenCV
             print(f'WARNING: HUB ops PIL failure {f}: {e}')
-            im = cv2.imread(f)
+            im = cv2.imdecode(np.fromfile(f, np.uint8), cv2.IMREAD_COLOR)
             im_height, im_width = im.shape[:2]
             r = max_dim / max(im_height, im_width)  # ratio
             if r < 1.0:  # image too large

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -148,6 +148,9 @@ class Loggers():
 
         if self.tb:
             import cv2
+            import numpy as np
+
+            cv2.imread = lambda x: cv2.imdecode(np.fromfile(x, np.uint8), cv2.IMREAD_COLOR)  # remap for Chinese files
             for f in files:
                 self.tb.add_image(f.stem, cv2.imread(str(f))[..., ::-1], epoch, dataformats='HWC')
 


### PR DESCRIPTION
use "cv2.imdecode(np.fromfile(f, np.uint8), cv2.IMREAD_COLOR)" instead of "cv2.imread(f)" for Chinese image path.

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced compatibility for non-ASCII filenames in YOLOv5.

### 📊 Key Changes
- Remapped `cv2.imread` function to handle Chinese characters in filenames using `cv2.imdecode` and `np.fromfile` across different modules.

### 🎯 Purpose & Impact
- **Purpose:** The purpose of this change is to ensure that images with filenames containing non-ASCII characters, particularly Chinese characters, can be properly loaded for processing without errors.
- **Impact:** Users working with datasets containing images with Chinese or other non-ASCII characters in their filenames will benefit from improved functionality, as YOLOv5 will now be able to handle these files seamlessly. This enhancement promotes broader usability of YOLOv5 across different languages and regions. 🌏🤖