### PR TITLE
Sidestep `os.path.relpath()` Windows bug

### DIFF
--- a/export.py
+++ b/export.py
@@ -61,7 +61,8 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
-ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
+if sys.platform != 'Windows':
+    ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.common import Conv
 from models.experimental import attempt_load

--- a/export.py
+++ b/export.py
@@ -61,7 +61,7 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
-if sys.platform != 'Windows':
+if platform.system() != 'Windows':
     ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.common import Conv

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -7,6 +7,7 @@ Usage:
 """
 
 import argparse
+import os
 import sys
 from copy import deepcopy
 from pathlib import Path

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -15,7 +15,8 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[1]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
-# ROOT = ROOT.relative_to(Path.cwd())  # relative
+if sys.platform != 'Windows':
+    ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.common import *
 from models.experimental import *

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -8,6 +8,7 @@ Usage:
 
 import argparse
 import os
+import platform
 import sys
 from copy import deepcopy
 from pathlib import Path
@@ -16,7 +17,7 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[1]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
-if sys.platform != 'Windows':
+if platform.system() != 'Windows':
     ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.common import *


### PR DESCRIPTION
os.path.relpath() seems to have a major bug on Windows caused by Windows own horrible path handling. This fix attempts to sidestep the issue.

```
File "C:\Users\mkokg/.cache\torch\hub\ultralytics_yolov5_master\export.py", line 64, in
ROOT = Path(os.path.relpath(ROOT, Path.cwd())) # relative
File "C:\Users\mkokg\AppData\Local\Programs\Python\Python310\lib\ntpath.py", line 718, in relpath
raise ValueError("path is on mount %r, start on mount %r" % (
ValueError: path is on mount 'C:', start on mount 'D:'
```

More info at https://bugs.python.org/issue7195

Test script:
```python
import torch

model = torch.hub.load('ultralytics/yolov5:fix/relpath', 'yolov5s', force_reload=True)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved cross-platform path handling in YOLOv5's export and model scripts.

### 📊 Key Changes
- Added `import os` and `import platform` to check the operating system type.
- Conditionally set the `ROOT` path to be relative unless running on Windows.

### 🎯 Purpose & Impact
- **Purpose:** To ensure proper path handling across different operating systems, addressing an issue where setting a relative `ROOT` path may cause errors on Windows.
- **Impact:** Users on non-Windows systems will benefit from cleaner path management, while Windows users will have reduced risk of encountering path-related errors. This change promotes cross-platform compatibility, making YOLOv5 more robust and user-friendly. 🖥️🚀