### PR TITLE
Disable `pbar` for DDP ranks > 0

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -522,7 +522,7 @@ class LoadImagesAndLabels(Dataset):
             self.im_hw0, self.im_hw = [None] * n, [None] * n
             fcn = self.cache_images_to_disk if cache_images == 'disk' else self.load_image
             results = ThreadPool(NUM_THREADS).imap(fcn, range(n))
-            pbar = tqdm(enumerate(results), total=n, bar_format=BAR_FORMAT)
+            pbar = tqdm(enumerate(results), total=n, bar_format=BAR_FORMAT, disable=LOCAL_RANK > 0)
             for i, x in pbar:
                 if cache_images == 'disk':
                     gb += self.npy_files[i].stat().st_size


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved logging output for parallel data loading processes.

### 📊 Key Changes
- Modified progress bar display settings in `utils/datasets.py`.

### 🎯 Purpose & Impact
- The change aims to prevent multiple progress bars from cluttering the console when data is being loaded across different processes in parallel.
- Users will benefit from cleaner and more readable output especially when running distributed training across multiple local ranks, enhancing user experience. 📈