### PR TITLE
Remove OpenVINO ONNX `opset<=12` check

### DIFF
--- a/export.py
+++ b/export.py
@@ -473,7 +473,6 @@ def run(
 
     # Checks
     imgsz *= 2 if len(imgsz) == 1 else 1  # expand
-    opset = 12 if ('openvino' in include) else opset  # OpenVINO requires opset <= 12
     assert nc == len(names), f'Model class count {nc} != len(names) {len(names)}'
 
     # Input


### PR DESCRIPTION
No longer needed.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplification of export conditions in `export.py`.

### 📊 Key Changes
- Removed the line of code that forces the OpenVINO model export to use ONNX opset version 12.

### 🎯 Purpose & Impact
- The goal is to streamline the export process by not explicitly limiting the OpenVINO export to a specific ONNX opset.
- Impact to users includes potentially greater flexibility and compatibility with various versions of OpenVINO without being restricted to opset 12.
- Developers may see a simplified codebase, making maintenance and further development easier.
- Users may need to ensure their OpenVINO setup is compatible with the opset version used by YOLOv5 for successful model deployment.