### PR TITLE
Update detection.py to support frame skip

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -74,7 +74,7 @@ def run(
         hide_conf=False,  # hide confidences
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
-        skip_frame=0, # skip frame in video
+        skip_frame=0,  # skip frame in video
 ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images

--- a/detect.py
+++ b/detect.py
@@ -74,6 +74,7 @@ def run(
         hide_conf=False,  # hide confidences
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
+        skip_frame=0, # skip frame in video
 ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
@@ -100,7 +101,7 @@ def run(
         dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt)
         bs = len(dataset)  # batch_size
     else:
-        dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt)
+        dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt, skipframe=skip_frame)
         bs = 1  # batch_size
     vid_path, vid_writer = [None] * bs, [None] * bs
 
@@ -236,6 +237,7 @@ def parse_opt():
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
+    parser.add_argument('--skip-frame', type=int, default=0, help='skip frame in the videos')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(vars(opt))


### PR DESCRIPTION
Working with the update of datasets.py to allow users to skip arbitrary frames in video detection by adding an argument "--skip-frame"

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added a frame skipping feature to the YOLOv5 detect.py script. 🏃‍♂️💨

### 📊 Key Changes
- New `skip_frame` parameter introduced in the `detect.py` script.
- Updated `LoadImages` function call to include the new `skipframe` argument.

### 🎯 Purpose & Impact
- **Purpose**: The `skip_frame` option allows users to process videos more quickly by skipping over a specified number of frames, potentially reducing computation time and resource usage.
- **Impact**: Users with time constraints or limited computational resources can now analyze video datasets more efficiently by choosing to process fewer frames. 🚀🕒