### PR TITLE
Add `python benchmarks.py --test` for export-only

### DIFF
--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -52,20 +52,26 @@ def run(
         data=ROOT / 'data/coco128.yaml',  # dataset.yaml path
         device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
         half=False,  # use FP16 half-precision inference
+        test=False,  # test exports only
 ):
     y, t = [], time.time()
     formats = export.export_formats()
     device = select_device(device)
     for i, (name, f, suffix, gpu) in formats.iterrows():  # index, (name, file, suffix, gpu-capable)
         try:
-            assert i < 9, 'Edge TPU and TF.js not supported'
+            assert i != 9, 'Edge TPU not supported'
+            assert i != 10, 'TF.js not supported'
             if device.type != 'cpu':
                 assert gpu, f'{name} inference not supported on GPU'
+
+            # Export
             if f == '-':
                 w = weights  # PyTorch format
             else:
                 w = export.run(weights=weights, imgsz=[imgsz], include=[f], device=device, half=half)[-1]  # all others
             assert suffix in str(w), 'export failed'
+
+            # Validate
             result = val.run(data, w, batch_size, imgsz, plots=False, device=device, task='benchmark', half=half)
             metrics = result[0]  # metrics (mp, mr, map50, map, *losses(box, obj, cls))
             speeds = result[2]  # times (preprocess, inference, postprocess)
@@ -78,8 +84,39 @@ def run(
     LOGGER.info('\n')
     parse_opt()
     notebook_init()  # print system info
-    py = pd.DataFrame(y, columns=['Format', 'mAP@0.5:0.95', 'Inference time (ms)'])
+    py = pd.DataFrame(y, columns=['Format', 'mAP@0.5:0.95', 'Inference time (ms)'] if map else ['Format', 'Export', ''])
     LOGGER.info(f'\nBenchmarks complete ({time.time() - t:.2f}s)')
+    LOGGER.info(str(py if map else py.iloc[:, :2]))
+    return py
+
+
+def test(
+        weights=ROOT / 'yolov5s.pt',  # weights path
+        imgsz=640,  # inference size (pixels)
+        batch_size=1,  # batch size
+        data=ROOT / 'data/coco128.yaml',  # dataset.yaml path
+        device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
+        half=False,  # use FP16 half-precision inference
+        test=False,  # test exports only
+):
+    y, t = [], time.time()
+    formats = export.export_formats()
+    device = select_device(device)
+    for i, (name, f, suffix, gpu) in formats.iterrows():  # index, (name, file, suffix, gpu-capable)
+        try:
+            w = weights if f == '-' else \
+                export.run(weights=weights, imgsz=[imgsz], include=[f], device=device, half=half)[-1]  # weights
+            assert suffix in str(w), 'export failed'
+            y.append([name, True])
+        except Exception as e:
+            y.append([name, False])  # mAP, t_inference
+
+    # Print results
+    LOGGER.info('\n')
+    parse_opt()
+    notebook_init()  # print system info
+    py = pd.DataFrame(y, columns=['Format', 'Export'])
+    LOGGER.info(f'\nExports complete ({time.time() - t:.2f}s)')
     LOGGER.info(str(py))
     return py
 
@@ -92,13 +129,14 @@ def parse_opt():
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
+    parser.add_argument('--test', action='store_true', help='test exports only')
     opt = parser.parse_args()
     print_args(vars(opt))
     return opt
 
 
 def main(opt):
-    run(**vars(opt))
+    test(**vars(opt)) if opt.test else run(**vars(opt))
 
 
 if __name__ == "__main__":

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -108,7 +108,7 @@ def test(
                 export.run(weights=weights, imgsz=[imgsz], include=[f], device=device, half=half)[-1]  # weights
             assert suffix in str(w), 'export failed'
             y.append([name, True])
-        except Exception as e:
+        except Exception:
             y.append([name, False])  # mAP, t_inference
 
     # Print results


### PR DESCRIPTION
Export tests. CPU example. @kalenmike 

### Colab Pro+ CPU
```bash
$ python utils/benchmarks.py --weights yolov5n.pt --test --device cpu

benchmarks: weights=yolov5n.pt, imgsz=640, batch_size=1, data=/content/yolov5/data/coco128.yaml, device=cpu, half=False, test=True
Checking setup...
YOLOv5 🚀 v6.1-117-g7e47852 torch 1.10.0+cu111 CPU
Setup complete ✅ (8 CPUs, 51.0 GB RAM, 42.5/166.8 GB disk)

Exports complete (219.55s)
                   Format  Export
0                 PyTorch    True
1             TorchScript    True
2                    ONNX    True
3                OpenVINO    True
4                TensorRT   False
5                  CoreML    True
6   TensorFlow SavedModel    True
7     TensorFlow GraphDef    True
8         TensorFlow Lite    True
9     TensorFlow Edge TPU    True
10          TensorFlow.js    True
```

### Colab Pro+ GPU
```bash
$ python utils/benchmarks.py --weights yolov5n.pt --test --device 0

benchmarks: weights=yolov5n.pt, imgsz=640, batch_size=1, data=/content/yolov5/data/coco128.yaml, device=0, half=False, test=True
Checking setup...
YOLOv5 🚀 v6.1-117-g7e47852 torch 1.10.0+cu111 CUDA:0 (Tesla V100-SXM2-16GB, 16160MiB)
Setup complete ✅ (8 CPUs, 51.0 GB RAM, 47.2/166.8 GB disk)

Exports complete (636.24s)
                   Format  Export
0                 PyTorch    True
1             TorchScript    True
2                    ONNX    True
3                OpenVINO    True
4                TensorRT    True
5                  CoreML   False
6   TensorFlow SavedModel    True
7     TensorFlow GraphDef    True
8         TensorFlow Lite    True
9     TensorFlow Edge TPU    True
10          TensorFlow.js    True
```


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements and new features added to the benchmarking and exporting capabilities of YOLOv5 models.

### 📊 Key Changes
- Added a new `test` flag to the benchmarking script to test model exports exclusively.
- Refined assertions for better handling and support checking for Edge TPU and TF.js export formats.
- Introduced a new function `test()` which tests only the exports, providing faster feedback on export validity.
- Enhanced logging with clear information whether the tests were on benchmarks or just exports.
- Both benchmark and export tests now have structured output in DataFrame form for post-process analysis and logging.

### 🎯 Purpose & Impact
- 🎛 The `test` flag and its associated `test()` function allow developers to quickly verify the export process without running full benchmarks, increasing efficiency.
- 🔧 Better assertions and structured error messages offer improved developer experience by quickly identifying non-supported export formats for certain devices.
- ⏱ Enhanced DataFrame outputs help in better tracking and understanding the performance and success of model exports.
- 🚀 Overall, this PR aims to streamline the development workflow, reducing the time needed to test and verify model export functionality, and enabling sharper focus on model deployment readiness.