### PR TITLE
Add  `check_requirements(('pycocotools>=2.0',))`

### DIFF
--- a/data/Objects365.yaml
+++ b/data/Objects365.yaml
@@ -60,11 +60,12 @@ names: ['Person', 'Sneakers', 'Chair', 'Other Shoes', 'Hat', 'Car', 'Lamp', 'Gla
 
 # Download script/URL (optional) ---------------------------------------------------------------------------------------
 download: |
-  from pycocotools.coco import COCO
   from tqdm import tqdm
-
-  from utils.general import Path, download, np, xyxy2xywhn
-
+  
+  from utils.general import Path, check_requirements, download, np, xyxy2xywhn
+  
+  check_requirements(('pycocotools>=2.0',))
+  from pycocotools.coco import COCO
 
   # Make Directories
   dir = Path(yaml['path'])  # dataset root dir


### PR DESCRIPTION
Add  `check_requirements(('pycocotools>=2.0',))`


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated Objects365 dataset configuration with dependency checks.

### 📊 Key Changes
- Added `check_requirements` function to enforce the presence of necessary packages.
- Included `pycocotools` version check within the dataset download script.

### 🎯 Purpose & Impact
- **Consistency**: Ensures users have the correct version of `pycocotools` before running the download script.
- **User Experience**: Prevents potential errors that could occur from missing or outdated dependencies, leading to a smoother workflow.