### PR TITLE
Use PIL to eliminate chroma subsampling in crops

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -467,5 +467,7 @@ def save_one_box(xyxy, im, file='image.jpg', gain=1.02, pad=10, square=False, BG
     crop = im[int(xyxy[0, 1]):int(xyxy[0, 3]), int(xyxy[0, 0]):int(xyxy[0, 2]), ::(1 if BGR else -1)]
     if save:
         file.parent.mkdir(parents=True, exist_ok=True)  # make directory
-        cv2.imwrite(str(increment_path(file).with_suffix('.jpg')), crop)
+        # use pillow to save higher-quality jpg (w/o color subsampling)
+        crop_pil = Image.fromarray(cv2.cvtColor(crop, cv2.COLOR_BGR2RGB))
+        crop_pil.save(str(increment_path(file).with_suffix('.jpg')), quality=95, subsampling=0)
     return crop

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -458,7 +458,7 @@ def profile_idetection(start=0, stop=0, labels=(), save_dir=''):
     plt.savefig(Path(save_dir) / 'idetection_profile.png', dpi=200)
 
 
-def save_one_box(xyxy, im, file='image.jpg', gain=1.02, pad=10, square=False, BGR=False, save=True):
+def save_one_box(xyxy, im, file=Path('im.jpg'), gain=1.02, pad=10, square=False, BGR=False, save=True):
     # Save image crop as {file} with crop size multiple {gain} and {pad} pixels. Save and/or return crop
     xyxy = torch.tensor(xyxy).view(-1, 4)
     b = xyxy2xywh(xyxy)  # boxes
@@ -470,7 +470,7 @@ def save_one_box(xyxy, im, file='image.jpg', gain=1.02, pad=10, square=False, BG
     crop = im[int(xyxy[0, 1]):int(xyxy[0, 3]), int(xyxy[0, 0]):int(xyxy[0, 2]), ::(1 if BGR else -1)]
     if save:
         file.parent.mkdir(parents=True, exist_ok=True)  # make directory
-        # use pillow to save higher-quality jpg (w/o color subsampling)
-        crop_pil = Image.fromarray(cv2.cvtColor(crop, cv2.COLOR_BGR2RGB))
-        crop_pil.save(str(increment_path(file).with_suffix('.jpg')), quality=95, subsampling=0)
+        f = str(increment_path(file).with_suffix('.jpg'))
+        # cv2.imwrite(f, crop)  # https://github.com/ultralytics/yolov5/issues/7007 chroma subsampling issue
+        Image.fromarray(cv2.cvtColor(crop, cv2.COLOR_BGR2RGB)).save(f, quality=95, subsampling=0)
     return crop


### PR DESCRIPTION
solution to issue ["improve image quality of cropped jpg files by disabling chroma subsampling"](https://github.com/ultralytics/yolov5/issues/7007)

this is my first PR, please be kind if formalities are not met :)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image cropping and saving functionality in YOLOv5.

### 📊 Key Changes
- The `file` parameter in `save_one_box` now defaults to a `Path` object instead of a string.
- Replaced `cv2.imwrite` with `PIL.Image.save` to address a chroma subsampling issue when saving images.

### 🎯 Purpose & Impact
- The change to a `Path` object ensures better path handling across different operating systems.
- The new saving method improves image quality by preventing chroma subsampling issues, resulting in crisper saved images for users 👌.
- Users may notice an increase in the size of saved images due to higher quality settings, which could potentially impact storage requirements 📈.