### PR TITLE
Fix TFDWConv() `c1 == c2` check

### DIFF
--- a/models/tf.py
+++ b/models/tf.py
@@ -88,10 +88,10 @@ class TFConv(keras.layers.Layer):
 
 class TFDWConv(keras.layers.Layer):
     # Depthwise convolution
-    def __init__(self, c1, c2, k=1, s=1, p=None, g=1, act=True, w=None):
+    def __init__(self, c1, c2, k=1, s=1, p=None, act=True, w=None):
         # ch_in, ch_out, weights, kernel, stride, padding, groups
         super().__init__()
-        assert g == c1 == c2, f'TFDWConv() groups={g} must equal input={c1} and output={c2} channels'
+        assert c1 == c2, f'TFDWConv() input={c1} must equal output={c2} channels'
         conv = keras.layers.DepthwiseConv2D(
             kernel_size=k,
             strides=s,


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of Depthwise Convolution Layer in TensorFlow Models.

### 📊 Key Changes
- Removed the `g` parameter (number of groups) from `TFDWConv` layer initializer arguments.
- Modified the assertion check to only require input channels (`c1`) to be equal to the output channels (`c2`), instead of also checking against the `g` parameter.

### 🎯 Purpose & Impact
- 🧹 Simplifies the initialization of the depthwise convolution layer by removing an unnecessary parameter.
- 🛠️ Ensures the integrity of the model by checking that the number of input channels matches the number of output channels, a requirement for depthwise convolution.
- 🔧 Reduces potential for configuration errors by removing the group check, which is not needed in depthwise convolutions as the input and output channels are naturally equal.
- 👩‍💻 Helps developers to work with a cleaner interface when utilizing the TFDWConv layer in their machine learning models, potentially increasing development productivity and model stability.