### PR TITLE
Fix2 `check_anchor_order()` in pixel-space not grid-space

### DIFF
--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -40,7 +40,8 @@ def check_anchors(dataset, model, thr=4.0, imgsz=640):
         bpr = (best > 1 / thr).float().mean()  # best possible recall
         return bpr, aat
 
-    anchors = m.anchors.clone() * m.stride.to(m.anchors.device).view(-1, 1, 1)  # current anchors
+    stride = m.stride.to(m.anchors.device).view(-1, 1, 1)  # model strides
+    anchors = m.anchors.clone() * stride  # current anchors
     bpr, aat = metric(anchors.cpu().view(-1, 2))
     s = f'\n{PREFIX}{aat:.2f} anchors/target, {bpr:.3f} Best Possible Recall (BPR). '
     if bpr > 0.98:  # threshold to recompute
@@ -55,8 +56,9 @@ def check_anchors(dataset, model, thr=4.0, imgsz=640):
         new_bpr = metric(anchors)[0]
         if new_bpr > bpr:  # replace anchors
             anchors = torch.tensor(anchors, device=m.anchors.device).type_as(m.anchors)
-            m.anchors[:] = anchors.clone().view_as(m.anchors) / m.stride.to(m.anchors.device).view(-1, 1, 1)  # loss
-            check_anchor_order(m)
+            m.anchors[:] = anchors.clone().view_as(m.anchors)
+            check_anchor_order(m)  # must be in pixel-space (not grid-space)
+            m.anchors /= stride
             s = f'{PREFIX}Done ✅ (optional: update model *.yaml to use these anchors in the future)'
         else:
             s = f'{PREFIX}Done ⚠️ (original anchors better than new anchors, proceeding with original anchors)'


### PR DESCRIPTION
Follows https://github.com/ultralytics/yolov5/pull/7060 which provided only a partial solution to this issue. #7060 resolved occurences in yolo.py, this applies the same fix in autoanchor.py.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved anchor scaling calculation in YOLOv5 autoanchor utility.

### 📊 Key Changes
- Separated the stride calculation for clarity.
- Updated the anchors' reassignment logic with additional ordering checks to ensure they remain in pixel-space.

### 🎯 Purpose & Impact
- The separation of stride calculation and more explicit assignment of anchors improve code readability and maintainability.
- Ensuring anchors stay in pixel-space after recalibration improves the model's accuracy and performance, which could result in more accurate object detection for users. 🎯📈