### PR TITLE
Fix `from yolov5 import utils` statement

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -410,7 +410,7 @@
         "%pip install -qr requirements.txt  # install\n",
         "\n",
         "import torch\n",
-        "from yolov5 import utils\n",
+        "import utils\n",
         "display = utils.notebook_init()  # checks"
       ],
       "execution_count": null,


### PR DESCRIPTION
Hi,
I ran the tutorial.ipynb in the repo. Then, I found the original import statement `from yolov5 import utils` could report error message `ModuleNotFoundError: No module named 'yolov5'`. So, I think it should be revised to `import utils` to work properly.
Please check whether it's a bug, thanks!

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of the YOLOv5 tutorial notebook's import statements.

### 📊 Key Changes
- Updated the import statement for `utils` in the YOLOv5 tutorial notebook.

### 🎯 Purpose & Impact
- Ensures consistency in how utility functions are imported within the notebook.
- Likely to prevent confusion or errors caused by potential namespace issues.
- Benefits users by providing a clearer example of how to properly import and use utility functions in their own YOLOv5 projects. ☀️