### PR TITLE
Update Dockerfile-cpu install `libpython3.8-dev`

### DIFF
--- a/utils/docker/Dockerfile-arm64
+++ b/utils/docker/Dockerfile-arm64
@@ -10,7 +10,7 @@ ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Aria
 # Install linux packages
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y tzdata
-RUN apt install --no-install-recommends -y python3-pip git zip curl htop screen libgl1-mesa-glx libglib2.0-0
+RUN apt install --no-install-recommends -y python3-pip git zip curl htop libgl1-mesa-glx libglib2.0-0 libpython3.8-dev
 # RUN alias python=python3
 
 # Install pip packages

--- a/utils/docker/Dockerfile-cpu
+++ b/utils/docker/Dockerfile-cpu
@@ -9,7 +9,7 @@ ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Aria
 # Install linux packages
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y tzdata
-RUN apt install --no-install-recommends -y python3-pip git zip curl htop screen libgl1-mesa-glx libglib2.0-0
+RUN apt install --no-install-recommends -y python3-pip git zip curl htop libgl1-mesa-glx libglib2.0-0 libpython3.8-dev
 # RUN alias python=python3
 
 # Install pip packages


### PR DESCRIPTION
Fix OpenVINO export 
```python
OpenVINO: export failure: libpython3.8.so.1.0: cannot open shared object file: No such file or directory
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update Dockerfiles to include `libpython3.8-dev` package.

### 📊 Key Changes
- 📦 `screen` package removed from Dockerfile dependencies.
- ➕ Added `libpython3.8-dev` to the Dockerfile for both ARM64 and CPU architectures.

### 🎯 Purpose & Impact
- 🛠️ The addition of `libpython3.8-dev` ensures that development headers and libraries for Python 3.8 are included, potentially aiding in the compilation of Python extensions or the execution of Python code that requires these resources.
- 🧹 Removing `screen` might streamline the Docker image, reducing its size slightly, as it implies that a terminal multiplexer is no longer considered necessary for the container environment.
- 👩‍💻👨‍💻 Users running YOLOv5 in Docker containers might experience more robust Python environment setup, particularly when dealing with extension modules that require development headers.