### PR TITLE
TFDWConv() `depthwise_initializer` fix

### DIFF
--- a/models/tf.py
+++ b/models/tf.py
@@ -97,7 +97,7 @@ class TFDWConv(keras.layers.Layer):
             strides=s,
             padding='SAME' if s == 1 else 'VALID',
             use_bias=not hasattr(w, 'bn'),
-            kernel_initializer=keras.initializers.Constant(w.conv.weight.permute(2, 3, 1, 0).numpy()),
+            depthwise_initializer=keras.initializers.Constant(w.conv.weight.permute(2, 3, 1, 0).numpy()),
             bias_initializer='zeros' if hasattr(w, 'bn') else keras.initializers.Constant(w.conv.bias.numpy()))
         self.conv = conv if s == 1 else keras.Sequential([TFPad(autopad(k, p)), conv])
         self.bn = TFBN(w.bn) if hasattr(w, 'bn') else tf.identity


### PR DESCRIPTION
Resolves bug in https://github.com/ultralytics/yolov5/pull/7824

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary

Improved TensorFlow kernel initialization in YOLOv5 models.

### 📊 Key Changes

- Changed `kernel_initializer` to `depthwise_initializer` in the TensorFlow convolution layer configuration.

### 🎯 Purpose & Impact

- 🎯 **Purpose**: Ensures the correct initializer is used when TensorFlow layers are created, specifically for depthwise convolutions which require `depthwise_initializer`.
- 💥 **Impact**: This change could lead to better performance and stability during the training of YOLOv5 models with TensorFlow, as it allows for the correct initialization of these layers' weights. It might also fix any potential bugs previously present due to the incorrect use of `kernel_initializer` for depthwise layers.