### PR TITLE
`torch.split()` 1.7.0 compatibility fix

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -108,13 +108,15 @@ class ComputeLoss:
         if g > 0:
             BCEcls, BCEobj = FocalLoss(BCEcls, g), FocalLoss(BCEobj, g)
 
-        det = de_parallel(model).model[-1]  # Detect() module
-        self.balance = {3: [4.0, 1.0, 0.4]}.get(det.nl, [4.0, 1.0, 0.25, 0.06, 0.02])  # P3-P7
-        self.ssi = list(det.stride).index(16) if autobalance else 0  # stride 16 index
+        m = de_parallel(model).model[-1]  # Detect() module
+        self.balance = {3: [4.0, 1.0, 0.4]}.get(m.nl, [4.0, 1.0, 0.25, 0.06, 0.02])  # P3-P7
+        self.ssi = list(m.stride).index(16) if autobalance else 0  # stride 16 index
         self.BCEcls, self.BCEobj, self.gr, self.hyp, self.autobalance = BCEcls, BCEobj, 1.0, h, autobalance
+        self.na = m.na  # number of anchors
+        self.nc = m.nc  # number of classes
+        self.nl = m.nl  # number of layers
+        self.anchors = m.anchors
         self.device = device
-        for k in 'na', 'nc', 'nl', 'anchors':
-            setattr(self, k, getattr(det, k))
 
     def __call__(self, p, targets):  # predictions, targets
         lcls = torch.zeros(1, device=self.device)  # class loss

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -131,7 +131,7 @@ class ComputeLoss:
             if n:
                 # pxy, pwh, _, pcls = pi[b, a, gj, gi].tensor_split((2, 4, 5), dim=1)  # faster, requires torch 1.8.0
                 pxy, pwh, _, pcls = pi[b, a, gj, gi].split((2, 2, 1, self.nc), 1)  # target-subset of predictions
-                
+
                 # Regression
                 pxy = pxy.sigmoid() * 2 - 0.5
                 pwh = (pwh.sigmoid() * 2) ** 2 * anchors[i]

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -129,8 +129,9 @@ class ComputeLoss:
 
             n = b.shape[0]  # number of targets
             if n:
-                pxy, pwh, _, pcls = pi[b, a, gj, gi].tensor_split((2, 4, 5), dim=1)  # target-subset of predictions
-
+                # pxy, pwh, _, pcls = pi[b, a, gj, gi].tensor_split((2, 4, 5), dim=1)  # faster, requires torch 1.8.0
+                pxy, pwh, _, pcls = pi[b, a, gj, gi].split((2, 2, 1, self.nc), 1)  # target-subset of predictions
+                
                 # Regression
                 pxy = pxy.sigmoid() * 2 - 0.5
                 pwh = (pwh.sigmoid() * 2) ** 2 * anchors[i]


### PR DESCRIPTION
Fix for https://github.com/ultralytics/yolov5/issues/7085#issuecomment-1075224274

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of the loss calculation functionality in the YOLOv5 model.

### 📊 Key Changes
- Refactored variable names for clarity, changing `det` to `m` representing the `Detect()` module.
- Direct assignment of the number of anchors (`na`), number of classes (`nc`), number of layers (`nl`), and anchors from the model `m` to the loss module for better readability and maintainability.
- Modified the method for splitting prediction tensors to support a broader range of PyTorch versions by using `split` instead of `tensor_split`.

### 🎯 Purpose & Impact
- These changes aim to make the code clearer and more maintainable, enabling easier future enhancements and debugging.
- With the update to the tensor splitting method, this improvement increases compatibility with different versions of PyTorch, allowing more users to work with the model regardless of their PyTorch version.
- The well-defined assignments and restructuring are expected to have a minimal direct impact on end-users but will provide a more robust foundation for future updates and potential new features.