### PR TITLE
Conditional `Timeout()` by OS (disable on Windows)

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -123,12 +123,12 @@ class Timeout(contextlib.ContextDecorator):
         raise TimeoutError(self.timeout_message)
 
     def __enter__(self):
-        if platform.system() != 'Windows'  # not supported on Windows
+        if platform.system() != 'Windows':  # not supported on Windows
             signal.signal(signal.SIGALRM, self._timeout_handler)  # Set handler for SIGALRM
             signal.alarm(self.seconds)  # start countdown for SIGALRM to be raised
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if platform.system() != 'Windows'
+        if platform.system() != 'Windows':
             signal.alarm(0)  # Cancel SIGALRM if it's scheduled
             if self.suppress and exc_type is TimeoutError:  # Suppress TimeoutError
                 return True

--- a/utils/general.py
+++ b/utils/general.py
@@ -123,13 +123,15 @@ class Timeout(contextlib.ContextDecorator):
         raise TimeoutError(self.timeout_message)
 
     def __enter__(self):
-        signal.signal(signal.SIGALRM, self._timeout_handler)  # Set handler for SIGALRM
-        signal.alarm(self.seconds)  # start countdown for SIGALRM to be raised
+        if platform.system() != 'Windows'  # not supported on Windows
+            signal.signal(signal.SIGALRM, self._timeout_handler)  # Set handler for SIGALRM
+            signal.alarm(self.seconds)  # start countdown for SIGALRM to be raised
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        signal.alarm(0)  # Cancel SIGALRM if it's scheduled
-        if self.suppress and exc_type is TimeoutError:  # Suppress TimeoutError
-            return True
+        if platform.system() != 'Windows'
+            signal.alarm(0)  # Cancel SIGALRM if it's scheduled
+            if self.suppress and exc_type is TimeoutError:  # Suppress TimeoutError
+                return True
 
 
 class WorkingDirectory(contextlib.ContextDecorator):


### PR DESCRIPTION
May resolve https://github.com/ultralytics/yolov5/issues/5395, #6871 


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced platform compatibility by preventing SIGALRM on Windows systems.

### 📊 Key Changes
- Conditional checks for Windows added before setting and cancelling alarms.
- `signal.SIGALRM` usage updated to be non-operative on Windows.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: These changes ensure that the `TimeoutHandler` does not attempt to use `signal.SIGALRM` on Windows, which isn't supported on that platform.
- 🚀 **Impact**: Windows users will experience fewer compatibility issues when using the YOLOv5 codebase, improving overall reliability and user experience. 

👩‍💻👨‍💻 **Users**: Developers and users running YOLOv5 on Windows platforms will specifically benefit from this update.