### PR TITLE
`check_fonts()` download to `CONFIG_DIR` fix

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -427,10 +427,11 @@ def check_file(file, suffix=''):
 def check_font(font=FONT, progress=False):
     # Download font to CONFIG_DIR if necessary
     font = Path(font)
-    if not font.exists() and not (CONFIG_DIR / font.name).exists():
+    file = CONFIG_DIR / font.name
+    if not font.exists() and not file.exists():
         url = "https://ultralytics.com/assets/" + font.name
-        LOGGER.info(f'Downloading {url} to {CONFIG_DIR / font.name}...')
-        torch.hub.download_url_to_file(url, str(font), progress=progress)
+        LOGGER.info(f'Downloading {url} to {file}...')
+        torch.hub.download_url_to_file(url, str(file), progress=progress)
 
 
 def check_dataset(data, autodownload=True):


### PR DESCRIPTION
Follows https://github.com/ultralytics/yolov5/pull/7488. Correct bug where fonts were downloading to current working directory rather than global CONFIG_DIR


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved font file handling in Ultralytics' YOLOv5 utility functions.

### 📊 Key Changes
- Font file existence check now uses a consolidated `file` variable.
- Download log message now references `file` directly.

### 🎯 Purpose & Impact
- ✨ **Simplified code:** Makes the function slightly cleaner and more readable.
- 🛠️ **Consistent logging:** Ensures the correct file path is displayed when downloading the font file.
- 🚀 **User experience:** Users are better informed about where the font file is being downloaded to, enhancing clarity.