### PR TITLE
Add ONNX export metadata

### DIFF
--- a/export.py
+++ b/export.py
@@ -140,7 +140,13 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
         # Checks
         model_onnx = onnx.load(f)  # load onnx model
         onnx.checker.check_model(model_onnx)  # check onnx model
-        # LOGGER.info(onnx.helper.printable_graph(model_onnx.graph))  # print
+
+        # Metadata
+        d = {'stride': int(max(model.stride)), 'names': model.names}
+        for k, v in d.items():
+            meta = model_onnx.metadata_props.add()
+            meta.key, meta.value = k, str(v)
+        onnx.save(model_onnx, f)
 
         # Simplify
         if simplify:

--- a/models/common.py
+++ b/models/common.py
@@ -328,6 +328,9 @@ class DetectMultiBackend(nn.Module):
             import onnxruntime
             providers = ['CUDAExecutionProvider', 'CPUExecutionProvider'] if cuda else ['CPUExecutionProvider']
             session = onnxruntime.InferenceSession(w, providers=providers)
+            meta = session.get_modelmeta().custom_metadata_map  # metadata
+            if 'stride' in meta:
+                stride, names = int(meta['stride']), eval(meta['names'])
         elif xml:  # OpenVINO
             LOGGER.info(f'Loading {w} for OpenVINO inference...')
             check_requirements(('openvino-dev',))  # requires openvino-dev: https://pypi.org/project/openvino-dev/


### PR DESCRIPTION
Adds stride and names to ONNX export metadata for reading during inference. Resolves #7342, https://github.com/ultralytics/yolov5/issues/7351

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced ONNX model export with metadata and improved model loading with custom metadata handling.

### 📊 Key Changes
- 🏷️ Added custom metadata properties (such as 'stride' and 'names') to the ONNX model during export.
- 📚 ONNX models now store additional information within their metadata properties.
- 🧠 Updated the model loading code to parse and utilize the new metadata when models are loaded using ONNX runtime.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: The inclusion of metadata in the ONNX models allows for more information to be packaged with the model itself, improving model portability and ease of use.
- 🔍 **Impact**: Users can benefit from the additional model metadata, leading to more informed and potentially optimized model deployment, especially in environments where model parameters like stride are important for integration.
- 🔄 Users relying on ONNX models from YOLOv5 will notice more robust integration with external tools due to enriched model metadata.