### PR TITLE
New TensorFlow `TFCrossConv()` module

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -124,6 +124,20 @@ class BottleneckCSP(nn.Module):
         return self.cv4(self.act(self.bn(torch.cat((y1, y2), 1))))
 
 
+class CrossConv(nn.Module):
+    # Cross Convolution Downsample
+    def __init__(self, c1, c2, k=3, s=1, g=1, e=1.0, shortcut=False):
+        # ch_in, ch_out, kernel, stride, groups, expansion, shortcut
+        super().__init__()
+        c_ = int(c2 * e)  # hidden channels
+        self.cv1 = Conv(c1, c_, (1, k), (1, s))
+        self.cv2 = Conv(c_, c2, (k, 1), (s, 1), g=g)
+        self.add = shortcut and c1 == c2
+
+    def forward(self, x):
+        return x + self.cv2(self.cv1(x)) if self.add else self.cv2(self.cv1(x))
+
+
 class C3(nn.Module):
     # CSP Bottleneck with 3 convolutions
     def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5):  # ch_in, ch_out, number, shortcut, groups, expansion

--- a/models/common.py
+++ b/models/common.py
@@ -31,7 +31,7 @@ from utils.torch_utils import copy_attr, time_sync
 def autopad(k, p=None):  # kernel, padding
     # Pad to 'same'
     if p is None:
-        p = k // 2 if isinstance(k, int) else (x // 2 for x in k)  # auto-pad
+        p = k // 2 if isinstance(k, int) else [x // 2 for x in k]  # auto-pad
     return p
 
 
@@ -147,10 +147,17 @@ class C3(nn.Module):
         self.cv2 = Conv(c1, c_, 1, 1)
         self.cv3 = Conv(2 * c_, c2, 1)  # optional act=FReLU(c2)
         self.m = nn.Sequential(*(Bottleneck(c_, c_, shortcut, g, e=1.0) for _ in range(n)))
-        # self.m = nn.Sequential(*(CrossConv(c_, c_, 3, 1, g, 1.0, shortcut) for _ in range(n)))
 
     def forward(self, x):
         return self.cv3(torch.cat((self.m(self.cv1(x)), self.cv2(x)), 1))
+
+
+class C3x(C3):
+    # C3 module with cross-convolutions
+    def __init__(self, c1, c2, n=1, shortcut=True, g=1, e=0.5):
+        super().__init__(c1, c2, n, shortcut, g, e)
+        c_ = int(c2 * e)
+        self.m = nn.Sequential(*(CrossConv(c_, c_, 3, 1, g, 1.0, shortcut) for _ in range(n)))
 
 
 class C3TR(C3):

--- a/models/experimental.py
+++ b/models/experimental.py
@@ -12,7 +12,6 @@ from models.common import Conv
 from utils.downloads import attempt_download
 
 
-
 class Sum(nn.Module):
     # Weighted sum of 2 or more layers https://arxiv.org/abs/1911.09070
     def __init__(self, n, weight=False):  # n: number of inputs

--- a/models/experimental.py
+++ b/models/experimental.py
@@ -12,19 +12,6 @@ from models.common import Conv
 from utils.downloads import attempt_download
 
 
-class CrossConv(nn.Module):
-    # Cross Convolution Downsample
-    def __init__(self, c1, c2, k=3, s=1, g=1, e=1.0, shortcut=False):
-        # ch_in, ch_out, kernel, stride, groups, expansion, shortcut
-        super().__init__()
-        c_ = int(c2 * e)  # hidden channels
-        self.cv1 = Conv(c1, c_, (1, k), (1, s))
-        self.cv2 = Conv(c_, c2, (k, 1), (s, 1), g=g)
-        self.add = shortcut and c1 == c2
-
-    def forward(self, x):
-        return x + self.cv2(self.cv1(x)) if self.add else self.cv2(self.cv1(x))
-
 
 class Sum(nn.Module):
     # Weighted sum of 2 or more layers https://arxiv.org/abs/1911.09070

--- a/models/tf.py
+++ b/models/tf.py
@@ -27,7 +27,7 @@ import torch
 import torch.nn as nn
 from tensorflow import keras
 
-from models.common import Bottleneck, BottleneckCSP, C3, C3x, Concat, Conv, CrossConv, DWConv, Focus, SPP, SPPF, autopad
+from models.common import C3, SPP, SPPF, Bottleneck, BottleneckCSP, C3x, Concat, Conv, CrossConv, DWConv, Focus, autopad
 from models.experimental import MixConv2d, attempt_load
 from models.yolo import Detect
 from utils.activations import SiLU

--- a/models/tf.py
+++ b/models/tf.py
@@ -27,7 +27,7 @@ import torch
 import torch.nn as nn
 from tensorflow import keras
 
-from models.common import C3, C3x, SPP, SPPF, Bottleneck, BottleneckCSP, Concat, Conv, CrossConv, DWConv, Focus, autopad
+from models.common import C3, SPP, SPPF, Bottleneck, BottleneckCSP, C3x, Concat, Conv, CrossConv, DWConv, Focus, autopad
 from models.experimental import MixConv2d, attempt_load
 from models.yolo import Detect
 from utils.activations import SiLU

--- a/models/tf.py
+++ b/models/tf.py
@@ -50,7 +50,7 @@ class TFBN(keras.layers.Layer):
 
 
 class TFPad(keras.layers.Layer):
-
+    # Pad inputs in spatial dimensions 1 and 2
     def __init__(self, pad):
         super().__init__()
         if isinstance(pad, int):

--- a/models/tf.py
+++ b/models/tf.py
@@ -141,9 +141,6 @@ class TFCrossConv(keras.layers.Layer):
         self.cv2 = TFConv(c_, c2, (k, 1), (s, 1), g=g, w=w.cv2)
         self.add = shortcut and c1 == c2
 
-        self.cv1 = Conv(c1, c_, (1, k), (1, s))
-        self.cv2 = Conv(c_, c2, (k, 1), (s, 1), g=g)
-
     def call(self, inputs):
         return inputs + self.cv2(self.cv1(inputs)) if self.add else self.cv2(self.cv1(inputs))
 

--- a/models/tf.py
+++ b/models/tf.py
@@ -343,7 +343,7 @@ def parse_model(d, ch, model, imgsz):  # model_dict, input_channels(3)
             c2 = make_divisible(c2 * gw, 8) if c2 != no else c2
 
             args = [c1, c2, *args[1:]]
-            if m in [BottleneckCSP, C3]:
+            if m in [BottleneckCSP, C3, C3x]:
                 args.insert(2, n)
                 n = 1
         elif m is nn.BatchNorm2d:

--- a/models/tf.py
+++ b/models/tf.py
@@ -27,7 +27,7 @@ import torch
 import torch.nn as nn
 from tensorflow import keras
 
-from models.common import C3, CrossConv, SPP, SPPF, Bottleneck, BottleneckCSP, Concat, Conv, DWConv, Focus, autopad
+from models.common import C3, SPP, SPPF, Bottleneck, BottleneckCSP, Concat, Conv, CrossConv, DWConv, Focus, autopad
 from models.experimental import MixConv2d, attempt_load
 from models.yolo import Detect
 from utils.activations import SiLU

--- a/models/tf.py
+++ b/models/tf.py
@@ -27,8 +27,8 @@ import torch
 import torch.nn as nn
 from tensorflow import keras
 
-from models.common import C3, SPP, SPPF, Bottleneck, BottleneckCSP, Concat, Conv, DWConv, Focus, autopad
-from models.experimental import CrossConv, MixConv2d, attempt_load
+from models.common import C3, CrossConv, SPP, SPPF, Bottleneck, BottleneckCSP, Concat, Conv, DWConv, Focus, autopad
+from models.experimental import MixConv2d, attempt_load
 from models.yolo import Detect
 from utils.activations import SiLU
 from utils.general import LOGGER, make_divisible, print_args

--- a/models/tf.py
+++ b/models/tf.py
@@ -27,7 +27,7 @@ import torch
 import torch.nn as nn
 from tensorflow import keras
 
-from models.common import C3, SPP, SPPF, Bottleneck, BottleneckCSP, Concat, Conv, CrossConv, DWConv, Focus, autopad
+from models.common import C3, C3x, SPP, SPPF, Bottleneck, BottleneckCSP, Concat, Conv, CrossConv, DWConv, Focus, autopad
 from models.experimental import MixConv2d, attempt_load
 from models.yolo import Detect
 from utils.activations import SiLU
@@ -341,7 +341,7 @@ def parse_model(d, ch, model, imgsz):  # model_dict, input_channels(3)
                 pass
 
         n = max(round(n * gd), 1) if n > 1 else n  # depth gain
-        if m in [nn.Conv2d, Conv, Bottleneck, SPP, SPPF, DWConv, MixConv2d, Focus, CrossConv, BottleneckCSP, C3]:
+        if m in [nn.Conv2d, Conv, Bottleneck, SPP, SPPF, DWConv, MixConv2d, Focus, CrossConv, BottleneckCSP, C3, C3x]:
             c1, c2 = ch[f], args[0]
             c2 = make_divisible(c2 * gw, 8) if c2 != no else c2
 

--- a/models/tf.py
+++ b/models/tf.py
@@ -209,7 +209,7 @@ class TFC3x(keras.layers.Layer):
         self.cv2 = TFConv(c1, c_, 1, 1, w=w.cv2)
         self.cv3 = TFConv(2 * c_, c2, 1, 1, w=w.cv3)
         self.m = keras.Sequential([
-            TFCrossConv(c_, c_, k=3, s=1, g=1, e=1.0, shortcut=False, w=w.m[j]) for j in range(n)])
+            TFCrossConv(c_, c_, k=3, s=1, g=g, e=1.0, shortcut=shortcut, w=w.m[j]) for j in range(n)])
 
     def call(self, inputs):
         return self.cv3(tf.concat((self.m(self.cv1(inputs)), self.cv2(inputs)), axis=3))

--- a/models/tf.py
+++ b/models/tf.py
@@ -50,6 +50,7 @@ class TFBN(keras.layers.Layer):
 
 
 class TFPad(keras.layers.Layer):
+
     def __init__(self, pad):
         super().__init__()
         if isinstance(pad, int):
@@ -210,8 +211,8 @@ class TFC3x(keras.layers.Layer):
         self.cv1 = TFConv(c1, c_, 1, 1, w=w.cv1)
         self.cv2 = TFConv(c1, c_, 1, 1, w=w.cv2)
         self.cv3 = TFConv(2 * c_, c2, 1, 1, w=w.cv3)
-        self.m = keras.Sequential(
-            [TFCrossConv(c_, c_, k=3, s=1, g=1, e=1.0, shortcut=False, w=w.m[j]) for j in range(n)])
+        self.m = keras.Sequential([
+            TFCrossConv(c_, c_, k=3, s=1, g=1, e=1.0, shortcut=False, w=w.m[j]) for j in range(n)])
 
     def call(self, inputs):
         return self.cv3(tf.concat((self.m(self.cv1(inputs)), self.cv2(inputs)), axis=3))

--- a/models/tf.py
+++ b/models/tf.py
@@ -27,7 +27,7 @@ import torch
 import torch.nn as nn
 from tensorflow import keras
 
-from models.common import C3, SPP, SPPF, Bottleneck, BottleneckCSP, C3x, Concat, Conv, CrossConv, DWConv, Focus, autopad
+from models.common import Bottleneck, BottleneckCSP, C3, C3x, Concat, Conv, CrossConv, DWConv, Focus, SPP, SPPF, autopad
 from models.experimental import MixConv2d, attempt_load
 from models.yolo import Detect
 from utils.activations import SiLU

--- a/models/tf.py
+++ b/models/tf.py
@@ -91,6 +91,7 @@ class TFDWConv(keras.layers.Layer):
     def __init__(self, c1, c2, k=1, s=1, p=None, g=1, act=True, w=None):
         # ch_in, ch_out, weights, kernel, stride, padding, groups
         super().__init__()
+        assert g == c1 == c2, f'TFDWConv() groups={g} must equal input={c1} and output={c2} channels'
         conv = keras.layers.DepthwiseConv2D(
             kernel_size=k,
             strides=s,

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -266,13 +266,13 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
 
         n = n_ = max(round(n * gd), 1) if n > 1 else n  # depth gain
         if m in (Conv, GhostConv, Bottleneck, GhostBottleneck, SPP, SPPF, DWConv, MixConv2d, Focus, CrossConv,
-                 BottleneckCSP, C3, C3TR, C3SPP, C3Ghost):
+                 BottleneckCSP, C3, C3TR, C3SPP, C3Ghost, C3x):
             c1, c2 = ch[f], args[0]
             if c2 != no:  # if not output
                 c2 = make_divisible(c2 * gw, 8)
 
             args = [c1, c2, *args[1:]]
-            if m in [BottleneckCSP, C3, C3TR, C3Ghost]:
+            if m in [BottleneckCSP, C3, C3TR, C3Ghost, C3x]:
                 args.insert(2, n)  # number of repeats
                 n = 1
         elif m is nn.BatchNorm2d:


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing CrossConv: a new cross-convolutional layer and updating autopad functionality.

### 📊 Key Changes
- Modified the `autopad` function to create lists instead of generators.
- Added a new `CrossConv` class to `common.py`, representing a cross-convolutional downsampling layer.
- Introduced `C3x` class to `common.py`, which is an extended version of the `C3` class with cross-convolutions.
- Moved `CrossConv` from `experimental.py` to `common.py` as it seems to be a more stable feature now.
- Updated the TensorFlow model definitions in `tf.py` to include the new `C3x` and `CrossConv` classes, along with adjustments for padding.
- Refactored `yolo.py` to recognize `C3x` as one of the core components of the model.

### 🎯 Purpose & Impact
- 🛠️ Enhances model flexibility with the addition of cross-convolutional layers which can help in capturing better features from input data.
- 🏎️ May improve the YOLOv5 model's accuracy and efficiency by enabling more complex feature mapping.
- ✅ Keeps TensorFlow and PyTorch implementations consistent with the addition of `C3x` and `CrossConv` in both model definitions.
- 📐 Adjustments in padding logic ensure that feature maps are properly aligned and there are no discrepancies between different layers' outputs.
- 🔄 Moving `CrossConv` to `common.py` suggests it has matured from an experimental feature to a more widely applicable component, potentially affecting a range of current and future models.