### PR TITLE
Added `YOLOv5_AUTOINSTALL` environment variable

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -40,6 +40,7 @@ FILE = Path(__file__).resolve()
 ROOT = FILE.parents[1]  # YOLOv5 root directory
 DATASETS_DIR = ROOT.parent / 'datasets'  # YOLOv5 datasets directory
 NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLOv5 multiprocessing threads
+AUTOINSTALL = str(os.getenv('YOLOv5_AUTOINSTALL', True)).lower() == 'true'  # global auto-install mode
 VERBOSE = str(os.getenv('YOLOv5_VERBOSE', True)).lower() == 'true'  # global verbose mode
 FONT = 'Arial.ttf'  # https://ultralytics.com/assets/Arial.ttf
 
@@ -322,8 +323,6 @@ def check_version(current='0.0.0', minimum='0.0.0', name='version ', pinned=Fals
 @try_except
 def check_requirements(requirements=ROOT / 'requirements.txt', exclude=(), install=True):
     # Check installed dependencies meet requirements (pass *.txt file or list of packages)
-    if os.environ.get('YOLOv5_AUTOINSTALL').lower() == 'false':
-        install = False
     prefix = colorstr('red', 'bold', 'requirements:')
     check_python()  # check python version
     if isinstance(requirements, (str, Path)):  # requirements.txt file
@@ -340,7 +339,7 @@ def check_requirements(requirements=ROOT / 'requirements.txt', exclude=(), insta
             pkg.require(r)
         except Exception:  # DistributionNotFound or VersionConflict if requirements not met
             s = f"{prefix} {r} not found and is required by YOLOv5"
-            if install:
+            if install and AUTOINSTALL:  # check environment variable
                 LOGGER.info(f"{s}, attempting auto-update...")
                 try:
                     assert check_online(), f"'pip install {r}' skipped (offline)"

--- a/utils/general.py
+++ b/utils/general.py
@@ -322,6 +322,8 @@ def check_version(current='0.0.0', minimum='0.0.0', name='version ', pinned=Fals
 @try_except
 def check_requirements(requirements=ROOT / 'requirements.txt', exclude=(), install=True):
     # Check installed dependencies meet requirements (pass *.txt file or list of packages)
+    if os.environ.get('YOLOv5_AUTOINSTALL').lower() == 'false':
+        install = False
     prefix = colorstr('red', 'bold', 'requirements:')
     check_python()  # check python version
     if isinstance(requirements, (str, Path)):  # requirements.txt file


### PR DESCRIPTION
Setting the environment variable `YOLOv5_AUTOINSTALL=False` will skip installing any missing dependencies as if the user had passed `install=False` to `check_requirements`.

See discussion #7472 for details.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced control over automatic dependencies installation in YOLOv5.

### 📊 Key Changes
- A new `AUTOINSTALL` global variable was introduced.
- Conditional check for auto-installation of requirements based on the `AUTOINSTALL` environment variable.

### 🎯 Purpose & Impact
- 🎛️ **Purpose**: The change allows users to control whether dependencies should be automatically installed by setting an environment variable `YOLOv5_AUTOINSTALL`.
- 🔧 **Impact**: Developers who prefer manual control over their environment can disable auto-install. Users can expect more predictable behavior in environments where automatic changes are restricted or not desired.