### PR TITLE
`cv2.resize` interpolation fix

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -663,7 +663,7 @@ class LoadImagesAndLabels(Dataset):
             h0, w0 = im.shape[:2]  # orig hw
             r = self.img_size / max(h0, w0)  # ratio
             if r != 1:  # if sizes are not equal
-                interp = cv2.INTER_LINEAR if self.augment else cv2.INTER_AREA  # random.choice(self.rand_interp_methods)
+                interp = cv2.INTER_LINEAR if (self.augment or r > 1) else cv2.INTER_AREA
                 im = cv2.resize(im, (int(w0 * r), int(h0 * r)), interpolation=interp)
             return im, (h0, w0), im.shape[:2]  # im, hw_original, hw_resized
         else:


### PR DESCRIPTION
Fix for https://github.com/ultralytics/yolov5/discussions/7901 causing incorrect results on resizing images upward.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in image resizing conditions for the YOLOv5 data loader.

### 📊 Key Changes
- Modified the condition to select the interpolation method during image resizing.

### 🎯 Purpose & Impact
- Ensures high-quality image resizing by choosing the appropriate interpolation method based on whether augmentation is applied or the resizing ratio is greater than 1.
- This can improve the model's performance by maintaining the quality of images during training, especially when images are being scaled up (enlarged). 📈
- Users may notice improved detection accuracy and better results from their trained models because the input data quality directly affects model performance. 🎯