### PR TITLE
Filter ONNX `prim::Constant type is missing` warnings

### DIFF
--- a/export.py
+++ b/export.py
@@ -117,6 +117,10 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
         LOGGER.info(f'\n{prefix} starting export with onnx {onnx.__version__}...')
         f = file.with_suffix('.onnx')
 
+        warnings.filterwarnings('ignore',
+                                'The shape inference of prim::Constant type is missing, so it may result in wrong shape'
+                                ' inference for the exported graph. Please consider adding it in symbolic function.')
+
         torch.onnx.export(
             model,
             im,

--- a/export.py
+++ b/export.py
@@ -117,9 +117,9 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
         LOGGER.info(f'\n{prefix} starting export with onnx {onnx.__version__}...')
         f = file.with_suffix('.onnx')
 
-        warnings.filterwarnings(
-            'ignore', 'The shape inference of prim::Constant type is missing, so it may result in wrong shape'
-            ' inference for the exported graph. Please consider adding it in symbolic function.')
+        s = 'WARNING: The shape inference of prim::Constant type is missing, so it may result in wrong shape ' \
+            'inference for the exported graph. Please consider adding it in symbolic function.'
+        warnings.filterwarnings(action='ignore', message=s)
 
         torch.onnx.export(
             model,

--- a/export.py
+++ b/export.py
@@ -117,9 +117,9 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
         LOGGER.info(f'\n{prefix} starting export with onnx {onnx.__version__}...')
         f = file.with_suffix('.onnx')
 
-        warnings.filterwarnings('ignore',
-                                'The shape inference of prim::Constant type is missing, so it may result in wrong shape'
-                                ' inference for the exported graph. Please consider adding it in symbolic function.')
+        warnings.filterwarnings(
+            'ignore', 'The shape inference of prim::Constant type is missing, so it may result in wrong shape'
+            ' inference for the exported graph. Please consider adding it in symbolic function.')
 
         torch.onnx.export(
             model,


### PR DESCRIPTION
Warnings not useful, attempting to filter so they don't appear on ONNX opset>=13 export.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved ONNX export handling by suppressing specific shape inference warnings.

### 📊 Key Changes
- Added a filter to suppress specific warnings related to shape inference during ONNX export.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: The change aims to prevent a common warning about shape inference for `prim::Constant` when exporting models to ONNX format.
- 🧑‍💻 **Impact on Users**: Users will now experience a cleaner export process, with fewer distractions from non-critical warnings, potentially improving the user experience and reducing confusion.
- 📈 **Overall Impact**: Streamlined export procedure could encourage more users to utilize the ONNX format and benefit from its advantages in deployment.