### PR TITLE
Add `DWConvTranspose2d()` module

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -56,6 +56,12 @@ class DWConv(Conv):
         super().__init__(c1, c2, k, s, g=math.gcd(c1, c2), act=act)
 
 
+class DWConvTranspose2d(nn.ConvTranspose2d):
+    # Depth-wise transpose convolution class
+    def __init__(self, c1, c2, k=1, s=1, p1=0, p2=0):  # ch_in, ch_out, kernel, stride, padding, padding_out
+        super().__init__(c1, c2, k, s, p1, p2, groups=math.gcd(c1, c2))
+
+
 class TransformerLayer(nn.Module):
     # Transformer layer https://arxiv.org/abs/2010.11929 (LayerNorm layers removed for better performance)
     def __init__(self, c, num_heads):

--- a/models/tf.py
+++ b/models/tf.py
@@ -117,7 +117,7 @@ class TFDWConvTranspose2d(keras.layers.Layer):
         assert c1 == c2, f'TFDWConv() output={c2} must be equal to input={c1} channels'
         assert k == 4 and p1 == 1, 'TFDWConv() only valid for k=4 and p1=1'
         weight, bias = w.weight.permute(2, 3, 1, 0).numpy(), w.bias.numpy()
-        self.ch = c1
+        self.c1 = c1
         self.conv = [
             keras.layers.Conv2DTranspose(filters=1,
                                          kernel_size=k,

--- a/models/tf.py
+++ b/models/tf.py
@@ -117,15 +117,15 @@ class TFDWConvTranspose2d(keras.layers.Layer):
         assert c1 == c2, f'TFDWConv() output={c2} must be equal to input={c1} channels'
         assert k == 4 and p1 == 1, 'TFDWConv() only valid for k=4 and p1=1'
         weight, bias = w.weight.permute(2, 3, 1, 0).numpy(), w.bias.numpy()
-        self.conv = [keras.layers.Conv2DTranspose(filters=1,
-                                                  kernel_size=k,
-                                                  strides=s,
-                                                  padding='VALID',
-                                                  output_padding=p2,
-                                                  use_bias=True,
-                                                  kernel_initializer=keras.initializers.Constant(weight),
-                                                  bias_initializer=keras.initializers.Constant(bias[i]))
-                     for i in range(c2)]
+        self.conv = [
+            keras.layers.Conv2DTranspose(filters=1,
+                                         kernel_size=k,
+                                         strides=s,
+                                         padding='VALID',
+                                         output_padding=p2,
+                                         use_bias=True,
+                                         kernel_initializer=keras.initializers.Constant(weight),
+                                         bias_initializer=keras.initializers.Constant(bias[i])) for i in range(c2)]
 
     def call(self, inputs):
         return tf.concat([x(inputs) for x in self.conv], 3)[:, 1:-1, 1:-1]

--- a/models/tf.py
+++ b/models/tf.py
@@ -27,8 +27,8 @@ import torch
 import torch.nn as nn
 from tensorflow import keras
 
-from models.common import C3, SPP, SPPF, Bottleneck, BottleneckCSP, C3x, Concat, Conv, CrossConv, DWConv, \
-    DWConvTranspose2d, Focus, autopad
+from models.common import (C3, SPP, SPPF, Bottleneck, BottleneckCSP, C3x, Concat, Conv, CrossConv, DWConv,
+                           DWConvTranspose2d, Focus, autopad)
 from models.experimental import MixConv2d, attempt_load
 from models.yolo import Detect
 from utils.activations import SiLU
@@ -116,15 +116,17 @@ class TFDWConvTranspose2d(keras.layers.Layer):
         super().__init__()
         assert c1 == c2, f'TFDWConv() output={c2} must be equal to input={c1} channels'
         assert k == 4 and p1 == 1, 'TFDWConv() only valid for k=4 and p1=1'
-        self.conv = [keras.layers.Conv2DTranspose(
-            filters=1,
-            kernel_size=k,
-            strides=s,
-            padding='VALID',
-            output_padding=p2,
-            use_bias=True,
-            kernel_initializer=keras.initializers.Constant(w.weight.permute(2, 3, 1, 0).numpy()[..., i:i + 1]),
-            bias_initializer=keras.initializers.Constant(w.bias.numpy()[i])) for i in range(c2)]
+        self.conv = [
+            keras.layers.Conv2DTranspose(filters=1,
+                                         kernel_size=k,
+                                         strides=s,
+                                         padding='VALID',
+                                         output_padding=p2,
+                                         use_bias=True,
+                                         kernel_initializer=keras.initializers.Constant(
+                                             w.weight.permute(2, 3, 1, 0).numpy()[..., i:i + 1]),
+                                         bias_initializer=keras.initializers.Constant(w.bias.numpy()[i]))
+            for i in range(c2)]
 
     def call(self, inputs):
         return tf.concat(self.conv(inputs), 3)[:, 1:-1, 1:-1]
@@ -174,14 +176,14 @@ class TFConv2d(keras.layers.Layer):
     def __init__(self, c1, c2, k, s=1, g=1, bias=True, w=None):
         super().__init__()
         assert g == 1, "TF v2.2 Conv2D does not support 'groups' argument"
-        self.conv = keras.layers.Conv2D(
-            filters=c2,
-            kernel_size=k,
-            strides=s,
-            padding='VALID',
-            use_bias=bias,
-            kernel_initializer=keras.initializers.Constant(w.weight.permute(2, 3, 1, 0).numpy()),
-            bias_initializer=keras.initializers.Constant(w.bias.numpy()) if bias else None)
+        self.conv = keras.layers.Conv2D(filters=c2,
+                                        kernel_size=k,
+                                        strides=s,
+                                        padding='VALID',
+                                        use_bias=bias,
+                                        kernel_initializer=keras.initializers.Constant(
+                                            w.weight.permute(2, 3, 1, 0).numpy()),
+                                        bias_initializer=keras.initializers.Constant(w.bias.numpy()) if bias else None)
 
     def call(self, inputs):
         return self.conv(inputs)
@@ -361,8 +363,9 @@ def parse_model(d, ch, model, imgsz):  # model_dict, input_channels(3)
                 pass
 
         n = max(round(n * gd), 1) if n > 1 else n  # depth gain
-        if m in [nn.Conv2d, Conv, DWConv, DWConvTranspose2d, Bottleneck, SPP, SPPF, MixConv2d, Focus, CrossConv,
-                 BottleneckCSP, C3, C3x]:
+        if m in [
+                nn.Conv2d, Conv, DWConv, DWConvTranspose2d, Bottleneck, SPP, SPPF, MixConv2d, Focus, CrossConv,
+                BottleneckCSP, C3, C3x]:
             c1, c2 = ch[f], args[0]
             c2 = make_divisible(c2 * gw, 8) if c2 != no else c2
 

--- a/models/tf.py
+++ b/models/tf.py
@@ -115,15 +115,17 @@ class TFDWConvTranspose2d(keras.layers.Layer):
         super().__init__()
         assert c1 == c2, f'TFDWConv() output={c2} must be equal to input={c1} channels'
         assert k == 4 and p1 == 1, 'TFDWConv() only valid for k=4 and p1=1'
-        self.conv = tf.concat([keras.layers.ConvTranspose2d(
-            filters=1,
-            kernel_size=k,
-            strides=s,
-            padding='VALID',
-            output_padding=p2,
-            use_bias=True,
-            kernel_initializer=keras.initializers.Constant(w.conv.weight.permute(2, 3, 1, 0).numpy()[:, i:i + 1]),
-            bias_initializer=keras.initializers.Constant(w.conv.bias.numpy())) for i in range(c2)], 3)
+        self.conv = tf.concat([
+            keras.layers.ConvTranspose2d(filters=1,
+                                         kernel_size=k,
+                                         strides=s,
+                                         padding='VALID',
+                                         output_padding=p2,
+                                         use_bias=True,
+                                         kernel_initializer=keras.initializers.Constant(
+                                             w.conv.weight.permute(2, 3, 1, 0).numpy()[:, i:i + 1]),
+                                         bias_initializer=keras.initializers.Constant(w.conv.bias.numpy()))
+            for i in range(c2)], 3)
 
     def call(self, inputs):
         return self.conv(inputs)[:, 1:-1, 1:-1]
@@ -173,14 +175,14 @@ class TFConv2d(keras.layers.Layer):
     def __init__(self, c1, c2, k, s=1, g=1, bias=True, w=None):
         super().__init__()
         assert g == 1, "TF v2.2 Conv2D does not support 'groups' argument"
-        self.conv = keras.layers.Conv2D(
-            filters=c2,
-            kernel_size=k,
-            strides=s,
-            padding='VALID',
-            use_bias=bias,
-            kernel_initializer=keras.initializers.Constant(w.weight.permute(2, 3, 1, 0).numpy()),
-            bias_initializer=keras.initializers.Constant(w.bias.numpy()) if bias else None)
+        self.conv = keras.layers.Conv2D(filters=c2,
+                                        kernel_size=k,
+                                        strides=s,
+                                        padding='VALID',
+                                        use_bias=bias,
+                                        kernel_initializer=keras.initializers.Constant(
+                                            w.weight.permute(2, 3, 1, 0).numpy()),
+                                        bias_initializer=keras.initializers.Constant(w.bias.numpy()) if bias else None)
 
     def call(self, inputs):
         return self.conv(inputs)

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -266,7 +266,7 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
 
         n = n_ = max(round(n * gd), 1) if n > 1 else n  # depth gain
         if m in (Conv, GhostConv, Bottleneck, GhostBottleneck, SPP, SPPF, DWConv, MixConv2d, Focus, CrossConv,
-                 BottleneckCSP, C3, C3TR, C3SPP, C3Ghost, C3x):
+                BottleneckCSP, C3, C3TR, C3SPP, C3Ghost, nn.ConvTranspose2d, DWConvTranspose2d, C3x):
             c1, c2 = ch[f], args[0]
             if c2 != no:  # if not output
                 c2 = make_divisible(c2 * gw, 8)

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -266,7 +266,7 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
 
         n = n_ = max(round(n * gd), 1) if n > 1 else n  # depth gain
         if m in (Conv, GhostConv, Bottleneck, GhostBottleneck, SPP, SPPF, DWConv, MixConv2d, Focus, CrossConv,
-                BottleneckCSP, C3, C3TR, C3SPP, C3Ghost, nn.ConvTranspose2d, DWConvTranspose2d, C3x):
+                 BottleneckCSP, C3, C3TR, C3SPP, C3Ghost, nn.ConvTranspose2d, DWConvTranspose2d, C3x):
             c1, c2 = ch[f], args[0]
             if c2 != no:  # if not output
                 c2 = make_divisible(c2 * gw, 8)


### PR DESCRIPTION
Add DWConvTranspose2d() module. @sergiossm 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Implementation of Depth-wise Transpose Convolutional layers in both PyTorch and TensorFlow for Ultralytics' YOLOv5.

### 📊 Key Changes
- 🛠 Added `DWConvTranspose2d` class in `models/common.py` which defines a new depth-wise transpose convolution operation in PyTorch.
- ✨ Introduced `TFDWConvTranspose2d` class in `models/tf.py`, which is the TensorFlow equivalent of the new depth-wise transpose convolutional layer.
- 🔧 Modified `models/yolo.py` and `models/common.py` to include depth-wise transpose convolutional layers in their respective model parsing methods.
- 🚀 Enhanced model architecture choices by allowing depth-wise transpose convolutions to be used in YOLO model definitions.

### 🎯 Purpose & Impact
- 📈 The new depth-wise transpose convolutional layers provide more architectural flexibility, potentially improving model performance for certain tasks.
- 🐍 By supporting both PyTorch and TensorFlow, these changes enable a wider range of developers to experiment with and benefit from these layers.
- 🔍 Users might expect better feature extraction capabilities and more efficient computation from models leveraging depth-wise transpose convolutions.