### PR TITLE
fix: add default PIL font as fallback 

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -7,6 +7,7 @@ import math
 import os
 from copy import copy
 from pathlib import Path
+from urllib.error import URLError
 
 import cv2
 import matplotlib
@@ -55,11 +56,13 @@ def check_pil_font(font=FONT, size=10):
     try:
         return ImageFont.truetype(str(font) if font.exists() else font.name, size)
     except Exception:  # download if missing
-        check_font(font)
         try:
+            check_font(font)
             return ImageFont.truetype(str(font), size)
         except TypeError:
             check_requirements('Pillow>=8.4.0')  # known issue https://github.com/ultralytics/yolov5/issues/5374
+        except URLError:
+            return ImageFont.load_default()
 
 
 class Annotator:

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -61,7 +61,7 @@ def check_pil_font(font=FONT, size=10):
             return ImageFont.truetype(str(font), size)
         except TypeError:
             check_requirements('Pillow>=8.4.0')  # known issue https://github.com/ultralytics/yolov5/issues/5374
-        except URLError:
+        except URLError:  # not online
             return ImageFont.load_default()
 
 


### PR DESCRIPTION
Move the check / download of the Arial font into the class init.
This allows to use inference also in restricted environments without
access to the public internet.

Fixes partially https://github.com/ultralytics/yolov5/issues/4664.
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements in font handling for YOLOv5 plotting utilities.

### 📊 Key Changes
- Added error handling for URLError to manage font downloads when offline.
- Rearranged the exception handling order to try downloading the font before throwing a TypeError.

### 🎯 Purpose & Impact
- **Purpose**: To ensure more robust font handling in the plotting utility, especially when an internet connection is not available.
- **Impact**: Users will experience fewer disruptions due to missing fonts when using YOLOv5's visualization features, leading to a smoother user experience, particularly in offline scenarios. 📈🖼️