### PR TITLE
FP16 for Coreml using --half flag

### DIFF
--- a/export.py
+++ b/export.py
@@ -186,7 +186,7 @@ def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
         LOGGER.info(f'\n{prefix} export failure: {e}')
 
 
-def export_coreml(model, im, file, half,prefix=colorstr('CoreML:')):
+def export_coreml(model, im, file, half, prefix=colorstr('CoreML:')):
     # YOLOv5 CoreML export
     try:
         check_requirements(('coremltools',))
@@ -197,7 +197,7 @@ def export_coreml(model, im, file, half,prefix=colorstr('CoreML:')):
 
         ts = torch.jit.trace(model, im, strict=False)  # TorchScript model
         ct_model = ct.convert(ts, inputs=[ct.ImageType('image', shape=im.shape, scale=1 / 255, bias=[0, 0, 0])])
-        if half : 
+        if half:
             ct_model = quantization_utils.quantize_weights(ct_model, nbits=16)
         ct_model.save(f)
 
@@ -468,7 +468,8 @@ def run(
 
     # Load PyTorch model
     device = select_device(device)
-    assert not ((device.type == 'cpu' and not coreml) and half), '--half only compatible with GPU export, i.e. use --device 0'
+    assert not ((device.type == 'cpu' and not coreml)
+                and half), '--half only compatible with GPU export, i.e. use --device 0'
     model = attempt_load(weights, map_location=device, inplace=True, fuse=True)  # load FP32 model
     nc, names = model.nc, model.names  # number of classes, class names
 
@@ -508,7 +509,7 @@ def run(
     if xml:  # OpenVINO
         f[3] = export_openvino(model, im, file)
     if coreml:
-        _, f[4] = export_coreml(model, im, file,half)
+        _, f[4] = export_coreml(model, im, file, half)
 
     # TensorFlow Exports
     if any((saved_model, pb, tflite, edgetpu, tfjs)):

--- a/export.py
+++ b/export.py
@@ -186,17 +186,19 @@ def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
         LOGGER.info(f'\n{prefix} export failure: {e}')
 
 
-def export_coreml(model, im, file, prefix=colorstr('CoreML:')):
+def export_coreml(model, im, file, half,prefix=colorstr('CoreML:')):
     # YOLOv5 CoreML export
     try:
         check_requirements(('coremltools',))
         import coremltools as ct
-
+        from coremltools.models.neural_network import quantization_utils
         LOGGER.info(f'\n{prefix} starting export with coremltools {ct.__version__}...')
         f = file.with_suffix('.mlmodel')
 
         ts = torch.jit.trace(model, im, strict=False)  # TorchScript model
         ct_model = ct.convert(ts, inputs=[ct.ImageType('image', shape=im.shape, scale=1 / 255, bias=[0, 0, 0])])
+        if half : 
+            ct_model = quantization_utils.quantize_weights(ct_model, nbits=16)
         ct_model.save(f)
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')
@@ -466,7 +468,7 @@ def run(
 
     # Load PyTorch model
     device = select_device(device)
-    assert not (device.type == 'cpu' and half), '--half only compatible with GPU export, i.e. use --device 0'
+    assert not ((device.type == 'cpu' and not coreml) and half), '--half only compatible with GPU export, i.e. use --device 0'
     model = attempt_load(weights, map_location=device, inplace=True, fuse=True)  # load FP32 model
     nc, names = model.nc, model.names  # number of classes, class names
 
@@ -480,7 +482,7 @@ def run(
     im = torch.zeros(batch_size, 3, *imgsz).to(device)  # image size(1,3,320,192) BCHW iDetection
 
     # Update model
-    if half:
+    if half and not coreml:
         im, model = im.half(), model.half()  # to FP16
     model.train() if train else model.eval()  # training mode = no Detect() layer grid construction
     for k, m in model.named_modules():
@@ -506,7 +508,7 @@ def run(
     if xml:  # OpenVINO
         f[3] = export_openvino(model, im, file)
     if coreml:
-        _, f[4] = export_coreml(model, im, file)
+        _, f[4] = export_coreml(model, im, file,half)
 
     # TensorFlow Exports
     if any((saved_model, pb, tflite, edgetpu, tfjs)):


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
The PR introduces an option to export YOLOv5 models to CoreML format with quantized weights for improved compatibility with mobile devices.

### 📊 Key Changes
- Added an option to perform weight quantization during CoreML model export.
- Updated the `export_coreml` function to include a `half` parameter, indicating whether to quantize the weights.
- Modified conditional checks to allow weight quantization `--half` flag usage when exporting to CoreML, even when using a CPU.

### 🎯 Purpose & Impact
- 🎈 **Purpose**: The changes aim to reduce the size of the CoreML models, potentially leading to better performance on mobile devices by supporting 16-bit weight quantization.
- 🚀 **Impact**: Users can now export lighter and possibly more efficient CoreML models, making this function more useful for developers targeting iOS devices with limited resources.
- ✅ **Compatibility**: These changes ensure that the `--half` flag can be used during export to CoreML on CPUs, increasing the flexibility of the export process.