### PR TITLE
Revert `C3()` change

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -124,9 +124,6 @@ class BottleneckCSP(nn.Module):
         return self.cv4(self.act(self.bn(torch.cat((y1, y2), 1))))
 
 
-from models.experimental import CrossConv
-
-
 class C3(nn.Module):
     # CSP Bottleneck with 3 convolutions
     def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5):  # ch_in, ch_out, number, shortcut, groups, expansion
@@ -135,8 +132,8 @@ class C3(nn.Module):
         self.cv1 = Conv(c1, c_, 1, 1)
         self.cv2 = Conv(c1, c_, 1, 1)
         self.cv3 = Conv(2 * c_, c2, 1)  # optional act=FReLU(c2)
-        # self.m = nn.Sequential(*(Bottleneck(c_, c_, shortcut, g, e=1.0) for _ in range(n)))
-        self.m = nn.Sequential(*(CrossConv(c_, c_, 3, 1, g, 1.0, shortcut) for _ in range(n)))
+        self.m = nn.Sequential(*(Bottleneck(c_, c_, shortcut, g, e=1.0) for _ in range(n)))
+        # self.m = nn.Sequential(*(CrossConv(c_, c_, 3, 1, g, 1.0, shortcut) for _ in range(n)))
 
     def forward(self, x):
         return self.cv3(torch.cat((self.m(self.cv1(x)), self.cv2(x)), 1))


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updating neural network architecture components in YOLOv5.

### 📊 Key Changes
- Removed `CrossConv` import from `models/common.py`.
- Switched from using `CrossConv` to `Bottleneck` in the `C3` class definition.

### 🎯 Purpose & Impact
- The update emphasizes simplifying the CSP bottleneck layer by replacing a potentially experimental or less efficient `CrossConv` block with a more standard `Bottleneck` block.
- This change could improve the maintainability of the code, potentially enhance model performance, and ensure more stable behavior.
- Users might experience benefits such as faster inference, better accuracy, or reduced complexity when working with the YOLOv5 architecture.