### PR TITLE
Add `--noplots` flag to suppress figures and images logging

### DIFF
--- a/train.py
+++ b/train.py
@@ -100,7 +100,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
             callbacks.register_action(k, callback=getattr(loggers, k))
 
     # Config
-    plots = not evolve and not opt.nomedia  # create plots
+    plots = not evolve and not opt.noplots  # create plots
     cuda = device.type != 'cpu'
     init_seeds(1 + RANK)
     with torch_distributed_zero_first(LOCAL_RANK):
@@ -488,6 +488,7 @@ def parse_opt(known=False):
     parser.add_argument('--nosave', action='store_true', help='only save final checkpoint')
     parser.add_argument('--noval', action='store_true', help='only validate final epoch')
     parser.add_argument('--noautoanchor', action='store_true', help='disable AutoAnchor')
+    parser.add_argument('--noplots', action='store_true', help='save no plot files')
     parser.add_argument('--evolve', type=int, nargs='?', const=300, help='evolve hyperparameters for x generations')
     parser.add_argument('--bucket', type=str, default='', help='gsutil bucket')
     parser.add_argument('--cache', type=str, nargs='?', const='ram', help='--cache images in "ram" (default) or "disk"')
@@ -508,7 +509,6 @@ def parse_opt(known=False):
     parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
-    parser.add_argument('--nomedia', action='store_true', help='Save no media files')
 
     # Weights & Biases arguments
     parser.add_argument('--entity', default=None, help='W&B: Entity')

--- a/train.py
+++ b/train.py
@@ -650,8 +650,7 @@ def main(opt, callbacks=Callbacks()):
             print_mutation(results, hyp.copy(), save_dir, opt.bucket)
 
         # Plot results
-        if not opt.nomedia:
-            plot_evolve(evolve_csv)
+        plot_evolve(evolve_csv)
         LOGGER.info(f'Hyperparameter evolution finished {opt.evolve} generations\n'
                     f"Results saved to {colorstr('bold', save_dir)}\n"
                     f'Usage example: $ python train.py --hyp {evolve_yaml}')

--- a/train.py
+++ b/train.py
@@ -100,7 +100,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
             callbacks.register_action(k, callback=getattr(loggers, k))
 
     # Config
-    plots = not evolve and not opt.nomedia # create plots
+    plots = not evolve and not opt.nomedia  # create plots
     cuda = device.type != 'cpu'
     init_seeds(1 + RANK)
     with torch_distributed_zero_first(LOCAL_RANK):

--- a/train.py
+++ b/train.py
@@ -508,6 +508,7 @@ def parse_opt(known=False):
     parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
+    parser.add_argument('--nomedia', action='store_true', help='save no media files')
 
     # Weights & Biases arguments
     parser.add_argument('--entity', default=None, help='W&B: Entity')
@@ -649,7 +650,8 @@ def main(opt, callbacks=Callbacks()):
             print_mutation(results, hyp.copy(), save_dir, opt.bucket)
 
         # Plot results
-        plot_evolve(evolve_csv)
+        if not opt.nomedia:
+            plot_evolve(evolve_csv)
         LOGGER.info(f'Hyperparameter evolution finished {opt.evolve} generations\n'
                     f"Results saved to {colorstr('bold', save_dir)}\n"
                     f'Usage example: $ python train.py --hyp {evolve_yaml}')

--- a/train.py
+++ b/train.py
@@ -100,7 +100,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
             callbacks.register_action(k, callback=getattr(loggers, k))
 
     # Config
-    plots = not evolve  # create plots
+    plots = not evolve and not opt.nomedia # create plots
     cuda = device.type != 'cpu'
     init_seeds(1 + RANK)
     with torch_distributed_zero_first(LOCAL_RANK):

--- a/train.py
+++ b/train.py
@@ -373,7 +373,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                 mem = f'{torch.cuda.memory_reserved() / 1E9 if torch.cuda.is_available() else 0:.3g}G'  # (GB)
                 pbar.set_description(('%10s' * 2 + '%10.4g' * 5) %
                                      (f'{epoch}/{epochs - 1}', mem, *mloss, targets.shape[0], imgs.shape[-1]))
-                callbacks.run('on_train_batch_end', ni, model, imgs, targets, paths, plots, opt.sync_bn)
+                callbacks.run('on_train_batch_end', ni, model, imgs, targets, paths, plots)
                 if callbacks.stop_training:
                     return
             # end batch ------------------------------------------------------------------------------------------------

--- a/train.py
+++ b/train.py
@@ -508,7 +508,7 @@ def parse_opt(known=False):
     parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
-    parser.add_argument('--nomedia', action='store_true', help='save no media files')
+    parser.add_argument('--nomedia', action='store_true', help='Save no media files')
 
     # Weights & Biases arguments
     parser.add_argument('--entity', default=None, help='W&B: Entity')

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -96,7 +96,7 @@ class Loggers():
     def on_pretrain_routine_end(self):
         # Callback runs on pre-train routine end
         paths = self.save_dir.glob('*labels*.jpg')  # training labels
-        if self.wandb:
+        if self.wandb and not self.opt.nomedia:
             self.wandb.log({"Labels": [wandb.Image(str(x), caption=x.name) for x in paths]})
 
     def on_train_batch_end(self, ni, model, imgs, targets, paths, plots, sync_bn):
@@ -109,7 +109,8 @@ class Loggers():
                         self.tb.add_graph(torch.jit.trace(de_parallel(model), imgs[0:1], strict=False), [])
             if ni < 3:
                 f = self.save_dir / f'train_batch{ni}.jpg'  # filename
-                Thread(target=plot_images, args=(imgs, targets, paths, f), daemon=True).start()
+                if not self.opt.nomedia:
+                    Thread(target=plot_images, args=(imgs, targets, paths, f), daemon=True).start()
             if self.wandb and ni == 10:
                 files = sorted(self.save_dir.glob('train*.jpg'))
                 self.wandb.log({'Mosaics': [wandb.Image(str(f), caption=f.name) for f in files if f.exists()]})
@@ -160,7 +161,7 @@ class Loggers():
 
     def on_train_end(self, last, best, plots, epoch, results):
         # Callback runs on training end
-        if plots:
+        if plots and not self.opt.nomedia:
             plot_results(file=self.save_dir / 'results.csv')  # save results.png
         files = ['results.png', 'confusion_matrix.png', *(f'{x}_curve.png' for x in ('F1', 'PR', 'P', 'R'))]
         files = [(self.save_dir / f) for f in files if (self.save_dir / f).exists()]  # filter

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -161,7 +161,7 @@ class Loggers():
 
     def on_train_end(self, last, best, plots, epoch, results):
         # Callback runs on training end
-        if plots and not self.opt.nomedia:
+        if plots:
             plot_results(file=self.save_dir / 'results.csv')  # save results.png
         files = ['results.png', 'confusion_matrix.png', *(f'{x}_curve.png' for x in ('F1', 'PR', 'P', 'R'))]
         files = [(self.save_dir / f) for f in files if (self.save_dir / f).exists()]  # filter

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -99,11 +99,11 @@ class Loggers():
         if self.wandb and not self.opt.nomedia:
             self.wandb.log({"Labels": [wandb.Image(str(x), caption=x.name) for x in paths]})
 
-    def on_train_batch_end(self, ni, model, imgs, targets, paths, plots, sync_bn):
+    def on_train_batch_end(self, ni, model, imgs, targets, paths, plots):
         # Callback runs on train batch end
         if plots:
             if ni == 0:
-                if not sync_bn:  # tb.add_graph() --sync known issue https://github.com/ultralytics/yolov5/issues/3754
+                if not self.opt.sync_bn:  # tb.add_graph() --sync known issue https://github.com/ultralytics/yolov5/issues/3754
                     with warnings.catch_warnings():
                         warnings.simplefilter('ignore')  # suppress jit trace warning
                         self.tb.add_graph(torch.jit.trace(de_parallel(model), imgs[0:1], strict=False), [])

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -250,7 +250,7 @@ class WandbLogger():
                 self.map_val_table_path()
         if opt.bbox_interval == -1:
             self.bbox_interval = opt.bbox_interval = (opt.epochs // 10) if opt.epochs > 10 else 1
-            if opt.evolve or opt.nomedia:
+            if opt.evolve or opt.noplots:
                 self.bbox_interval = opt.bbox_interval = opt.epochs + 1  # disable bbox_interval
         train_from_artifact = self.train_artifact_path is not None and self.val_artifact_path is not None
         # Update the the data_dict to point to local artifacts dir

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -251,7 +251,7 @@ class WandbLogger():
         if opt.bbox_interval == -1:
             self.bbox_interval = opt.bbox_interval = (opt.epochs // 10) if opt.epochs > 10 else 1
             if opt.evolve or opt.nomedia:
-                self.bbox_interval = opt.bbox_interval = opt.epochs + 1
+                self.bbox_interval = opt.bbox_interval = opt.epochs + 1  # disable bbox_interval
         train_from_artifact = self.train_artifact_path is not None and self.val_artifact_path is not None
         # Update the the data_dict to point to local artifacts dir
         if train_from_artifact:

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -250,7 +250,7 @@ class WandbLogger():
                 self.map_val_table_path()
         if opt.bbox_interval == -1:
             self.bbox_interval = opt.bbox_interval = (opt.epochs // 10) if opt.epochs > 10 else 1
-            if opt.evolve:
+            if opt.evolve or opt.nomedia:
                 self.bbox_interval = opt.bbox_interval = opt.epochs + 1
         train_from_artifact = self.train_artifact_path is not None and self.val_artifact_path is not None
         # Update the the data_dict to point to local artifacts dir


### PR DESCRIPTION
Addresses -> https://github.com/ultralytics/yolov5/discussions/7484
This PR adds support for a argparse flag `nomedia` which prevent any media logging locally or W&B dashboard. 
W&B dash with `nomedia` enabled -> https://wandb.ai/acwb/YOLOv5/runs/4shjupfd?workspace=user-
<img width="1440" alt="Screenshot 2022-04-22 at 6 08 54 PM" src="https://user-images.githubusercontent.com/15766192/164715918-3a821c37-0f4f-461d-b843-41885e891176.png">
Local run folder
<img width="697" alt="Screenshot 2022-04-22 at 6 09 12 PM" src="https://user-images.githubusercontent.com/15766192/164715955-690c88c6-82f3-4d4b-815a-f5441d586db2.png">

@glenn-jocher you might need to take a closer look as this touches some non-wandb code.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced training options for generating plots and synchronized batch normalization in YOLOv5.

### 📊 Key Changes
- Added `--noplots` flag to disable plot generation during training.
- Removed `sync_bn` parameter from `on_train_batch_end` callback and accessed it directly from the options.
- Adjusted conditions for setting `bbox_interval` to also consider the new `--noplots` flag.

### 🎯 Purpose & Impact
- **Disabling Plots**: Users can now skip the creation of plot files during training, which can save time and resources, especially when plots are not needed.
- **Simplified Synchronization**: Streamlining the code by removing an extra parameter and preventing known issues with torch's `tb.add_graph()` when using synchronized batch normalization.
- **Bbox Interval Adjustment**: Ensures that bounding box intervals are configured correctly in relation to plot generation preferences, providing more control over when evaluation metrics are logged during training.

With these changes, users gain more flexibility in how they train their models, potentially speeding up the training process and focusing system resources on essential tasks. 🚀