### PR TITLE
Export with official `nn.SiLU()`

### DIFF
--- a/export.py
+++ b/export.py
@@ -54,7 +54,6 @@ from pathlib import Path
 
 import pandas as pd
 import torch
-import torch.nn as nn
 from torch.utils.mobile_optimizer import optimize_for_mobile
 
 FILE = Path(__file__).resolve()
@@ -64,10 +63,8 @@ if str(ROOT) not in sys.path:
 if platform.system() != 'Windows':
     ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
-from models.common import Conv
 from models.experimental import attempt_load
 from models.yolo import Detect
-from utils.activations import SiLU
 from utils.datasets import LoadImages
 from utils.general import (LOGGER, check_dataset, check_img_size, check_requirements, check_version, colorstr,
                            file_size, print_args, url2file)
@@ -474,10 +471,10 @@ def run(
         im, model = im.half(), model.half()  # to FP16
     model.train() if train else model.eval()  # training mode = no Detect() layer grid construction
     for k, m in model.named_modules():
-        if isinstance(m, Conv):  # assign export-friendly activations
-            if isinstance(m.act, nn.SiLU):
-                m.act = SiLU()
-        elif isinstance(m, Detect):
+        # if isinstance(m, Conv):  # assign export-friendly activations
+        #     if isinstance(m.act, nn.SiLU):
+        #         m.act = SiLU()
+        if isinstance(m, Detect):
             m.inplace = inplace
             m.onnx_dynamic = dynamic
             if hasattr(m, 'forward_export'):

--- a/utils/general.py
+++ b/utils/general.py
@@ -738,7 +738,7 @@ def non_max_suppression(prediction,
     # min_wh = 2  # (pixels) minimum box width and height
     max_wh = 7680  # (pixels) maximum box width and height
     max_nms = 30000  # maximum number of boxes into torchvision.ops.nms()
-    time_limit = 0.030 * bs  # seconds to quit after
+    time_limit = 0.1 + 0.03 * bs  # seconds to quit after
     redundant = True  # require redundant detections
     multi_label &= nc > 1  # multiple labels per box (adds 0.5ms/img)
     merge = False  # use merge-NMS


### PR DESCRIPTION
Remove utils.activations.SiLU replacement for nn.SiLU on export. This was in place for export support on some formats that did not recognize PyTorch's nn.SiLU module, but now all export formats fully support this. Note may require coremltools>=5.1 for CoreML exports, not tested with coremltools==4.1 support.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplified model activation functions and updated non-max suppression timing parameters in YOLOv5 export script.

### 📊 Key Changes
- Removed specific activation function handling (`SiLU`) during model export.
- Removed unused imports (`torch.nn`, `Conv`, and `SiLU` modules).
- Increased the base non-max suppression time limit from dynamic-only to a static base time plus a dynamic component based on batch size.

### 🎯 Purpose & Impact
- Simplifying activation functions helps streamline the export process and removes potential obstacles when converting models for mobile or other platforms. 🚀
- Cleaning up imports reduces clutter and slightly improves code maintainability. 🧹
- Adjusting the non-max suppression timing ensures the algorithm has enough time to process the results even with larger batch sizes, which could improve detection reliability at the cost of potential slight latency increase. ⏱️💡

These changes collectively work towards optimizing YOLOv5's performance and usability across different deployment scenarios. Users can expect a smoother export process for their trained models with these updates.