### PR TITLE
Swap `unsafe_chunk()` for `chunk()`

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -220,7 +220,7 @@ class ComputeLoss:
                 offsets = 0
 
             # Define
-            bc, gxy, gwh, a = t.unsafe_chunk(4, dim=1)  # (image, class), grid xy, grid wh, anchors
+            bc, gxy, gwh, a = t.chunk(4, 1)  # (image, class), grid xy, grid wh, anchors
             a, (b, c) = a.long().view(-1), bc.long().T  # anchors, image, class
             gij = (gxy - offsets).long()
             gi, gj = gij.T  # grid indices


### PR DESCRIPTION
Eliminates all unsafe function in YOLOv5 out of an abundance of caution.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved safety in anchor chunking during target building in YOLOv5 loss calculation.

### 📊 Key Changes
- Replaced `unsafe_chunk` with `chunk` in the `build_targets` method within `utils/loss.py`.

### 🎯 Purpose & Impact
- 🛡️ **Enhanced Safety**: The change from `unsafe_chunk` to `chunk` avoids potential out-of-bounds memory access, which can lead to undefined behavior.
- ✨ **Reliability**: Ensures the target-building process in loss computation is more reliable across various environments and input data scenarios.
- 🚀 **User Trust**: Users can trust that their models are trained with robust and error-resistant code, likely reducing bugs and training issues.