### PR TITLE
Ability to download older assets

### DIFF
--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -43,10 +43,8 @@ def safe_download(file, url, url2=None, min_bytes=1E0, error_msg=''):
         LOGGER.info('')
 
 
-def attempt_download(file,
-                     repo='ultralytics/yolov5',
-                     release='latest'):  # from utils.downloads import *; attempt_download()
-    # Attempt file download if does not exist
+def attempt_download(file, repo='ultralytics/yolov5', release='latest'):
+    # Attempt file download from GitHub release assets if does not exist locally
     from utils.general import LOGGER
 
     file = Path(str(file).strip().replace("'", ''))
@@ -65,7 +63,7 @@ def attempt_download(file,
         # GitHub assets
         file.parent.mkdir(parents=True, exist_ok=True)  # make parent dir (if required)
         if release != 'latest' and not release.startswith('tags/'):
-            release = f'tags/{release}'
+            release = f'tags/{release}'  # prepend i.e. tags/v6.1
         try:
             response = requests.get(f'https://api.github.com/repos/{repo}/releases/{release}').json()  # github api
             assets = [x['name'] for x in response['assets']]  # release assets, i.e. ['yolov5s.pt', 'yolov5m.pt', ...]

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -43,7 +43,7 @@ def safe_download(file, url, url2=None, min_bytes=1E0, error_msg=''):
         LOGGER.info('')
 
 
-def attempt_download(file, repo='ultralytics/yolov5'):  # from utils.downloads import *; attempt_download()
+def attempt_download(file, repo='ultralytics/yolov5', release='latest'):  # from utils.downloads import *; attempt_download()
     # Attempt file download if does not exist
     from utils.general import LOGGER
 
@@ -62,8 +62,10 @@ def attempt_download(file, repo='ultralytics/yolov5'):  # from utils.downloads i
 
         # GitHub assets
         file.parent.mkdir(parents=True, exist_ok=True)  # make parent dir (if required)
+        if release != 'latest' and not release.startswith('tags/'):
+            release = f'tags/{release}'
         try:
-            response = requests.get(f'https://api.github.com/repos/{repo}/releases/latest').json()  # github api
+            response = requests.get(f'https://api.github.com/repos/{repo}/releases/{release}').json()  # github api
             assets = [x['name'] for x in response['assets']]  # release assets, i.e. ['yolov5s.pt', 'yolov5m.pt', ...]
             tag = response['tag_name']  # i.e. 'v1.0'
         except Exception:  # fallback plan

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -43,7 +43,9 @@ def safe_download(file, url, url2=None, min_bytes=1E0, error_msg=''):
         LOGGER.info('')
 
 
-def attempt_download(file, repo='ultralytics/yolov5', release='latest'):  # from utils.downloads import *; attempt_download()
+def attempt_download(file,
+                     repo='ultralytics/yolov5',
+                     release='latest'):  # from utils.downloads import *; attempt_download()
     # Attempt file download if does not exist
     from utils.general import LOGGER
 

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -44,7 +44,7 @@ def safe_download(file, url, url2=None, min_bytes=1E0, error_msg=''):
 
 
 def attempt_download(file, repo='ultralytics/yolov5', release='latest'):
-    # Attempt file download from GitHub release assets if does not exist locally
+    # Attempt file download from GitHub release assets if not found locally
     from utils.general import LOGGER
 
     file = Path(str(file).strip().replace("'", ''))


### PR DESCRIPTION
Sometimes, one would need to download the assets for a previously released version. Instead of doing it manually (either from browser, either changing the *URL*), it's possible to make use of *attempt_download*'s newly added parameter (and a small change in *data/scripts/download\_weights.sh*):

The release can be specified in 2 ways:

- `attempt_download(..., release='v5.0')`

- `attempt_download(..., release='tags/v5.0')`

Of course, current existing behavior is the default.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced `attempt_download` function to support specific GitHub release assets.

### 📊 Key Changes
- `attempt_download` now accepts an additional `release` parameter to specify the GitHub release version.
- Default behavior targets the `latest` release if no other is specified.
- Constructed the URL to fetch from GitHub API now includes the specified release.
- Added a check to prepend "tags/" to the release string if it is not the `latest` and does not already start with "tags/".

### 🎯 Purpose & Impact
- Users can now download model weights or other assets from a specific release, providing greater control over the version of files used.
- Enhances reproducibility and flexibility for developers and researchers who need specific versions of code or data.
- Reduces potential issues from always pulling the latest version which might not be compatible with certain codebases or project requirements.