### PR TITLE
Replace Slack with Community Forum in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Slack
-    url: https://join.slack.com/t/ultralytics/shared_invite/zt-w29ei8bp-jczz7QYUmDtgo6r6KcMIAg
-    about: Ask on Ultralytics Slack Forum
+  - name: 💬 Forum
+    url: https://community.ultralytics.com/
+    about: Ask on Ultralytics Community Forum
   - name: Stack Overflow
     url: https://stackoverflow.com/search?q=YOLOv5
     about: Ask on Stack Overflow with 'YOLOv5' tag


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to issue reporting channels to direct users to the Ultralytics Community Forum.

### 📊 Key Changes
- Removed Slack contact link for issue reporting.
- Added a new contact link for the Ultralytics Community Forum.

### 🎯 Purpose & Impact
- **Purpose:** To streamline user support by guiding them to the newly established community forum rather than using Slack.
- **Impact:** Users reporting issues or seeking help will now be directed to a dedicated forum which could offer better-structured support and community engagement. 🧑‍🤝‍🧑