### PR TITLE
Fix EdgeTPU output directory

### DIFF
--- a/export.py
+++ b/export.py
@@ -387,7 +387,7 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
         f = str(file).replace('.pt', '-int8_edgetpu.tflite')  # Edge TPU model
         f_tfl = str(file).replace('.pt', '-int8.tflite')  # TFLite model
 
-        cmd = f"edgetpu_compiler -s {f_tfl}"
+        cmd = f"edgetpu_compiler -s -o {file.parent} {f_tfl} "
         subprocess.run(cmd, shell=True, check=True)
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')

--- a/export.py
+++ b/export.py
@@ -387,7 +387,7 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
         f = str(file).replace('.pt', '-int8_edgetpu.tflite')  # Edge TPU model
         f_tfl = str(file).replace('.pt', '-int8.tflite')  # TFLite model
 
-        cmd = f"edgetpu_compiler -s -o {file.parent} {f_tfl} "
+        cmd = f"edgetpu_compiler -s -o {file.parent} {f_tfl}"
         subprocess.run(cmd, shell=True, check=True)
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')


### PR DESCRIPTION
Outputs to same directory as `--weights`


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Edge TPU model export functionality in `export.py`.

### 📊 Key Changes
- Modified the `edgetpu_compiler` command to specify the output directory for the compiled Edge TPU model.

### 🎯 Purpose & Impact
- 🎯 **Purpose:** 
  - Ensures the Edge TPU compiled models are saved in the same directory as the source model, making it easier for users to locate their files.
- 🚀 **Impact:**
  - Users will benefit from better file organization and a more streamlined export process when working with Edge TPU models, resulting in a smoother development and deployment experience.