### PR TITLE
Add non-zero `da` `check_anchor_order()` condition

### DIFF
--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -20,7 +20,7 @@ def check_anchor_order(m):
     a = m.anchors.prod(-1).mean(-1).view(-1)  # mean anchor area per output layer
     da = a[-1] - a[0]  # delta a
     ds = m.stride[-1] - m.stride[0]  # delta s
-    if da.sign() != ds.sign():  # same order
+    if da and (da.sign() != ds.sign()):  # same order
         LOGGER.info(f'{PREFIX}Reversing anchor order')
         m.anchors[:] = m.anchors.flip(0)
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved anchor checking logic in YOLOv5's automatic anchor optimization.

### 📊 Key Changes
- Added a condition to ensure anchor differences are non-zero before checking the order relative to stride differences.

### 🎯 Purpose & Impact
- 🛠️ Ensures anchors are only reordered if a meaningful size difference exists, preventing potential errors in models where anchor sizes don't change across layers.
- 🏃‍♂️ Improves model performance and accuracy by correcting anchor ordering only when necessary.