### PR TITLE
Add `--keras` argument for TF exports

### DIFF
--- a/export.py
+++ b/export.py
@@ -455,6 +455,7 @@ def run(
         half=False,  # FP16 half-precision export
         inplace=False,  # set YOLOv5 Detect() inplace=True
         train=False,  # model.train() mode
+        keras=False,  # use Keras
         optimize=False,  # TorchScript: optimize for mobile
         int8=False,  # CoreML/TF INT8 quantization
         dynamic=False,  # ONNX/TF: dynamic axes
@@ -536,8 +537,9 @@ def run(
                                          agnostic_nms=agnostic_nms or tfjs,
                                          topk_per_class=topk_per_class,
                                          topk_all=topk_all,
+                                         iou_thres=iou_thres,
                                          conf_thres=conf_thres,
-                                         iou_thres=iou_thres)  # keras model
+                                         keras=keras)
         if pb or tfjs:  # pb prerequisite to tfjs
             f[6] = export_pb(model, file)
         if tflite or edgetpu:
@@ -569,6 +571,7 @@ def parse_opt():
     parser.add_argument('--half', action='store_true', help='FP16 half-precision export')
     parser.add_argument('--inplace', action='store_true', help='set YOLOv5 Detect() inplace=True')
     parser.add_argument('--train', action='store_true', help='model.train() mode')
+    parser.add_argument('--keras', action='store_true', help='TF: use Keras')
     parser.add_argument('--optimize', action='store_true', help='TorchScript: optimize for mobile')
     parser.add_argument('--int8', action='store_true', help='CoreML/TF INT8 quantization')
     parser.add_argument('--dynamic', action='store_true', help='ONNX/TF: dynamic axes')


### PR DESCRIPTION
Resolves https://github.com/ultralytics/yolov5/issues/7911#issuecomment-1133671255

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced export capabilities with Keras model support in YOLOv5.

### 📊 Key Changes
- Added a `keras` flag to enable Keras model export functionality.
- Incorporated Keras export logic into the model export process.
- Updated command-line argument parser to accept the new `--keras` parameter for triggering Keras exports.

### 🎯 Purpose & Impact
- **Purpose:** This change allows users to export YOLOv5 models as Keras models, providing additional flexibility.
- **Impact:** Users can now integrate YOLOv5 with applications and systems that operate better with Keras models, potentially widening the framework's adoption and making it more accessible in different machine learning ecosystems. 🚀