### PR TITLE
Reduce `opencv-python>=4.1.1` for Jetson Nano

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # Base ----------------------------------------
 matplotlib>=3.2.2
 numpy>=1.18.5
-opencv-python>=4.1.2
+opencv-python>=4.1.1
 Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0


### PR DESCRIPTION
May help https://github.com/ultralytics/yolov5/issues/7631#issuecomment-1113007451


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjustment of OpenCV minimum version requirement.

### 📊 Key Changes
- The `opencv-python` minimum version has been downgraded from `4.1.2` to `4.1.1`.

### 🎯 Purpose & Impact
- **Purpose:** This change seems to be a minor adjustment to the dependencies, likely to increase compatibility or address an underlying issue with the dependency version.
- **Impact:** 
  - This should allow users with slightly older versions of `opencv-python` to use YOLOv5 without needing to upgrade, fostering a broader user base.
  - It could also resolve potential bugs or conflicts that were discovered with `4.1.2`.
  - Overall, impact is minimal for most users but can be significant for those unable to use the newer OpenCV version due to various constraints.