### PR TITLE
Update detect.py, enable skip frames with command line option.

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -74,6 +74,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
         hide_conf=False,  # hide confidences
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
+        frame_keep=1,  # process every n frame, 2 skips every other frame, 5, ...,
         ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
@@ -107,7 +108,10 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
     # Run inference
     model.warmup(imgsz=(1 if pt else bs, 3, *imgsz))  # warmup
     dt, seen = [0.0, 0.0, 0.0], 0
+    idx=-1
     for path, im, im0s, vid_cap, s in dataset:
+        idx+=1
+        if not idx % frame_keep == 0: continue
         t1 = time_sync()
         im = torch.from_numpy(im).to(device)
         im = im.half() if model.fp16 else im.float()  # uint8 to fp16/32
@@ -236,6 +240,7 @@ def parse_opt():
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
+    parser.add_argument('--frame_keep', type=int, default=1, help='process every n frames, 1=all')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(FILE.stem, opt)


### PR DESCRIPTION
skip frames is an option to process subsets of large data collections including video input.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added frame skipping feature to YOLOv5 detection.

### 📊 Key Changes
- 🔂 Introduced a `frame_keep` parameter to process every nth frame during video inference.

### 🎯 Purpose & Impact
- 🚀 **Purpose:** The new `frame_keep` feature aims to reduce computational workload and increase processing speed by allowing users to skip frames during video detection tasks.
- 🌐 **Impact:** Users can now choose to process fewer frames, which can be especially beneficial for real-time applications where speed is crucial, or when analyzing long videos to save time. This could, however, reduce detection accuracy or miss transient objects due to less frequent analysis.