### PR TITLE
Enable `results.print()` when `_verbose=False`

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -629,7 +629,7 @@ class Detections:
 
             im = Image.fromarray(im.astype(np.uint8)) if isinstance(im, np.ndarray) else im  # from np
             if pprint:
-                LOGGER.info(s.rstrip(', '))
+                print(s.rstrip(', '))
             if show:
                 im.show(self.files[i])  # show
             if save:
@@ -646,8 +646,7 @@ class Detections:
 
     def print(self):
         self.display(pprint=True)  # print results
-        LOGGER.info(f'Speed: %.1fms pre-process, %.1fms inference, %.1fms NMS per image at shape {tuple(self.s)}' %
-                    self.t)
+        print(f'Speed: %.1fms pre-process, %.1fms inference, %.1fms NMS per image at shape {tuple(self.s)}' % self.t)
 
     def show(self, labels=True):
         self.display(show=True, labels=labels)  # show results


### PR DESCRIPTION
Follows implementation of _verbose flag for PyTorch Hub models in #7550. Currently these are so silent that result.print() does nothing 😂


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improve logging output in display and speed reporting functions.

### 📊 Key Changes
- `LOGGER.info` calls replaced with regular `print` statements within the `display` and `print` methods.

### 🎯 Purpose & Impact
- Improves the readability and simplicity of output logging, making printed results more accessible to users.
- Non-expert users will appreciate the direct output to consoles or notebooks without getting confused by logger formatting.
- Developers gain a more straightforward way to see outputs during debugging and testing. 🛠️