### PR TITLE
Update Dockerfile to `git clone` instead of `COPY`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Copy contents
-COPY . /usr/src/app
+RUN git clone https://github.com/ultralytics/yolov5 /usr/src/app
+# COPY . /usr/src/app
 
 # Downloads to user config dir
 ADD https://ultralytics.com/assets/Arial.ttf /root/.config/Ultralytics/


### PR DESCRIPTION
Resolves `git` command errors that currently happen in Docker image, i.e.:

```bash
root@382ae64aeca2:/usr/src/app# git pull
Warning: Permanently added the ECDSA host key for IP address '140.82.113.3' to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR changes the Dockerfile to clone the YOLOv5 repository instead of copying local files.

### 📊 Key Changes
- The Dockerfile now uses `git clone` to fetch the latest YOLOv5 code directly from GitHub.
- The previous method of copying local files into the Docker container has been commented out.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: Ensures that the Docker container always has the latest version of YOLOv5, directly from the source.
- 📈 **Impact**: Provides users with a more reliable and up-to-date Docker environment, simplifying deployment and development workflows.