### PR TITLE
Fix `detect.py --view-img` for non-ASCII paths

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -29,7 +29,6 @@ import os
 import sys
 from pathlib import Path
 
-import cv2
 import torch
 import torch.backends.cudnn as cudnn
 
@@ -41,9 +40,8 @@ ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.common import DetectMultiBackend
 from utils.datasets import IMG_FORMATS, VID_FORMATS, LoadImages, LoadStreams
-from utils.general import (LOGGER, check_file, check_img_size, check_imshow, check_requirements, colorstr,
-                           increment_path, is_chinese, non_max_suppression, print_args, scale_coords, strip_optimizer,
-                           xyxy2xywh)
+from utils.general import (LOGGER, check_file, check_img_size, check_imshow, check_requirements, colorstr, cv2,
+                           increment_path, non_max_suppression, print_args, scale_coords, strip_optimizer, xyxy2xywh)
 from utils.plots import Annotator, colors, save_one_box
 from utils.torch_utils import select_device, time_sync
 
@@ -174,7 +172,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
             # Stream results
             im0 = annotator.result()
             if view_img:
-                cv2.imshow(str(str(p).encode("unicode_escape")), im0) if is_chinese(str(p)) else cv2.imshow(str(p), im0)
+                cv2.imshow(str(p), im0)
                 cv2.waitKey(1)  # 1 millisecond
 
             # Save results (image with detections)

--- a/detect.py
+++ b/detect.py
@@ -42,7 +42,8 @@ ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 from models.common import DetectMultiBackend
 from utils.datasets import IMG_FORMATS, VID_FORMATS, LoadImages, LoadStreams
 from utils.general import (LOGGER, check_file, check_img_size, check_imshow, check_requirements, colorstr,
-                           increment_path, is_chinese, non_max_suppression, print_args, scale_coords, strip_optimizer, xyxy2xywh)
+                           increment_path, is_chinese, non_max_suppression, print_args, scale_coords, strip_optimizer,
+                           xyxy2xywh)
 from utils.plots import Annotator, colors, save_one_box
 from utils.torch_utils import select_device, time_sync
 

--- a/detect.py
+++ b/detect.py
@@ -42,7 +42,7 @@ ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 from models.common import DetectMultiBackend
 from utils.datasets import IMG_FORMATS, VID_FORMATS, LoadImages, LoadStreams
 from utils.general import (LOGGER, check_file, check_img_size, check_imshow, check_requirements, colorstr,
-                           increment_path, non_max_suppression, print_args, scale_coords, strip_optimizer, xyxy2xywh)
+                           increment_path, is_chinese, non_max_suppression, print_args, scale_coords, strip_optimizer, xyxy2xywh)
 from utils.plots import Annotator, colors, save_one_box
 from utils.torch_utils import select_device, time_sync
 
@@ -173,7 +173,7 @@ def run(weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
             # Stream results
             im0 = annotator.result()
             if view_img:
-                cv2.imshow(str(p), im0)
+                cv2.imshow(str(str(p).encode("unicode_escape")), im0) if is_chinese(str(p)) else cv2.imshow(str(p), im0)
                 cv2.waitKey(1)  # 1 millisecond
 
             # Save results (image with detections)

--- a/utils/general.py
+++ b/utils/general.py
@@ -905,8 +905,8 @@ def increment_path(path, exist_ok=False, sep='', mkdir=False):
 
 
 # OpenCV Chinese-friendly functions ------------------------------------------------------------------------------------
-def imshow(p, im):
-    cv2.imshow(str(p).encode().decode('utf-8', 'ignore'), im)
+def imshow(path, im):
+    cv2.imshow(path.encode().decode('utf-8', 'ignore'), im)
 
 
 cv2.imshow = imshow

--- a/utils/general.py
+++ b/utils/general.py
@@ -905,11 +905,14 @@ def increment_path(path, exist_ok=False, sep='', mkdir=False):
 
 
 # OpenCV Chinese-friendly functions ------------------------------------------------------------------------------------
+imshow_ = cv2.imshow  # copy to avoid recursion
+
+
 def imshow(path, im):
-    cv2.imshow(path.encode().decode('utf-8', 'ignore'), im)
+    imshow_(path.encode().decode('utf-8', 'ignore'), im)
 
 
-cv2.imshow = imshow
+cv2.imshow = imshow  # redefine
 
 # Variables ------------------------------------------------------------------------------------------------------------
 NCOLS = 0 if is_docker() else shutil.get_terminal_size().columns  # terminal window size for tqdm

--- a/utils/general.py
+++ b/utils/general.py
@@ -919,11 +919,11 @@ def imwrite(path, im):
     except Exception:
         return False
 
-      
+
 def imshow(path, im):
     imshow_(path.encode().decode('utf-8', 'ignore'), im)
 
-    
+
 cv2.imread, cv2.imwrite, cv2.imshow = imread, imwrite, imshow  # redefine
 
 # Variables ------------------------------------------------------------------------------------------------------------

--- a/utils/general.py
+++ b/utils/general.py
@@ -906,7 +906,7 @@ def increment_path(path, exist_ok=False, sep='', mkdir=False):
 
 # OpenCV Chinese-friendly functions ------------------------------------------------------------------------------------
 def imshow(p, im):
-    cv2.imshow(p.encode('unicode_escape'), im)
+    cv2.imshow(str(p).encode().decode('utf-8', 'ignore'), im)
 
 
 cv2.imshow = imshow

--- a/utils/general.py
+++ b/utils/general.py
@@ -921,7 +921,7 @@ def imwrite(path, im):
 
 
 def imshow(path, im):
-    imshow_(path.encode().decode('utf-8', 'ignore'), im)
+    imshow_(path.encode('unicode_escape').decode(), im)
 
 
 cv2.imread, cv2.imwrite, cv2.imshow = imread, imwrite, imshow  # redefine

--- a/utils/general.py
+++ b/utils/general.py
@@ -906,7 +906,7 @@ def increment_path(path, exist_ok=False, sep='', mkdir=False):
 
 # OpenCV Chinese-friendly functions ------------------------------------------------------------------------------------
 def imshow(p, im):
-    cv2.imshow(p.encode('string_escape') if is_chinese(p) else p, im)
+    cv2.imshow(p.encode('unicode_escape'), im)
 
 
 cv2.imshow = imshow

--- a/utils/general.py
+++ b/utils/general.py
@@ -220,8 +220,8 @@ def is_chinese(s='人工智能'):
 
 
 def emojis(str=''):
-    # Return emoji-safe version of string
-    return str.encode().decode('utf-8', 'ignore')
+    # Return platform-dependent emoji-safe version of string
+    return str.encode().decode('ascii', 'ignore') if platform.system() == 'Windows' else str
 
 
 def file_age(path=__file__):

--- a/utils/general.py
+++ b/utils/general.py
@@ -905,7 +905,7 @@ def increment_path(path, exist_ok=False, sep='', mkdir=False):
 
 
 # OpenCV Chinese-friendly functions ------------------------------------------------------------------------------------
-imshow_ = cv2.imshow  # copy to avoid recursion
+imshow_ = cv2.imshow  # copy to avoid recursion errors
 
 
 def imshow(path, im):

--- a/utils/general.py
+++ b/utils/general.py
@@ -220,8 +220,8 @@ def is_chinese(s='人工智能'):
 
 
 def emojis(str=''):
-    # Return platform-dependent emoji-safe version of string
-    return str.encode().decode('ascii', 'ignore') if platform.system() == 'Windows' else str
+    # Return emoji-safe version of string
+    return str.encode().decode('utf-8', 'ignore')
 
 
 def file_age(path=__file__):

--- a/utils/general.py
+++ b/utils/general.py
@@ -904,5 +904,12 @@ def increment_path(path, exist_ok=False, sep='', mkdir=False):
     return path
 
 
-# Variables
+# OpenCV Chinese-friendly functions ------------------------------------------------------------------------------------
+def imshow(p, im):
+    cv2.imshow(p.encode('string_escape') if is_chinese(p) else p, im)
+
+
+cv2.imshow = imshow
+
+# Variables ------------------------------------------------------------------------------------------------------------
 NCOLS = 0 if is_docker() else shutil.get_terminal_size().columns  # terminal window size for tqdm


### PR DESCRIPTION
@glenn-jocher 
I found a solution to the problem mentioned in https://github.com/ultralytics/yolov5/issues/7075, the reason is that my yolov5 project path includes Chinese, so `cv2.imshow(str(p), im0) `This line of code cannot display the window, resulting in the inability to display pictures and videos, I will fix this bug.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved OpenCV functions for better Chinese character handling in file paths.

### 📊 Key Changes
- Added a wrapper function around `cv2.imshow` to prevent recursion errors.
- Extended functionality to encode file paths for proper handling of Chinese characters within the `imshow` function.
- Redefined `cv2.imread`, `cv2.imwrite`, and `cv2.imshow` to utilize the new, improved functions supporting Chinese character file paths.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: The main goal is to enhance compatibility with Chinese characters in file paths when using OpenCV functions, mitigating issues faced by users with non-Latin alphabets in their file system.
- 🌍 **Impact**: This change makes the YOLOv5 more accessible and user-friendly for a global audience, particularly assisting Chinese-speaking developers and users in running image processing tasks without encountering errors related to file path encoding.