### PR TITLE
Add `retry=3` to `download()`

### DIFF
--- a/data/VOC.yaml
+++ b/data/VOC.yaml
@@ -62,7 +62,7 @@ download: |
   urls = [url + 'VOCtrainval_06-Nov-2007.zip',  # 446MB, 5012 images
           url + 'VOCtest_06-Nov-2007.zip',  # 438MB, 4953 images
           url + 'VOCtrainval_11-May-2012.zip']  # 1.95GB, 17126 images
-  download(urls, dir=dir / 'images', delete=False, threads=3)
+  download(urls, dir=dir / 'images', delete=False, curl=True, threads=3)
 
   # Convert
   path = dir / f'images/VOCdevkit'

--- a/data/VisDrone.yaml
+++ b/data/VisDrone.yaml
@@ -54,7 +54,7 @@ download: |
           'https://github.com/ultralytics/yolov5/releases/download/v1.0/VisDrone2019-DET-val.zip',
           'https://github.com/ultralytics/yolov5/releases/download/v1.0/VisDrone2019-DET-test-dev.zip',
           'https://github.com/ultralytics/yolov5/releases/download/v1.0/VisDrone2019-DET-test-challenge.zip']
-  download(urls, dir=dir, threads=4)
+  download(urls, dir=dir, curl=True, threads=4)
 
   # Convert
   for d in 'VisDrone2019-DET-train', 'VisDrone2019-DET-val', 'VisDrone2019-DET-test-dev':

--- a/utils/general.py
+++ b/utils/general.py
@@ -507,7 +507,7 @@ def download(url, dir='.', unzip=True, delete=True, curl=False, threads=1, retry
             Path(url).rename(f)  # move to dir
         elif not f.exists():
             LOGGER.info(f'Downloading {url} to {f}...')
-            for _ in range(retry):
+            for i in range(retry):
                 if curl:
                     s = 'sS' if threads > 1 else ''  # silent
                     r = os.system(f"curl -{s}L '{url}' -o '{f}' --retry 9 -C -")  # curl download
@@ -517,8 +517,10 @@ def download(url, dir='.', unzip=True, delete=True, curl=False, threads=1, retry
                     success = f.is_file()
                 if success:
                     break
+                elif i < (retry - 1):
+                    LOGGER.info(f'Failure, retrying {i + 1}/{retry} {url}...')
                 else:
-                    LOGGER.info(f'Failure, retrying {url} to {f}...')
+                    LOGGER.info(f'Failed to download {url}...')
 
         if unzip and success and f.suffix in ('.zip', '.gz'):
             LOGGER.info(f'Unzipping {f}...')

--- a/utils/general.py
+++ b/utils/general.py
@@ -509,13 +509,16 @@ def download(url, dir='.', unzip=True, delete=True, curl=False, threads=1, retry
             LOGGER.info(f'Downloading {url} to {f}...')
             for _ in range(retry):
                 if curl:
-                    r = os.system(f"curl -L '{url}' -o '{f}' --retry 9 -C -")  # curl download, retry and resume on fail
+                    s = 'sS' if threads > 1 else ''  # silent
+                    r = os.system(f"curl -{s}L '{url}' -o '{f}' --retry 9 -C -")  # curl download
                     success = r == 0
                 else:
                     torch.hub.download_url_to_file(url, f, progress=threads == 1)  # torch download
                     success = f.is_file()
                 if success:
                     break
+                else:
+                    LOGGER.info(f'Failure, retrying {url} to {f}...')
 
         if unzip and success and f.suffix in ('.zip', '.gz'):
             LOGGER.info(f'Unzipping {f}...')

--- a/utils/general.py
+++ b/utils/general.py
@@ -507,7 +507,7 @@ def download(url, dir='.', unzip=True, delete=True, curl=False, threads=1, retry
             Path(url).rename(f)  # move to dir
         elif not f.exists():
             LOGGER.info(f'Downloading {url} to {f}...')
-            for i in range(retry):
+            for i in range(retry + 1):
                 if curl:
                     s = 'sS' if threads > 1 else ''  # silent
                     r = os.system(f"curl -{s}L '{url}' -o '{f}' --retry 9 -C -")  # curl download
@@ -517,10 +517,10 @@ def download(url, dir='.', unzip=True, delete=True, curl=False, threads=1, retry
                     success = f.is_file()
                 if success:
                     break
-                elif i < (retry - 1):
-                    LOGGER.info(f'Failure, retrying {i + 1}/{retry} {url}...')
+                elif i < retry:
+                    LOGGER.warning(f'Download failure, retrying {i + 1}/{retry} {url}...')
                 else:
-                    LOGGER.info(f'Failed to download {url}...')
+                    LOGGER.warning(f'Failed to download {url}...')
 
         if unzip and success and f.suffix in ('.zip', '.gz'):
             LOGGER.info(f'Unzipping {f}...')


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to dataset download process with improved error handling and optional cURL utility.

### 📊 Key Changes
- The `download` function now accepts a `retry` parameter for multiple download attempts.
- cURL can be optionally used in dataset downloading by setting the `curl` parameter to `True`.
- Download error handling has been improved with retries and warnings on failure.

### 🎯 Purpose & Impact
- 🔄 The introduction of the retry mechanism aims to make downloading more robust, especially in unreliable network conditions.
- 🚀 Using cURL as an alternate download method provides flexibility and may improve download speeds or reliability for some users.
- ⚠️ Better error messages on download failures will help users diagnose and rectify issues more effectively, improving the overall user experience.