### PR TITLE
Invert Docker Image publishing order

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ name: Publish Docker Images
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   # pull_request:
   #   branches: [master]
 
@@ -28,6 +28,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Build and push arm64 image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/arm64
+          file: utils/docker/Dockerfile-arm64
+          push: true
+          tags: ultralytics/yolov5:latest-arm64
+
       - name: Build and push CPU image
         uses: docker/build-push-action@v3
         with:
@@ -43,12 +52,3 @@ jobs:
           file: utils/docker/Dockerfile
           push: true
           tags: ultralytics/yolov5:latest
-
-      - name: Build and push arm64 image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/arm64
-          file: utils/docker/Dockerfile-arm64
-          push: true
-          tags: ultralytics/yolov5:latest-arm64


### PR DESCRIPTION
To appear on Docker Hub (https://calendly.com/ultralytics/meet) in top down order:

- latest
- latest-cpu
- latest-arm64

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to the Docker image publishing workflow for YOLOv5.

### 📊 Key Changes
- Reformatted the branches line in the workflow for clarity.
- Reorganized steps to build and push Docker images, specifically for the ARM64 architecture.

### 🎯 Purpose & Impact
- Improved readability in the CI configuration helps maintainability.
- By moving the ARM64 Docker image build to an earlier step, the workflow is potentially streamlined, potentially leading to faster builds.
- Users of ARM64 architecture will receive Docker images faster and could experience improved reliability in image delivery.