### PR TITLE
Add `--half` support for OpenVINO exports

### DIFF
--- a/export.py
+++ b/export.py
@@ -168,7 +168,7 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
         LOGGER.info(f'{prefix} export failure: {e}')
 
 
-def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
+def export_openvino(model, im, file, half, prefix=colorstr('OpenVINO:')):
     # YOLOv5 OpenVINO export
     try:
         check_requirements(('openvino-dev',))  # requires openvino-dev: https://pypi.org/project/openvino-dev/
@@ -177,7 +177,7 @@ def export_openvino(model, im, file, prefix=colorstr('OpenVINO:')):
         LOGGER.info(f'\n{prefix} starting export with openvino {ie.__version__}...')
         f = str(file).replace('.pt', '_openvino_model' + os.sep)
 
-        cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f}"
+        cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f} {'--data_type FP16' if half else ''}"
         subprocess.check_output(cmd, shell=True)
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')
@@ -477,7 +477,7 @@ def run(
     # Load PyTorch model
     device = select_device(device)
     if half:
-        assert device.type != 'cpu' or coreml, '--half only compatible with GPU export, i.e. use --device 0'
+        assert device.type != 'cpu' or coreml or xml, '--half only compatible with GPU and OpenVINO export, i.e. use --device 0'
     model = attempt_load(weights, map_location=device, inplace=True, fuse=True)  # load FP32 model
     nc, names = model.nc, model.names  # number of classes, class names
 
@@ -491,7 +491,7 @@ def run(
     im = torch.zeros(batch_size, 3, *imgsz).to(device)  # image size(1,3,320,192) BCHW iDetection
 
     # Update model
-    if half and not coreml:
+    if half and not (coreml or xml):
         im, model = im.half(), model.half()  # to FP16
     model.train() if train else model.eval()  # training mode = no Detect() layer grid construction
     for k, m in model.named_modules():
@@ -515,7 +515,7 @@ def run(
     if onnx or xml:  # OpenVINO requires ONNX
         f[2] = export_onnx(model, im, file, opset, train, dynamic, simplify)
     if xml:  # OpenVINO
-        f[3] = export_openvino(model, im, file)
+        f[3] = export_openvino(model, im, file, half)
     if coreml:
         _, f[4] = export_coreml(model, im, file, int8, half)
 

--- a/export.py
+++ b/export.py
@@ -177,7 +177,7 @@ def export_openvino(model, im, file, half, prefix=colorstr('OpenVINO:')):
         LOGGER.info(f'\n{prefix} starting export with openvino {ie.__version__}...')
         f = str(file).replace('.pt', '_openvino_model' + os.sep)
 
-        cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f} {'--data_type FP16' if half else ''}"
+        cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f} --data_type {'FP16' if half else 'FP32'}"
         subprocess.check_output(cmd, shell=True)
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')

--- a/export.py
+++ b/export.py
@@ -477,7 +477,7 @@ def run(
     # Load PyTorch model
     device = select_device(device)
     if half:
-        assert device.type != 'cpu' or coreml or xml, '--half only compatible with GPU and OpenVINO export, i.e. use --device 0'
+        assert device.type != 'cpu' or coreml or xml, '--half only compatible with GPU export, i.e. use --device 0'
     model = attempt_load(weights, map_location=device, inplace=True, fuse=True)  # load FP32 model
     nc, names = model.nc, model.names  # number of classes, class names
 


### PR DESCRIPTION
This PR enables exporting OpenVINO models with the FP16 data type.

Size and Accuracy comparison between OpenVINO FP32 and FP16 versions of yolov5n6:
![image](https://user-images.githubusercontent.com/6038874/165649127-54b390a5-89c7-4f7f-b1ca-37e7bd5493cf.png)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to model exporting for OpenVINO with FP16 support.

### 📊 Key Changes
- Added a `half` parameter to `export_openvino` function to allow exporting models in FP16 precision.
- Included `--data_type` argument in the OpenVINO Model Optimizer command to support FP16 or FP32 during export.
- Adjusted assertion to allow `--half` usage with OpenVINO (`xml`) export.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: To enable YOLOv5 models to be exported for OpenVINO in a more memory-efficient FP16 format, when compatible hardware is available.
- 💻 **Impact for Users**: Users can now reduce the computational requirements of their YOLOv5 models when deploying to hardware supporting FP16, potentially improving performance. This change is particularly beneficial for edge computing scenarios where resources are limited.