### PR TITLE
Add yesqa to precommit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,8 +62,3 @@ repos:
     hooks:
       - id: flake8
         name: PEP8
-
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.2.4
-    hooks:
-      - id: python-safety-dependencies-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,14 +52,18 @@ repos:
   #        - mdformat-black
   #        - mdformat_frontmatter
 
-  # TODO
-  #- repo: https://github.com/asottile/yesqa
-  #  rev: v1.2.3
-  #  hooks:
-  #    - id: yesqa
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.3.0
+    hooks:
+      - id: yesqa
 
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8
         name: PEP8
+
+  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
+    rev: v1.2.4
+    hooks:
+      - id: python-safety-dependencies-check


### PR DESCRIPTION
I fixed yesqa.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Integration of yesqa tool to manage Python code's 'noqa' comments.

### 📊 Key Changes
- Un-commented the yesqa configuration in the `.pre-commit-config.yaml` file, making it an active part of the pre-commit checks.
- Updated the yesqa tool to version `v1.3.0`.

### 🎯 Purpose & Impact
- **Enhanced Code Quality:** Aids in the automatic removal of unnecessary `# noqa` comments, ensuring they're only used when required.
- **Streamlined Development:** Improves the pre-commit process, offering developers a cleaner code base and assisting with maintaining coding standards.
- **User Benefit:** Developers working on the Ultralytics/yolov5 codebase will experience less clutter and better adherence to Python coding conventions.