### PR TITLE
Pin Docker-cpu `FROM ubuntu:20.04`

### DIFF
--- a/utils/docker/Dockerfile-cpu
+++ b/utils/docker/Dockerfile-cpu
@@ -1,22 +1,18 @@
 # YOLOv5 🚀 by Ultralytics, GPL-3.0 license
 
 # Start FROM Ubuntu image https://hub.docker.com/_/ubuntu
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 # Install linux packages
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y tzdata
-RUN apt install -y python3-pip git zip curl htop screen libgl1-mesa-glx libglib2.0-0 software-properties-common
-
-# Install python3.9
-RUN add-apt-repository ppa:deadsnakes/ppa -y
-RUN apt install python3.9 python3.9-distutils libpython3.9 -y
-# RUN alias python=python3.9
+RUN apt install -y python3-pip git zip curl htop screen libgl1-mesa-glx libglib2.0-0
+# RUN alias python=python3
 
 # Install pip packages
 COPY requirements.txt .
-RUN python3.9 -m pip install --upgrade pip
-RUN python3.9 -m pip install --no-cache -r requirements.txt albumentations gsutil notebook \
+RUN python3 -m pip install --upgrade pip
+RUN pip install --no-cache -r requirements.txt albumentations gsutil notebook \
     coremltools onnx onnx-simplifier onnxruntime openvino-dev tensorflow-cpu tensorflowjs \
     torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu
 


### PR DESCRIPTION
Pin `FROM ubuntu:20.04`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update and simplify the YOLOv5 CPU Dockerfile.

### 📊 Key Changes
- 🚢 Switched the base Docker image from `ubuntu:latest` to `ubuntu:20.04`.
- ✂️ Removed unnecessary steps for installing Python 3.9 since Ubuntu 20.04 comes with Python 3.8 by default.
- 🔧 Changed python commands from `python3.9` to the default `python3`.
- 🧹 Cleaned up the installation process, removing more complex setup for a simpler one.

### 🎯 Purpose & Impact
- 🔄 Ensures compatibility by using a more stable version of Ubuntu rather than the latest, which can vary over time.
- ⚙️ Simplifies the Docker image by removing redundant installation steps for Python 3.9, as the version included with Ubuntu 20.04 is sufficient.
- 👍 Improves the maintainability of the Dockerfile by using default python aliases, which reduces confusion and potential errors.
- 💨 May result in faster build times and reduced complexity for users setting up the YOLOv5 environment on CPU-based systems.