### PR TITLE
add capability to save bounding box in xmin,ymin,xmax,ymax format

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -58,6 +58,7 @@ def run(
         device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
         view_img=False,  # show results
         save_txt=False,  # save results to *.txt
+        use_xyxy = False, #save result in xmin,ymin,xmax,ymax format
         save_conf=False,  # save confidences in --save-txt labels
         save_crop=False,  # save cropped prediction boxes
         nosave=False,  # do not save images/videos
@@ -158,8 +159,12 @@ def run(
                 # Write results
                 for *xyxy, conf, cls in reversed(det):
                     if save_txt:  # Write to file
-                        xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
-                        line = (cls, *xywh, conf) if save_conf else (cls, *xywh)  # label format
+                        if use_xyxy:
+                            line = (cls, *xyxy, conf) if save_conf else (cls, *xyxy)  # label format
+                        else:
+                            xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
+                            line = (cls, *xywh, conf) if save_conf else (cls, *xywh)  # label format
+
                         with open(txt_path + '.txt', 'a') as f:
                             f.write(('%g ' * len(line)).rstrip() % line + '\n')
 
@@ -220,6 +225,7 @@ def parse_opt():
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--view-img', action='store_true', help='show results')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
+    parser.add_argument('--use-xyxy', action='store_true', help='save result in xmin,ymin,xmax,ymax format')
     parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
     parser.add_argument('--save-crop', action='store_true', help='save cropped prediction boxes')
     parser.add_argument('--nosave', action='store_true', help='do not save images/videos')

--- a/detect.py
+++ b/detect.py
@@ -58,7 +58,7 @@ def run(
         device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
         view_img=False,  # show results
         save_txt=False,  # save results to *.txt
-        use_xyxy=False,  #save result in xmin,ymin,xmax,ymax format
+        use_xyxy=False,  # save result in xmin,ymin,xmax,ymax format
         save_conf=False,  # save confidences in --save-txt labels
         save_crop=False,  # save cropped prediction boxes
         nosave=False,  # do not save images/videos

--- a/detect.py
+++ b/detect.py
@@ -58,7 +58,7 @@ def run(
         device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
         view_img=False,  # show results
         save_txt=False,  # save results to *.txt
-        use_xyxy = False, #save result in xmin,ymin,xmax,ymax format
+        use_xyxy=False,  #save result in xmin,ymin,xmax,ymax format
         save_conf=False,  # save confidences in --save-txt labels
         save_crop=False,  # save cropped prediction boxes
         nosave=False,  # do not save images/videos


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

This PR adds the capability to save the bounding box in a traditional format as opposed to in a normalized one.



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced output format options for detection results in YOLOv5.

### 📊 Key Changes
- Added a `use_xyxy` option within the detection script `detect.py`.
- Resulting detection coordinates can now be saved in the `xmin, ymin, xmax, ymax` format.
- Modified the logic in the result-writing part of the code to accommodate the new output format.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: Offers flexibility in the choice of output coordinate formats, catering to different post-processing needs or integration requirements.
- 🚀 **Impact**: Users gaining more control over how detection results are formatted, potentially simplifying integration with other tools or systems that require bounding box coordinates in `xmin, ymin, xmax, ymax` format.