### PR TITLE
Update Dockerfile `--no-install-recommends`

### DIFF
--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN rm -rf /opt/pytorch  # remove 1.2GB dir
 ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/
 
 # Install linux packages
-RUN apt update && apt install -y zip htop screen libgl1-mesa-glx
+RUN apt update && apt install --no-install-recommends -y zip htop screen libgl1-mesa-glx
 
 # Install pip packages
 COPY requirements.txt .

--- a/utils/docker/Dockerfile-M1
+++ b/utils/docker/Dockerfile-M1
@@ -10,7 +10,7 @@ ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Aria
 # Install linux packages
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y tzdata
-RUN apt install -y python3-pip git zip curl htop screen libgl1-mesa-glx libglib2.0-0
+RUN apt install -y apt install --no-install-recommends python3-pip git zip curl htop screen libgl1-mesa-glx libglib2.0-0
 # RUN alias python=python3
 
 # Install pip packages

--- a/utils/docker/Dockerfile-M1
+++ b/utils/docker/Dockerfile-M1
@@ -10,7 +10,7 @@ ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Aria
 # Install linux packages
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y tzdata
-RUN apt install -y apt install --no-install-recommends python3-pip git zip curl htop screen libgl1-mesa-glx libglib2.0-0
+RUN apt install --no-install-recommends -y python3-pip git zip curl htop screen libgl1-mesa-glx libglib2.0-0
 # RUN alias python=python3
 
 # Install pip packages

--- a/utils/docker/Dockerfile-cpu
+++ b/utils/docker/Dockerfile-cpu
@@ -10,7 +10,6 @@ ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Aria
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y tzdata
 RUN apt install --no-install-recommends -y python3-pip git zip curl htop screen libgl1-mesa-glx libglib2.0-0
-
 # RUN alias python=python3
 
 # Install pip packages

--- a/utils/docker/Dockerfile-cpu
+++ b/utils/docker/Dockerfile-cpu
@@ -9,7 +9,8 @@ ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Aria
 # Install linux packages
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y tzdata
-RUN apt install -y python3-pip git zip curl htop screen libgl1-mesa-glx libglib2.0-0
+RUN apt install --no-install-recommends -y python3-pip git zip curl htop screen libgl1-mesa-glx libglib2.0-0
+
 # RUN alias python=python3
 
 # Install pip packages


### PR DESCRIPTION
Per https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Docker build efficiency by optimizing Linux package installations.

### 📊 Key Changes
- Modified the `apt install` command to include `--no-install-recommends` which reduces the number of installed packages.

### 🎯 Purpose & Impact
- **Reduced Image Size**: By not installing recommended but unnecessary packages, the Docker images will be smaller, which saves storage space and speeds up the download time for users.
- **Faster Build Times**: Smaller images lead to quicker build and deployment processes, improving efficiency.
- **Streamlined Environments**: Reduces potential for software conflicts and security vulnerabilities by limiting the number of packages installed in the images.