### PR TITLE
Added Windows cmd to count GPU devices

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -40,14 +40,10 @@ def torch_distributed_zero_first(local_rank: int):
 
 
 def device_count():
-    # Returns number of CUDA devices available. Safe version of torch.cuda.device_count(). Only works on Linux.
-    system_platform = platform.system()
-    assert system_platform == 'Linux' or 'Windows', 'device_count() function only works on Linux or Windows'
+    # Returns number of CUDA devices available. Safe version of torch.cuda.device_count(). Supports Linux and Windows
+    assert platform.system() in ('Linux', 'Windows'), 'device_count() only supported on Linux or Windows'
     try:
-        if system_platform == 'Linux':
-            cmd = 'nvidia-smi -L | wc -l'
-        elif system_platform == 'Windows':
-            cmd = 'nvidia-smi -L | find /c /v ""'
+        cmd = 'nvidia-smi -L | wc -l' if platform.system() == 'Linux' else 'nvidia-smi -L | find /c /v ""'  # Windows
         return int(subprocess.run(cmd, shell=True, capture_output=True, check=True).stdout.decode().split()[-1])
     except Exception:
         return 0

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -41,9 +41,13 @@ def torch_distributed_zero_first(local_rank: int):
 
 def device_count():
     # Returns number of CUDA devices available. Safe version of torch.cuda.device_count(). Only works on Linux.
-    assert platform.system() == 'Linux', 'device_count() function only works on Linux'
+    system_platform = platform.system()
+    assert system_platform == 'Linux' or 'Windows', 'device_count() function only works on Linux or Windows'
     try:
-        cmd = 'nvidia-smi -L | wc -l'
+        if system_platform == 'Linux':
+            cmd = 'nvidia-smi -L | wc -l'
+        elif system_platform == 'Windows':
+            cmd = 'nvidia-smi -L | find /c /v ""'
         return int(subprocess.run(cmd, shell=True, capture_output=True, check=True).stdout.decode().split()[-1])
     except Exception:
         return 0


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced GPU count compatibility for YOLOv5 on Windows.

### 📊 Key Changes
- Updated `device_count()` in `utils/torch_utils.py` to support Windows.
- Modified the assertion to allow the function to run on both Linux and Windows systems.
- Adapted the command within `device_count()` to differentiate between Linux and Windows environments.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: Expand the usability of the YOLOv5 by allowing it to correctly count available CUDA devices on Windows, not just Linux.
- 💻 **Impact**: Windows users can now leverage YOLOv5 with improved support for their GPU environments, leading to better accessibility and convenience for a broader user base.