### PR TITLE
Removed shell=True from subprocess commands that require user inputs

### DIFF
--- a/export.py
+++ b/export.py
@@ -84,7 +84,7 @@ def export_formats():
         ['TensorFlow GraphDef', 'pb', '.pb', True],
         ['TensorFlow Lite', 'tflite', '.tflite', False],
         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False],
-        ['TensorFlow.js', 'tfjs', '_web_model', False],]
+        ['TensorFlow.js', 'tfjs', '_web_model', False], ]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'GPU'])
 
 
@@ -168,7 +168,7 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
         LOGGER.info(f'{prefix} export failure: {e}')
 
 
-def export_openvino(model, im, file, half, prefix=colorstr('OpenVINO:')):
+def export_openvino(file, half, prefix=colorstr('OpenVINO:')):
     # YOLOv5 OpenVINO export
     try:
         check_requirements(('openvino-dev',))  # requires openvino-dev: https://pypi.org/project/openvino-dev/
@@ -178,7 +178,7 @@ def export_openvino(model, im, file, half, prefix=colorstr('OpenVINO:')):
         f = str(file).replace('.pt', f'_openvino_model{os.sep}')
 
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f} --data_type {'FP16' if half else 'FP32'}"
-        subprocess.check_output(cmd, shell=True)
+        subprocess.check_output(cmd.split())
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')
         return f
@@ -324,7 +324,7 @@ def export_saved_model(model,
         return None, None
 
 
-def export_pb(keras_model, im, file, prefix=colorstr('TensorFlow GraphDef:')):
+def export_pb(keras_model, file, prefix=colorstr('TensorFlow GraphDef:')):
     # YOLOv5 TensorFlow GraphDef *.pb export https://github.com/leimao/Frozen_Graph_TensorFlow
     try:
         import tensorflow as tf
@@ -379,7 +379,7 @@ def export_tflite(keras_model, im, file, int8, data, nms, agnostic_nms, prefix=c
         LOGGER.info(f'\n{prefix} export failure: {e}')
 
 
-def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
+def export_edgetpu(file, prefix=colorstr('Edge TPU:')):
     # YOLOv5 Edge TPU export https://coral.ai/docs/edgetpu/models-intro/
     try:
         cmd = 'edgetpu_compiler --version'
@@ -400,7 +400,7 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
         f_tfl = str(file).replace('.pt', '-int8.tflite')  # TFLite model
 
         cmd = f"edgetpu_compiler -s -o {file.parent} {f_tfl}"
-        subprocess.run(cmd, shell=True, check=True)
+        subprocess.run(cmd.split())
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')
         return f
@@ -408,7 +408,7 @@ def export_edgetpu(keras_model, im, file, prefix=colorstr('Edge TPU:')):
         LOGGER.info(f'\n{prefix} export failure: {e}')
 
 
-def export_tfjs(keras_model, im, file, prefix=colorstr('TensorFlow.js:')):
+def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
     # YOLOv5 TensorFlow.js export
     try:
         check_requirements(('tensorflowjs',))
@@ -422,8 +422,9 @@ def export_tfjs(keras_model, im, file, prefix=colorstr('TensorFlow.js:')):
         f_json = f'{f}/model.json'  # *.json path
 
         cmd = f'tensorflowjs_converter --input_format=tf_frozen_model ' \
-              f'--output_node_names="Identity,Identity_1,Identity_2,Identity_3" {f_pb} {f}'
-        subprocess.run(cmd, shell=True)
+              f'--output_node_names=Identity,Identity_1,Identity_2,Identity_3 {f_pb} {f}'
+
+        subprocess.run(cmd.split())
 
         with open(f_json) as j:
             json = j.read()
@@ -519,7 +520,7 @@ def run(
     if onnx or xml:  # OpenVINO requires ONNX
         f[2] = export_onnx(model, im, file, opset, train, dynamic, simplify)
     if xml:  # OpenVINO
-        f[3] = export_openvino(model, im, file, half)
+        f[3] = export_openvino(file, half)
     if coreml:
         _, f[4] = export_coreml(model, im, file, int8, half)
 
@@ -539,13 +540,13 @@ def run(
                                          conf_thres=conf_thres,
                                          iou_thres=iou_thres)  # keras model
         if pb or tfjs:  # pb prerequisite to tfjs
-            f[6] = export_pb(model, im, file)
+            f[6] = export_pb(model, file)
         if tflite or edgetpu:
             f[7] = export_tflite(model, im, file, int8=int8 or edgetpu, data=data, nms=nms, agnostic_nms=agnostic_nms)
         if edgetpu:
-            f[8] = export_edgetpu(model, im, file)
+            f[8] = export_edgetpu(file)
         if tfjs:
-            f[9] = export_tfjs(model, im, file)
+            f[9] = export_tfjs(file)
 
     # Finish
     f = [str(x) for x in f if x]  # filter out '' and None

--- a/export.py
+++ b/export.py
@@ -84,7 +84,7 @@ def export_formats():
         ['TensorFlow GraphDef', 'pb', '.pb', True],
         ['TensorFlow Lite', 'tflite', '.tflite', False],
         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False],
-        ['TensorFlow.js', 'tfjs', '_web_model', False], ]
+        ['TensorFlow.js', 'tfjs', '_web_model', False],]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'GPU'])
 
 

--- a/export.py
+++ b/export.py
@@ -423,7 +423,6 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
 
         cmd = f'tensorflowjs_converter --input_format=tf_frozen_model ' \
               f'--output_node_names=Identity,Identity_1,Identity_2,Identity_3 {f_pb} {f}'
-
         subprocess.run(cmd.split())
 
         with open(f_json) as j:

--- a/export.py
+++ b/export.py
@@ -400,7 +400,7 @@ def export_edgetpu(file, prefix=colorstr('Edge TPU:')):
         f_tfl = str(file).replace('.pt', '-int8.tflite')  # TFLite model
 
         cmd = f"edgetpu_compiler -s -o {file.parent} {f_tfl}"
-        subprocess.run(cmd.split())
+        subprocess.run(cmd.split(), check=True)
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')
         return f


### PR DESCRIPTION
This PR involves the following changes
- Removal of unused arguments in functions
- Removed `shell=True` from subprocess calls where user-defined inputs are provided (to prevent possible unwanted injection)

I ran the scripts after modification inside of the yolo docker container and checked manually to see if it works. 
If needed I can also post serialized outputs and computational graph generated by netron. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to model export functionality in 'ultralytics/yolov5.'

### 📊 Key Changes
- Simplified function signatures by removing unnecessary `model` and `im` parameters from OpenVINO, TensorFlow GraphDef (pb), Edge TPU, and TensorFlow.js export functions.
- Replaced `subprocess.check_output` and `subprocess.run` with `shell=True` to use `.split()` method, enhancing security and preventing shell injection vulnerabilities.

### 🎯 Purpose & Impact
- 🛠 **Code Simplicity:** Removing unused parameters makes the codebase cleaner and easier to understand.
- 🔒 **Security Improvement:** Moving away from `shell=True` prevents execution of arbitrary code, making exports more secure.
- 👩‍💻 **Developer Experience:** These changes could improve the maintainability and contribute to the robustness of the export functionality for developers.
- 🏃‍♂️ **Operational Efficiency:** Users can export models more safely and potentially with fewer errors or complications.