### PR TITLE
Add `print(results)` override for PyTorch Hub results

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -683,7 +683,11 @@ class Detections:
         return x
 
     def __len__(self):
-        return self.n
+        return self.n  # override len(results)
+
+    def __str__(self):
+        self.print()  # override print(results)
+        return ''
 
 
 class Classify(nn.Module):


### PR DESCRIPTION
Usage example:

```python
import torch

# Model
model = torch.hub.load('ultralytics/yolov5', 'yolov5s')  # or yolov5m, yolov5l, yolov5x, custom

# Images
img = 'https://ultralytics.com/images/zidane.jpg'  # or file, Path, PIL, OpenCV, numpy, list

# Inference
results = model(img)

# Results
results.print()
print(results)  # <---- NEW 

# image 1/1: 720x1280 2 persons, 2 ties
# Speed: 299.5ms pre-process, 319.2ms inference, 12.9ms NMS per image at shape (1, 3, 384, 640)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved usability of model results in Ultralytics YOLOv5 with new string representation.

### 📊 Key Changes
- 🧩 Added an override of the `__str__` method to the `Results` class.
- 🖨️ Modified the `__len__` method comment for clarity.

### 🎯 Purpose & Impact
- 👁️‍🗨️ Enhances the user's visibility of results by automatically printing when using the `print()` function on a `Results` object.
- 🌐 Provides a more Pythonic usage experience, as users expect `print(object)` to display useful information.
- 🆒 Potentially improves debugging and logging with minimal changes to existing codebases.