### PR TITLE
Improve availability of YOLOv5 in Russia

### DIFF
--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -125,6 +125,7 @@ def get_token(cookie="./cookie"):
                 return line.split()[-1]
     return ""
 
+
 # Google utils: https://cloud.google.com/storage/docs/reference/libraries ----------------------------------------------
 #
 #

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -72,12 +72,13 @@ def attempt_download(file, repo='ultralytics/yolov5'):  # from utils.downloads i
                 tag = 'v6.1'  # current release
 
         if name in assets:
+            url3 = 'https://drive.google.com/drive/folders/1EFQTEUeXWSFww0luse2jB9M1QNZQGwNl'  # backup gdrive mirror
             safe_download(
                 file,
                 url=f'https://github.com/{repo}/releases/download/{tag}/{name}',
-                # url2=f'https://storage.googleapis.com/{repo}/ckpt/{name}',  # backup url (optional)
+                url2=f'https://storage.googleapis.com/{repo}/{tag}/{name}',  # backup url (optional)
                 min_bytes=1E5,
-                error_msg=f'{file} missing, try downloading from https://github.com/{repo}/releases/')
+                error_msg=f'{file} missing, try downloading from https://github.com/{repo}/releases/{tag} or {url3}')
 
     return str(file)
 
@@ -123,7 +124,6 @@ def get_token(cookie="./cookie"):
             if "download" in line:
                 return line.split()[-1]
     return ""
-
 
 # Google utils: https://cloud.google.com/storage/docs/reference/libraries ----------------------------------------------
 #


### PR DESCRIPTION
This PR seeks to improve access worldwide to YOLOv5 weights. **Universal access to AI for all** is our core value at Ultralytics, and we are against any efforts to censor or restrict the free exchange of information.

I've uploaded the official YOLOv5 v6.1 weights to a primary backup bucket on GCP and to secondary backup on Google Drive at https://drive.google.com/drive/folders/1EFQTEUeXWSFww0luse2jB9M1QNZQGwNl.

Autodownload with try the first two locations (GitHub release assets and GCP bucket), and point users to the Google Drive folder if the first two fail.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved backup download options for YOLOv5 models.

### 📊 Key Changes
- Added a Google Drive mirror URL as a new backup download option.
- Updated the Google Storage backup URL to include the release tag.

### 🎯 Purpose & Impact
- Provides additional redundancy for downloading YOLOv5 models, ensuring accessibility even if GitHub is unavailable.
- Enhances user experience by minimizing disruptions due to missing files or download issues. 🛠️
- Users are now presented with more options and clearer instructions when the main download source fails. 👍