### PR TITLE
TensorRT PyTorch Hub inference fix

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -531,7 +531,7 @@ class AutoShape(nn.Module):
         #   multiple:        = [Image.open('image1.jpg'), Image.open('image2.jpg'), ...]  # list of images
 
         t = [time_sync()]
-        p = next(self.model.parameters()) if self.pt else torch.zeros(1)  # for device and type
+        p = next(self.model.parameters()) if self.pt else torch.zeros(1, device=self.model.device)  # for device, type
         autocast = self.amp and (p.device.type != 'cpu')  # Automatic Mixed Precision (AMP) inference
         if isinstance(imgs, torch.Tensor):  # torch
             with amp.autocast(autocast):


### PR DESCRIPTION
Solution proposed in https://github.com/ultralytics/yolov5/issues/7128 to TRT PyTorch Hub CUDA illegal memory errors.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in device compatibility for AMP inferences within YOLOv5.

### 📊 Key Changes
- Ensured that the dummy tensor `p` is on the same device as `self.model` when `self.pt` is `False`.

### 🎯 Purpose & Impact
- **Purpose:** To fix a potential issue where the dummy tensor for device and type determination was not being consistently placed on the correct device (e.g., GPU or CPU).
- **Impact:** Enhanced compatibility and stability when running Automatic Mixed Precision (AMP) inferences, preventing errors related to device mismatches. This change is particularly relevant when `self.pt` is `False`, ensuring that users who are performing inferences without a `.pt` model (PyTorch format) do not face device-related issues.