### PR TITLE
Restrict TRT autoinstall to Linux-only

### DIFF
--- a/export.py
+++ b/export.py
@@ -218,7 +218,8 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
     # YOLOv5 TensorRT export https://developer.nvidia.com/tensorrt
     try:
         assert im.device.type != 'cpu', 'export running on CPU but must be on GPU, i.e. `python export.py --device 0`'
-        check_requirements(('nvidia-tensorrt',), cmds=('-U --index-url https://pypi.ngc.nvidia.com',))
+        if platform.system() == 'Linux':
+            check_requirements(('nvidia-tensorrt',), cmds=('-U --index-url https://pypi.ngc.nvidia.com',))
         import tensorrt as trt
 
         if trt.__version__[0] == '7':  # TensorRT 7 handling https://github.com/ultralytics/yolov5/issues/6012


### PR DESCRIPTION
May partially resolve concerns in https://github.com/ultralytics/yolov5/pull/7537#discussion_r856843711

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced `export.py` to conditionally check `nvidia-tensorrt` requirements based on the operating system. 

### 📊 Key Changes
- Added a conditional check to ensure `nvidia-tensorrt` requirements are only verified on Linux systems.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: The adjustment is made to prevent irrelevant requirement checks on non-Linux systems which do not support `nvidia-tensorrt`. This targets avoiding errors or confusion when exporting models on those platforms.
- 🔍 **Impact**: Users on non-Linux systems will experience a smoother export process without facing errors related to missing TensorRT libraries, which are not applicable to their operating system. This makes the export script more robust and user-friendly for a wider audience.