### PR TITLE
Update numpy version to fix CVE vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 # Base ----------------------------------------
 matplotlib>=3.2.2
-numpy>=1.18.5
+numpy>=1.22.2
 opencv-python>=4.1.1
 Pillow>=7.1.2
 PyYAML>=5.3.1


### PR DESCRIPTION
When I used CVE to scan the dependencies of my project, I found that there are serious vulnerabilities when numpy<1.22.2, so I referred to this link: https://github.com/numpy/numpy/issues/19038. I'm wondering if YOLOv5 also needs to close this CVE vulnerability?

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgrade minimum required version of NumPy.

### 📊 Key Changes
- Updated the minimum version of NumPy from 1.18.5 to 1.22.2 in the `requirements.txt` file.

### 🎯 Purpose & Impact
- **Purpose:** Ensuring compatibility with newer features, bug fixes, and performance improvements in NumPy.
- **Impact:** Users will benefit from enhanced stability and potential new functionalities that come with the newer NumPy version. Requires users to update their NumPy installation if they're using an older version.