### PR TITLE
Fix mAP calculations

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -96,7 +96,7 @@ def compute_ap(recall, precision):
     """
 
     # Append sentinel values to beginning and end
-    mrec = np.concatenate((recall, [recall[-1]+0.001]))
+    mrec = np.concatenate((recall, [recall[-1] + 0.001]))
     mpre = np.concatenate((precision, [0.0]))
 
     # Compute the precision envelope

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -57,11 +57,11 @@ def ap_per_class(tp, conf, pred_cls, target_cls, plot=False, save_dir='.', names
 
             # Recall
             recall = tpc / (n_l + eps)  # recall curve
-            r[ci] = np.interp(-px, -conf[i], recall[:, 0], left=0)  # negative x, xp because xp decreases
+            r[ci] = np.interp(-px, -conf[i], recall[:, 0], left=0, right=0)  # negative x, xp because xp decreases
 
             # Precision
             precision = tpc / (tpc + fpc)  # precision curve
-            p[ci] = np.interp(-px, -conf[i], precision[:, 0], left=1)  # p at pr_score
+            p[ci] = np.interp(-px, -conf[i], precision[:, 0], left=0, right=0)  # p at pr_score
 
             # AP from recall-precision curve
             for j in range(tp.shape[1]):
@@ -96,8 +96,8 @@ def compute_ap(recall, precision):
     """
 
     # Append sentinel values to beginning and end
-    mrec = np.concatenate(([0.0], recall, [1.0]))
-    mpre = np.concatenate(([1.0], precision, [0.0]))
+    mrec = np.concatenate((recall, [recall[-1]+0.001]))
+    mpre = np.concatenate((precision, [0.0]))
 
     # Compute the precision envelope
     mpre = np.flip(np.maximum.accumulate(np.flip(mpre)))


### PR DESCRIPTION
Fix mAP calculations.
Originally, there were extrapolations to generate precision curve, recall curve, and PR curve.
The extrapolations generate large differenced with cocoapi.
This commit removes extrapolations to accurately calculate mAP, especially false-negative related mAP errors when conf-thres is high. 


related issue : https://github.com/ultralytics/yolov5/issues/1466

Dataset: coco128
Model: yolov5s.pt

Original
mAP@0.50 (conf-thres=0.001) : 0.719
mAP@0.50 (conf-thres=0.25) : 0.687

Fixed
mAP@0.50 (conf-thres=0.001) : 0.712
mAP@0.50 (conf-thres=0.25) : 0.594


Original Curves (conf-thres=0.25)
![P_curve](https://user-images.githubusercontent.com/33407038/167058798-fac8a1b0-1b6d-4229-89ef-301848625630.png)
![R_curve](https://user-images.githubusercontent.com/33407038/167058779-fd7351ea-287a-419a-83fc-d5f9bcc9930e.png)
![PR_curve](https://user-images.githubusercontent.com/33407038/167058795-b1827e9a-c386-45cd-94c7-8ec77ea651b7.png)

Fixed Curves (conf-thres=0.25)
![P_curve_fixed](https://user-images.githubusercontent.com/33407038/167058847-d9df7e10-9be1-4f57-8ef1-4678c7e543b5.png)
![R_curve_fixed](https://user-images.githubusercontent.com/33407038/167058854-0640df80-ec29-4314-a3da-54b302e94f9c.png)
![PR_curve_fixed](https://user-images.githubusercontent.com/33407038/167058859-9f1b2ff4-8a4e-4dcd-9824-d399e5d989a3.png)





## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved precision-recall curve interpolation and AP calculation for object detection metrics.

### 📊 Key Changes
- Updated the interpolation method to specify `right=0` for both recall and precision in `ap_per_class` function.
- Altered computation of sentinel values in `compute_ap` function for precision-recall curves.

### 🎯 Purpose & Impact
- **Consistency in Border Handling**: Adding `right=0` ensures that extrapolation for values outside the data range is consistent, avoiding assumed default values.
- **Better Precision-Recall Curves**: Modifying the sentinel values leads to more accurate precision-recall curves, especially towards the limits where recall is high.
- **Impact on Users**: Users will experience more accurate Average Precision (AP) scores, which are crucial for evaluating object detection models, leading to improved trust in the metrics reported by YOLOv5 models.📈🔍