### PR TITLE
Fix val `plots=plots`

### DIFF
--- a/train.py
+++ b/train.py
@@ -461,7 +461,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                         save_dir=save_dir,
                         save_json=is_coco,
                         verbose=True,
-                        plots=True,
+                        plots=plots,
                         callbacks=callbacks,
                         compute_loss=compute_loss)  # val best model with plots
                     if is_coco:


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced customization of validation plots during training in YOLOv5.

### 📊 Key Changes
- The `plots` parameter within the `train.py` script can now be dynamically set, rather than being hardcoded to `True`.

### 🎯 Purpose & Impact
- This change allows developers and users to specify whether they want to generate validation plots during model training. It offers greater flexibility and can potentially speed up training when plots are not needed.
- Users can now decide if they want to allocate resources to plotting, which may be beneficial in constrained environments or when running numerous training experiments. 🚀
- The ability to toggle plot generation can lead to reduced overhead, particularly useful during automated or large-scale training runs. 📉