### PR TITLE
Add TFDWConv() `depth_multiplier` arg

### DIFF
--- a/models/tf.py
+++ b/models/tf.py
@@ -91,9 +91,10 @@ class TFDWConv(keras.layers.Layer):
     def __init__(self, c1, c2, k=1, s=1, p=None, act=True, w=None):
         # ch_in, ch_out, weights, kernel, stride, padding, groups
         super().__init__()
-        assert c1 == c2, f'TFDWConv() input={c1} must equal output={c2} channels'
+        assert c2 % c1 == 0, f'TFDWConv() output={c2} must be a multiple of input={c1} channels'
         conv = keras.layers.DepthwiseConv2D(
             kernel_size=k,
+            depth_multiplier=c2 // c1,
             strides=s,
             padding='SAME' if s == 1 else 'VALID',
             use_bias=not hasattr(w, 'bn'),


### PR DESCRIPTION
Enables grouped non c1 == c2 convolutions in TF YOLOv5 models.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced compatibility for TensorFlow depth-wise convolution layers in YOLOv5 models.

### 📊 Key Changes
- Adjusted the assertion in the `TFDWConv` layer to allow the output channels to be a multiple of the input channels, not strictly equal.
- Added `depth_multiplier` argument to the `DepthwiseConv2D` layer to handle the case where output channels are multiple of input channels.

### 🎯 Purpose & Impact
- 🎨 **Flexibility**: Allows more flexibility in model design by supporting depth-wise convolutions with varied channel proportions.
- 🎓 **Compatibility**: Ensures broader compatibility with different model architectures that use depth-wise convolutions.
- 🚀 **Potential Impact**: Users can design and train more complex models within TensorFlow using YOLOv5, potentially improving performance on various tasks.