### PR TITLE
Disallow `--dynamic` when `--half` is passed

### DIFF
--- a/export.py
+++ b/export.py
@@ -478,6 +478,7 @@ def run(
     device = select_device(device)
     if half:
         assert device.type != 'cpu' or coreml or xml, '--half only compatible with GPU export, i.e. use --device 0'
+        assert not dynamic, '--half only compatible with static axes'
     model = attempt_load(weights, map_location=device, inplace=True, fuse=True)  # load FP32 model
     nc, names = model.nc, model.names  # number of classes, class names
 

--- a/export.py
+++ b/export.py
@@ -478,7 +478,7 @@ def run(
     device = select_device(device)
     if half:
         assert device.type != 'cpu' or coreml or xml, '--half only compatible with GPU export, i.e. use --device 0'
-        assert not dynamic, '--half only compatible with static axes'
+        assert not dynamic, '--half not compatible with --dynamic, i.e. use either --half or --dynamic but not both'
     model = attempt_load(weights, map_location=device, inplace=True, fuse=True)  # load FP32 model
     nc, names = model.nc, model.names  # number of classes, class names
 


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->
Hi, 
Add this `assertion` when dynamic is given as well as the `--half` argument to avoid the error as mentioned in issue #7641. 


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced compatibility checks in YOLOv5 model export script.

### 📊 Key Changes
- Added a new assertion to `export.py` that prevents using the `--half` precision flag in conjunction with the `--dynamic` flag during model export.

### 🎯 Purpose & Impact
- **Purpose:** The update ensures that users do not attempt to export a model with incompatible flags that could lead to errors during the export process.
- **Impact:** This change improves user experience by providing clear error messages, preventing potential confusion and frustration. It helps maintain the stability and reliability of the model export feature by enforcing correct usage patterns.