### PR TITLE
Model summary `pathlib` fix

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -11,6 +11,7 @@ import time
 import warnings
 from contextlib import contextmanager
 from copy import deepcopy
+from pathlib import Path
 
 import torch
 import torch.distributed as dist
@@ -229,7 +230,7 @@ def model_info(model, verbose=False, img_size=640):
     except (ImportError, Exception):
         fs = ''
 
-    name = model.yaml_file.rstrip('.yaml').replace('yolov5', 'YOLOv5') if hasattr(model, 'yaml_file') else 'Model'
+    name = Path(model.yaml_file).stem.replace('yolov5', 'YOLOv5') if hasattr(model, 'yaml_file') else 'Model'
     LOGGER.info(f"{name} summary: {len(list(model.modules()))} layers, {n_p} parameters, {n_g} gradients{fs}")
 
 


### PR DESCRIPTION
Stems not working correctly for YOLOv5l with current .rstrip() implementation. After fix:
```
YOLOv5l summary: 468 layers, 46563709 parameters, 46563709 gradients, 109.3 GFLOPs
```



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model's naming consistency and path handling in logging information.

### 📊 Key Changes
- Imported `Path` from `pathlib` for better path manipulation.
- Modified the model's name extraction logic to use `Path` object, providing a more reliable way of getting the base filename without the extension.

### 🎯 Purpose & Impact
- 🏗️ **Consistent Naming**: Ensures that model naming in the logs is more consistent, especially when the `.yaml` file is referred to, enhancing readability.
- 📁 **Path Management**: Using `Path` from `pathlib` improves file path handling, making it less prone to errors across different operating systems.