### PR TITLE
Add train.py `--name cfg` option

### DIFF
--- a/train.py
+++ b/train.py
@@ -519,6 +519,8 @@ def main(opt, callbacks=Callbacks()):
             if opt.project == str(ROOT / 'runs/train'):  # if default project name, rename to runs/evolve
                 opt.project = str(ROOT / 'runs/evolve')
             opt.exist_ok, opt.resume = opt.resume, False  # pass resume to exist_ok and disable resume
+        if opt.name == 'cfg':
+            opt.name = Path(opt.cfg).stem  # use model.yaml as name
         opt.save_dir = str(increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok))
 
     # DDP mode


### PR DESCRIPTION
Automatically names run as `--cfg` argument, i.e. `python train.py --name cfg`


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Automatic renaming feature added to training script when evolving models.

### 📊 Key Changes
- A new conditional block has been added that automatically sets the name of the experiment to the stem of the configuration file, provided that the user has specified 'cfg' as the name.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To streamline the process of model evolution by reducing the need for manual naming of each experiment, ensuring that each evolved model has a unique and meaningful name based on its configuration file.
- 💥 **Impact**: Users evolving models will find their output directories more organized and easier to navigate, with a lower risk of overwriting previous experiments due to naming collisions. It can also aid in the recognition of which model configuration was used just by looking at the name.