### PR TITLE
Add `--half` support for FP16 CoreML exports with

### DIFF
--- a/export.py
+++ b/export.py
@@ -468,8 +468,8 @@ def run(
 
     # Load PyTorch model
     device = select_device(device)
-    assert not ((device.type == 'cpu' and not coreml)
-                and half), '--half only compatible with GPU export, i.e. use --device 0'
+    if half:
+        assert device.type != 'cpu' or coreml, '--half only compatible with GPU export, i.e. use --device 0'
     model = attempt_load(weights, map_location=device, inplace=True, fuse=True)  # load FP32 model
     nc, names = model.nc, model.names  # number of classes, class names
 

--- a/export.py
+++ b/export.py
@@ -191,7 +191,7 @@ def export_coreml(model, im, file, int8, half, prefix=colorstr('CoreML:')):
     try:
         check_requirements(('coremltools',))
         import coremltools as ct
-        
+
         LOGGER.info(f'\n{prefix} starting export with coremltools {ct.__version__}...')
         f = file.with_suffix('.mlmodel')
 

--- a/export.py
+++ b/export.py
@@ -19,10 +19,10 @@ TensorFlow.js               | `tfjs`                        | yolov5s_web_model/
 Requirements:
     $ pip install -r requirements.txt coremltools onnx onnx-simplifier onnxruntime openvino-dev tensorflow-cpu  # CPU
     $ pip install -r requirements.txt coremltools onnx onnx-simplifier onnxruntime-gpu openvino-dev tensorflow  # GPU
-    
+
 Usage:
     $ python path/to/export.py --weights yolov5s.pt --include torchscript onnx openvino engine coreml tflite ...
-    
+
 Inference:
     $ python path/to/detect.py --weights yolov5s.pt                 # PyTorch
                                          yolov5s.torchscript        # TorchScript
@@ -34,7 +34,7 @@ Inference:
                                          yolov5s.pb                 # TensorFlow GraphDef
                                          yolov5s.tflite             # TensorFlow Lite
                                          yolov5s_edgetpu.tflite     # TensorFlow Edge TPU
-                                         
+
 TensorFlow.js:
     $ cd .. && git clone https://github.com/zldrobit/tfjs-yolov5-example.git && cd tfjs-yolov5-example
     $ npm install
@@ -186,7 +186,7 @@ def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
         LOGGER.info(f'\n{prefix} export failure: {e}')
 
 
-def export_coreml(model, im, file, half,prefix=colorstr('CoreML:')):
+def export_coreml(model, im, file, half, prefix=colorstr('CoreML:')):
     # YOLOv5 CoreML export
     try:
         check_requirements(('coremltools',))
@@ -197,7 +197,7 @@ def export_coreml(model, im, file, half,prefix=colorstr('CoreML:')):
 
         ts = torch.jit.trace(model, im, strict=False)  # TorchScript model
         ct_model = ct.convert(ts, inputs=[ct.ImageType('image', shape=im.shape, scale=1 / 255, bias=[0, 0, 0])])
-        if half : 
+        if half:
             ct_model = quantization_utils.quantize_weights(ct_model, nbits=16)
         ct_model.save(f)
 
@@ -468,7 +468,7 @@ def run(
 
     # Load PyTorch model
     device = select_device(device)
-    assert not ((device.type == 'cpu' and not coreml) 
+    assert not ((device.type == 'cpu' and not coreml)
                 and half), '--half only compatible with GPU export, i.e. use --device 0'
     model = attempt_load(weights, map_location=device, inplace=True, fuse=True)  # load FP32 model
     nc, names = model.nc, model.names  # number of classes, class names
@@ -509,7 +509,7 @@ def run(
     if xml:  # OpenVINO
         f[3] = export_openvino(model, im, file)
     if coreml:
-        _, f[4] = export_coreml(model, im, file,half)
+        _, f[4] = export_coreml(model, im, file, half)
 
     # TensorFlow Exports
     if any((saved_model, pb, tflite, edgetpu, tfjs)):

--- a/export.py
+++ b/export.py
@@ -191,6 +191,7 @@ def export_coreml(model, im, file, int8, half, prefix=colorstr('CoreML:')):
     try:
         check_requirements(('coremltools',))
         import coremltools as ct
+        
         LOGGER.info(f'\n{prefix} starting export with coremltools {ct.__version__}...')
         f = file.with_suffix('.mlmodel')
 

--- a/export.py
+++ b/export.py
@@ -84,7 +84,7 @@ def export_formats():
         ['TensorFlow GraphDef', 'pb', '.pb', True],
         ['TensorFlow Lite', 'tflite', '.tflite', False],
         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False],
-        ['TensorFlow.js', 'tfjs', '_web_model', False], ]
+        ['TensorFlow.js', 'tfjs', '_web_model', False],]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'GPU'])
 
 
@@ -427,9 +427,9 @@ def export_tfjs(keras_model, im, file, prefix=colorstr('TensorFlow.js:')):
                 r'"Identity.?.?": {"name": "Identity.?.?"}, '
                 r'"Identity.?.?": {"name": "Identity.?.?"}, '
                 r'"Identity.?.?": {"name": "Identity.?.?"}}}', r'{"outputs": {"Identity": {"name": "Identity"}, '
-                                                               r'"Identity_1": {"name": "Identity_1"}, '
-                                                               r'"Identity_2": {"name": "Identity_2"}, '
-                                                               r'"Identity_3": {"name": "Identity_3"}}}', json)
+                r'"Identity_1": {"name": "Identity_1"}, '
+                r'"Identity_2": {"name": "Identity_2"}, '
+                r'"Identity_3": {"name": "Identity_3"}}}', json)
             j.write(subst)
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved CoreML model export with optional quantization.

### 📊 Key Changes
- Added `int8` and `half` arguments to `export_coreml()` function enabling weight quantization.
- Wrapped the CoreML weight quantization code with a check for macOS, as quantization is only supported on that OS.
- Updated the `run()` function to conditionally enable FP16 (`half`) mode based on whether CoreML export is enabled.
- Conditionally run weight quantization depending on the presence of `int8` or `half` flags and the operating system.

### 🎯 Purpose & Impact
- 🔍 **Purpose**: This update aims to provide users with the ability to export CoreML models with reduced size and potentially improved performance on devices by using weight quantization (either 8-bit or 16-bit precision).
- ⚡ **Impact**: Users exporting YOLOv5 models to CoreML format can now choose to quantize their models, leading to more efficient models especially suitable for mobile and edge devices. However, the quantization features are limited to macOS users due to platform restrictions.