### PR TITLE
`ENV OMP_NUM_THREADS=8`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN git clone https://github.com/ultralytics/yolov5 /usr/src/app
 ADD https://ultralytics.com/assets/Arial.ttf /root/.config/Ultralytics/
 
 # Set environment variables
+ENV OMP_NUM_THREADS=8
 # ENV HOME=/usr/src/app
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Docker performance for YOLOv5.

### 📊 Key Changes
- Added an environment variable (`OMP_NUM_THREADS`) to the Dockerfile.

### 🎯 Purpose & Impact
- **Purpose:** To optimize the number of threads used by OpenMP in YOLOv5 Docker containers for better performance.
- **Impact:** Users may experience faster processing as the change ensures that the container utilizes a defined number of CPU threads consistently (8 in this case). This can be especially beneficial when running YOLOv5 on multi-core systems. 🚀