### PR TITLE
Replace `openvino-dev` with OpenVINO Runtime inference

### DIFF
--- a/export.py
+++ b/export.py
@@ -171,7 +171,7 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
 def export_openvino(model, im, file, half, prefix=colorstr('OpenVINO:')):
     # YOLOv5 OpenVINO export
     try:
-        check_requirements(('openvino')) 
+        check_requirements('openvino')
         import openvino.runtime
         LOGGER.info(f'\n{prefix} starting export with openvino {openvino.runtime.get_version()}...')
         f = str(file).replace('.pt', f'_openvino_model{os.sep}')

--- a/export.py
+++ b/export.py
@@ -171,9 +171,10 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
 def export_openvino(model, im, file, half, prefix=colorstr('OpenVINO:')):
     # YOLOv5 OpenVINO export
     try:
-        check_requirements('openvino')
-        import openvino.runtime
-        LOGGER.info(f'\n{prefix} starting export with openvino {openvino.runtime.get_version()}...')
+        check_requirements(('openvino-dev',))  # requires openvino-dev: https://pypi.org/project/openvino-dev/
+        import openvino.inference_engine as ie
+
+        LOGGER.info(f'\n{prefix} starting export with openvino {ie.__version__}...')
         f = str(file).replace('.pt', f'_openvino_model{os.sep}')
 
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f} --data_type {'FP16' if half else 'FP32'}"

--- a/export.py
+++ b/export.py
@@ -171,10 +171,9 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
 def export_openvino(model, im, file, half, prefix=colorstr('OpenVINO:')):
     # YOLOv5 OpenVINO export
     try:
-        check_requirements(('openvino-dev',))  # requires openvino-dev: https://pypi.org/project/openvino-dev/
-        import openvino.inference_engine as ie
-
-        LOGGER.info(f'\n{prefix} starting export with openvino {ie.__version__}...')
+        check_requirements(('openvino')) 
+        import openvino.runtime
+        LOGGER.info(f'\n{prefix} starting export with openvino {openvino.runtime.get_version()}...')
         f = str(file).replace('.pt', f'_openvino_model{os.sep}')
 
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f} --data_type {'FP16' if half else 'FP32'}"

--- a/models/common.py
+++ b/models/common.py
@@ -354,8 +354,8 @@ class DetectMultiBackend(nn.Module):
                 stride, names = int(meta['stride']), eval(meta['names'])
         elif xml:  # OpenVINO
             LOGGER.info(f'Loading {w} for OpenVINO inference...')
-            check_requirements(('openvino'))  # requires openvino-dev: https://pypi.org/project/openvino-dev/
-            from openvino.runtime import Core 
+            check_requirements('openvino')  # requires openvino-dev: https://pypi.org/project/openvino-dev/
+            from openvino.runtime import Core
             ie = Core()
             if not Path(w).is_file():  # if not *.xml
                 w = next(Path(w).glob('*.xml'))  # get *.xml file from *_openvino_model dir

--- a/models/common.py
+++ b/models/common.py
@@ -354,7 +354,7 @@ class DetectMultiBackend(nn.Module):
                 stride, names = int(meta['stride']), eval(meta['names'])
         elif xml:  # OpenVINO
             LOGGER.info(f'Loading {w} for OpenVINO inference...')
-            check_requirements('openvino')  # requires openvino-dev: https://pypi.org/project/openvino-dev/
+            check_requirements(('openvino',))  # requires openvino-dev: https://pypi.org/project/openvino-dev/
             from openvino.runtime import Core
             ie = Core()
             if not Path(w).is_file():  # if not *.xml

--- a/models/common.py
+++ b/models/common.py
@@ -354,13 +354,14 @@ class DetectMultiBackend(nn.Module):
                 stride, names = int(meta['stride']), eval(meta['names'])
         elif xml:  # OpenVINO
             LOGGER.info(f'Loading {w} for OpenVINO inference...')
-            check_requirements(('openvino-dev',))  # requires openvino-dev: https://pypi.org/project/openvino-dev/
-            import openvino.inference_engine as ie
-            core = ie.IECore()
+            check_requirements(('openvino'))  # requires openvino-dev: https://pypi.org/project/openvino-dev/
+            from openvino.runtime import Core 
+            ie = Core()
             if not Path(w).is_file():  # if not *.xml
                 w = next(Path(w).glob('*.xml'))  # get *.xml file from *_openvino_model dir
-            network = core.read_network(model=w, weights=Path(w).with_suffix('.bin'))  # *.xml, *.bin paths
-            executable_network = core.load_network(network, device_name='CPU', num_requests=1)
+            network = ie.read_model(model=w, weights=Path(w).with_suffix('.bin'))
+            executable_network = ie.compile_model(model=network, device_name="CPU")
+            self.output_layer = next(iter(executable_network.outputs))
         elif engine:  # TensorRT
             LOGGER.info(f'Loading {w} for TensorRT inference...')
             import tensorrt as trt  # https://developer.nvidia.com/nvidia-tensorrt-download
@@ -444,11 +445,7 @@ class DetectMultiBackend(nn.Module):
             y = self.session.run([self.session.get_outputs()[0].name], {self.session.get_inputs()[0].name: im})[0]
         elif self.xml:  # OpenVINO
             im = im.cpu().numpy()  # FP32
-            desc = self.ie.TensorDesc(precision='FP32', dims=im.shape, layout='NCHW')  # Tensor Description
-            request = self.executable_network.requests[0]  # inference request
-            request.set_blob(blob_name='images', blob=self.ie.Blob(desc, im))  # name=next(iter(request.input_blobs))
-            request.infer()
-            y = request.output_blobs['output'].buffer  # name=next(iter(request.output_blobs))
+            y = self.executable_network([im])[self.output_layer]
         elif self.engine:  # TensorRT
             assert im.shape == self.bindings['images'].shape, (im.shape, self.bindings['images'].shape)
             self.binding_addrs['images'] = int(im.data_ptr())


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

One of OpenVINO use cases is to run it on Raspberry devices. I'm proposing to make the inference using openvino.runtime, which is installable at raspberry and is available at latest openvino package (tested with openvino==2022.1.0).

The previous inference using openvino-dev was not usable at devices where the dev package is not available.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved OpenVINO integration in YOLOv5's model loading and inference.

### 📊 Key Changes
- Updated OpenVINO package requirement from `openvino-dev` to `openvino`.
- Switched to newer OpenVINO Python API usage with `Core` instead of `IECore`.
- Simplified OpenVINO network reading and compiling processes.
- Streamlined OpenVINO inference code to reduce verbosity and complexity.

### 🎯 Purpose & Impact
- **Purpose**: The update ensures compatibility with the latest OpenVINO version and takes advantage of the more user-friendly API.
- **Impact**: Users leveraging OpenVINO for model inference will experience a more straightforward setup with potentially enhanced stability and performance improvements. 🚀