### PR TITLE
OpenVINO metadata fix2

### DIFF
--- a/export.py
+++ b/export.py
@@ -180,7 +180,7 @@ def export_openvino(model, file, half, prefix=colorstr('OpenVINO:')):
 
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f} --data_type {'FP16' if half else 'FP32'}"
         subprocess.check_output(cmd.split())  # export
-        with open(Path(f) / file.with_suffix('.yaml'), 'w') as g:
+        with open(f + str(Path(file).name).replace('.pt', '') + '.yaml', 'w') as g:
             yaml.dump({'stride': int(max(model.stride)), 'names': model.names}, g)  # add metadata.yaml
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')

--- a/export.py
+++ b/export.py
@@ -180,7 +180,7 @@ def export_openvino(model, file, half, prefix=colorstr('OpenVINO:')):
 
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f} --data_type {'FP16' if half else 'FP32'}"
         subprocess.check_output(cmd.split())  # export
-        with open(f + str(Path(file).name).replace('.pt', '') + '.yaml', 'w') as g:
+        with open(Path(f) / file.stem / '.yaml', 'w') as g:
             yaml.dump({'stride': int(max(model.stride)), 'names': model.names}, g)  # add metadata.yaml
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')

--- a/export.py
+++ b/export.py
@@ -180,7 +180,7 @@ def export_openvino(model, file, half, prefix=colorstr('OpenVINO:')):
 
         cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f} --data_type {'FP16' if half else 'FP32'}"
         subprocess.check_output(cmd.split())  # export
-        with open(Path(f) / file.stem / '.yaml', 'w') as g:
+        with open(Path(f) / file.with_suffix('.yaml').name, 'w') as g:
             yaml.dump({'stride': int(max(model.stride)), 'names': model.names}, g)  # add metadata.yaml
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')

--- a/models/common.py
+++ b/models/common.py
@@ -368,7 +368,7 @@ class DetectMultiBackend(nn.Module):
             network = ie.read_model(model=w, weights=Path(w).with_suffix('.bin'))
             executable_network = ie.compile_model(model=network, device_name="CPU")
             output_layer = next(iter(executable_network.outputs))
-            meta = w.with_suffix('.yaml')
+            meta = Path(w).with_suffix('.yaml')
             if meta.exists():
                 stride, names = self._load_metadata(meta)  # load metadata
         elif engine:  # TensorRT


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved compatibility within the OpenVINO export functionality and metadata file handling.

### 📊 Key Changes
- Modified the way the metadata file name is constructed during OpenVINO export in `export.py`
- Ensured correct Path object handling when checking for the existence of a metadata file in `models/common.py`

### 🎯 Purpose & Impact
- 🛠 Ensures metadata files are correctly named and stored, preventing potential export errors for OpenVINO users.
- ⚙️ Improves overall reliability when integrating YOLOv5 models with Intel's OpenVINO toolkit, which could lead to smoother deployment on various platforms, including those requiring FP16 or FP32 precision formats.
- 🚀 Users can expect more robust model export experiences, particularly when working with different data types and deploying across diverse hardware.