### PR TITLE
Display model name in model summary

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -229,7 +229,8 @@ def model_info(model, verbose=False, img_size=640):
     except (ImportError, Exception):
         fs = ''
 
-    LOGGER.info(f"Model Summary: {len(list(model.modules()))} layers, {n_p} parameters, {n_g} gradients{fs}")
+    name = model.yaml_file.rstrip('.yaml').replace('yolov5', 'YOLOv5') if hasattr(model, 'yaml_file') else 'Model'
+    LOGGER.info(f"{name} summary: {len(list(model.modules()))} layers, {n_p} parameters, {n_g} gradients{fs}")
 
 
 def scale_img(img, ratio=1.0, same_shape=False, gs=32):  # img(16,3,256,416)


### PR DESCRIPTION
i.e.

```bash
...
 27          [-1, 15]  1         0  models.common.Concat                    [1]                           
 28                -1  1    715008  models.common.C3                        [512, 384, 1, False]          
 29                -1  1   1327872  models.common.Conv                      [384, 384, 3, 2]              
 30          [-1, 11]  1         0  models.common.Concat                    [1]                           
 31                -1  1   1313792  models.common.C3                        [768, 512, 1, False]          
 32  [22, 25, 28, 31]  1    327420  Detect                                  [80, [[8, 11, 16, 19, 38, 24], [20, 48, 45, 52, 50, 103], [100, 57, 122, 116, 88, 197], [241, 171, 174, 304, 423, 370]], [128, 256, 384, 512]]
YOLOv5s6-C2SPPF-768 summary: 351 layers, 12265404 parameters, 12265404 gradients, 16.8 GFLOPs
```


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model summary logging with model name identification.

### 📊 Key Changes
- Model's summary log now includes the model name instead of a generic "Model Summary" label.
- The model name is derived from the `yaml_file` attribute, with formatting changes applied.

### 🎯 Purpose & Impact
- Helps users clearly identify which model's summary is being logged, particularly useful when dealing with multiple models.
- Improves readability and usability of logs by incorporating meaningful model names into log messages.