### PR TITLE
Use `tqdm.auto`

### DIFF
--- a/data/Argoverse.yaml
+++ b/data/Argoverse.yaml
@@ -22,7 +22,7 @@ names: ['person',  'bicycle',  'car',  'motorcycle',  'bus',  'truck',  'traffic
 download: |
   import json
 
-  from tqdm import tqdm
+  from tqdm.auto import tqdm
   from utils.general import download, Path
 
 

--- a/data/Objects365.yaml
+++ b/data/Objects365.yaml
@@ -60,7 +60,7 @@ names: ['Person', 'Sneakers', 'Chair', 'Other Shoes', 'Hat', 'Car', 'Lamp', 'Gla
 
 # Download script/URL (optional) ---------------------------------------------------------------------------------------
 download: |
-  from tqdm import tqdm
+  from tqdm.auto import tqdm
 
   from utils.general import Path, check_requirements, download, np, xyxy2xywhn
 

--- a/data/SKU-110K.yaml
+++ b/data/SKU-110K.yaml
@@ -21,7 +21,7 @@ names: ['object']  # class names
 # Download script/URL (optional) ---------------------------------------------------------------------------------------
 download: |
   import shutil
-  from tqdm import tqdm
+  from tqdm.auto import tqdm
   from utils.general import np, pd, Path, download, xyxy2xywh
 
 

--- a/data/VOC.yaml
+++ b/data/VOC.yaml
@@ -29,7 +29,7 @@ names: ['aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus', 'car', 'cat', '
 download: |
   import xml.etree.ElementTree as ET
 
-  from tqdm import tqdm
+  from tqdm.auto import tqdm
   from utils.general import download, Path
 
 

--- a/data/VisDrone.yaml
+++ b/data/VisDrone.yaml
@@ -24,7 +24,7 @@ download: |
 
   def visdrone2yolo(dir):
       from PIL import Image
-      from tqdm import tqdm
+      from tqdm.auto import tqdm
 
       def convert_box(size, box):
           # Convert VisDrone box to YOLO xywh box

--- a/data/xView.yaml
+++ b/data/xView.yaml
@@ -34,7 +34,7 @@ download: |
 
   import numpy as np
   from PIL import Image
-  from tqdm import tqdm
+  from tqdm.auto import tqdm
 
   from utils.datasets import autosplit
   from utils.general import download, xyxy2xywhn

--- a/train.py
+++ b/train.py
@@ -30,7 +30,7 @@ import yaml
 from torch.cuda import amp
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim import SGD, Adam, AdamW, lr_scheduler
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory

--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -8,7 +8,7 @@ import random
 import numpy as np
 import torch
 import yaml
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from utils.general import LOGGER, colorstr, emojis
 

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -24,7 +24,7 @@ import torch.nn.functional as F
 import yaml
 from PIL import ExifTags, Image, ImageOps
 from torch.utils.data import DataLoader, Dataset, dataloader, distributed
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from utils.augmentations import Albumentations, augment_hsv, copy_paste, letterbox, mixup, random_perspective
 from utils.general import (DATASETS_DIR, LOGGER, NUM_THREADS, check_dataset, check_requirements, check_yaml, clean_str,

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Dict
 
 import yaml
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[3]  # YOLOv5 root directory

--- a/val.py
+++ b/val.py
@@ -27,7 +27,7 @@ from threading import Thread
 
 import numpy as np
 import torch
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory


### PR DESCRIPTION
Automatically select proper tqdm submodule if available. I saw torch.hub is using this so following suit.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved progress bar compatibility across different platforms.

### 📊 Key Changes
- Changed the import statement from `from tqdm import tqdm` to `from tqdm.auto import tqdm` in multiple YAML files and Python scripts.

### 🎯 Purpose & Impact
- **Purpose:** The update ensures that the progress bar (associated with the `tqdm` library) adapts to the environment where the code is executed, providing better support for Jupyter notebooks and various terminal interfaces.
- **Impact:** This change will enhance the user experience by displaying more robust and visually appropriate progress indicators across different platforms, without altering any core functionalities of the YOLOv5 model. Users developing in notebooks or using different terminals should notice a smoother interface when running processes that utilize progress bars. 🔄💻📈