### PR TITLE
Copy wandb param dict before training to avoid overwrites.

### DIFF
--- a/utils/loggers/wandb/sweep.py
+++ b/utils/loggers/wandb/sweep.py
@@ -16,8 +16,9 @@ from utils.torch_utils import select_device
 
 def sweep():
     wandb.init()
-    # Get hyp dict from sweep agent
-    hyp_dict = vars(wandb.config).get("_items")
+    # Get hyp dict from sweep agent. Copy it because train() will
+    # overwrite some parameters which confuses wandb.
+    hyp_dict = vars(wandb.config).get("_items").copy()
 
     # Workaround: get necessary opt args
     opt = parse_opt(known=True)

--- a/utils/loggers/wandb/sweep.py
+++ b/utils/loggers/wandb/sweep.py
@@ -16,8 +16,7 @@ from utils.torch_utils import select_device
 
 def sweep():
     wandb.init()
-    # Get hyp dict from sweep agent. Copy it because train() will
-    # overwrite some parameters which confuses wandb.
+    # Get hyp dict from sweep agent. Copy because train() modifies parameters which confused wandb.
     hyp_dict = vars(wandb.config).get("_items").copy()
 
     # Workaround: get necessary opt args


### PR DESCRIPTION
Copy the hyperparameter dict retrieved from wandb configuration before passing it to `train()`. Training overwrites parameters in the dictionary (eg scaling obj/box/cls gains), which causes the values reported in wandb to not match the input values. This is confusing as it makes it hard to reproduce a run, and also throws off wandb's Bayesian sweep algorithm.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved stability in the Weights & Biases (wandb) sweeping process within YOLOv5 repo.

### 📊 Key Changes
- Modified the method of obtaining hyperparameters (`hyp_dict`) from the wandb sweep agent to include a `.copy()` operation.

### 🎯 Purpose & Impact
- This change ensures that there are no unexpected behaviors during parameter sweeps, as `train()` modifies parameters that could confuse wandb if the dictionary is not copied.
- Users conducting hyperparameter sweeps with wandb will experience more reliable and consistent logging and parameter handling. 🛠️