### PR TITLE
Update setup.cfg to `description_file` field

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 license_file = LICENSE
-description-file = README.md
+description_file = README.md
 
 
 [tool:pytest]


### PR DESCRIPTION
Resolve `UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved consistency in the `setup.cfg` configuration file.

### 📊 Key Changes
- Corrected the `description-file` key to `description_file` in `setup.cfg`.

### 🎯 Purpose & Impact
- Ensures compliance with the expected standard for setup configuration, which might prevent potential parsing errors by tools that read this file.
- This change has a minimal direct impact on users but maintains the quality and reliability of the codebase.