### PR TITLE
Fix box similarity functions in metrics.py

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -240,10 +240,10 @@ def bbox_iou(box1, box2, xywh=True, GIoU=False, DIoU=False, CIoU=False, eps=1e-7
                 v = (4 / math.pi ** 2) * torch.pow(torch.atan(w2 / h2) - torch.atan(w1 / h1), 2)
                 with torch.no_grad():
                     alpha = v / (v - iou + (1 + eps))
-                return iou - (rho2 / c2 + v * alpha)  # CIoU
-            return iou - rho2 / c2  # DIoU
+                return iou + (rho2 / c2 + v * alpha)  # CIoU
+            return iou + rho2 / c2  # DIoU
         c_area = cw * ch + eps  # convex area
-        return iou - (c_area - union) / c_area  # GIoU https://arxiv.org/pdf/1902.09630.pdf
+        return iou + (c_area - union) / c_area  # GIoU https://arxiv.org/pdf/1902.09630.pdf
     return iou  # IoU
 
 


### PR DESCRIPTION
fixes signs in equations of various box similarity functions (CIoU, DIoU and GIoU)

see [issue 7709](https://github.com/ultralytics/yolov5/issues/7709)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved IoU calculation in YOLOv5's metric utilities.

### 📊 Key Changes
- Adjusted the return statements in the intersection-over-union (IoU) calculation functions to fix an error where additional terms (GIoU, DIoU, CIoU) were being subtracted instead of added.
- GIoU, DIoU, CIoU calculations now correctly add the respective term to the base IoU.

### 🎯 Purpose & Impact
- **Correctness**: Fixes a bug in the computation of IoU variants, now providing accurate bounding box overlap ratios.
- **User Confidence**: Users can trust the accuracy of model evaluation and comparison metrics when assessing object detection performance.
- **Research & Development**: Accurate metrics are crucial for effective model training and improvement, which now can be achieved using the corrected IoU calculations.