### PR TITLE
Add version warning for wandb

### DIFF
--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -83,8 +83,8 @@ class Loggers():
             self.wandb = WandbLogger(self.opt, run_id)
             # temp warn. because nested artifacts not supported after 0.12.10
             if pkg.parse_version(wandb.__version__) >= pkg.parse_version('0.12.11'):
-                self.logger.info(
-                    "yolov5 uses wandb version 0.12.10 or below. Some features might not work as expected!")
+                self.logger.warning(
+                    "YOLOv5 temporarily requires wandb version 0.12.10 or below. Some features might not work as expected.")
         else:
             self.wandb = None
 

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -84,8 +84,7 @@ class Loggers():
             # temp warn. because nested artifacts not supported after 0.12.10
             if pkg.parse_version(wandb.__version__) >= pkg.parse_version('0.12.11'):
                 self.logger.warning(
-                    "YOLOv5 temporarily requires wandb version 0.12.10 or below. Some features might not work as expected."
-                )
+                    "YOLOv5 temporarily requires wandb version 0.12.10 or below. Some features may not work as expected.")
         else:
             self.wandb = None
 

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -84,7 +84,8 @@ class Loggers():
             # temp warn. because nested artifacts not supported after 0.12.10
             if pkg.parse_version(wandb.__version__) >= pkg.parse_version('0.12.11'):
                 self.logger.warning(
-                    "YOLOv5 temporarily requires wandb version 0.12.10 or below. Some features may not work as expected.")
+                    "YOLOv5 temporarily requires wandb version 0.12.10 or below. Some features may not work as expected."
+                )
         else:
             self.wandb = None
 

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -84,7 +84,8 @@ class Loggers():
             # temp warn. because nested artifacts not supported after 0.12.10
             if pkg.parse_version(wandb.__version__) >= pkg.parse_version('0.12.11'):
                 self.logger.warning(
-                    "YOLOv5 temporarily requires wandb version 0.12.10 or below. Some features might not work as expected.")
+                    "YOLOv5 temporarily requires wandb version 0.12.10 or below. Some features might not work as expected."
+                )
         else:
             self.wandb = None
 

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -81,6 +81,9 @@ class Loggers():
             run_id = torch.load(self.weights).get('wandb_id') if self.opt.resume and not wandb_artifact_resume else None
             self.opt.hyp = self.hyp  # add hyperparameters
             self.wandb = WandbLogger(self.opt, run_id)
+            # temp warn. because nested artifacts not supported after 0.12.10
+            if pkg.parse_version(wandb.__version__) >= pkg.parse_version('0.12.11'):
+                self.logger.info("yolov5 uses wandb version 0.12.10 or below. Some features might not work as expected!")
         else:
             self.wandb = None
 

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -83,7 +83,8 @@ class Loggers():
             self.wandb = WandbLogger(self.opt, run_id)
             # temp warn. because nested artifacts not supported after 0.12.10
             if pkg.parse_version(wandb.__version__) >= pkg.parse_version('0.12.11'):
-                self.logger.info("yolov5 uses wandb version 0.12.10 or below. Some features might not work as expected!")
+                self.logger.info(
+                    "yolov5 uses wandb version 0.12.10 or below. Some features might not work as expected!")
         else:
             self.wandb = None
 


### PR DESCRIPTION
This PR adds warning if wandb version is higher than 0.12.10. There's a regression causing resume from artifacts to not work in versions greater than 0.12.10. While we get it fixed in the client, it's better to warn users.

Fixes - https://github.com/ultralytics/yolov5/issues/7077

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging to warn users of compatibility issues with newer wandb versions 🚦

### 📊 Key Changes
- Added a warning message that triggers if the wandb version is `0.12.11` or newer.
- The warning informs users that YOLOv5 currently requires version `0.12.10` of wandb or below for full compatibility.

### 🎯 Purpose & Impact
- This update is aimed at preventing potential issues that users may encounter when using incompatible versions of wandb with YOLOv5.
- Users will benefit from knowing they should stick to an earlier version of wandb to ensure all features of YOLOv5 work as expected. This proactive communication can save time troubleshooting and preserve a smooth user experience. 🛠️