### PR TITLE
val.py os.sep is more general

### DIFF
--- a/export.py
+++ b/export.py
@@ -123,7 +123,7 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
                           do_constant_folding=not train,
                           input_names=['images'],
                           output_names=['output'],
-                          dynamic_axes={'images': {0: 'batch', 2: 'height', 3: 'width'},  # shape(1,3,640,640)
+                          dynamic_axes={'images': {0: 'batch', 1: 'height', 2: 'width'},  # shape(1,3,640,640)
                                         'output': {0: 'batch', 1: 'anchors'}  # shape(1,25200,85)
                                         } if dynamic else None)
 


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

I run yolov5 train.py in cocodataset.
in val.py def run()
```python
data['val'] = 'D:\\datasets\\coco\\val2017.txt'

is_coco = isinstance(data.get('val'), str) and data['val'].endswith('coco/val2017.txt')
-->>
is_coco = isinstance(data.get('val'), str) and data['val'].endswith('coco'+os.sep+'val2017.txt')
```
for window's understanding!!

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved ONNX export support for dynamic input shapes.

### 📊 Key Changes
- Modified the dynamic_axes parameter in the ONNX export settings.
- The `height` and `width` axes indices for 'images' were updated from `{2: 'height', 3: 'width'}` to `{1: 'height', 2: 'width'}`.

### 🎯 Purpose & Impact
- This change aims to correct the axis specification for dynamic image sizes in ONNX exports.
- Users exporting their models to ONNX will experience more accurate handling of varying image sizes, which can be especially beneficial for deployment on different platforms where input dimensions may change. 🔄
- The impact is likely to improve the compatibility and flexibility of YOLOv5 models in production environments. 🚀