### PR TITLE
Increase NMS time limit to 50 ms/img

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -795,7 +795,7 @@ def non_max_suppression(prediction,
     # min_wh = 2  # (pixels) minimum box width and height
     max_wh = 7680  # (pixels) maximum box width and height
     max_nms = 30000  # maximum number of boxes into torchvision.ops.nms()
-    time_limit = 0.1 + 0.03 * bs  # seconds to quit after
+    time_limit = 0.1 + 0.05 * bs  # seconds to quit after
     redundant = True  # require redundant detections
     multi_label &= nc > 1  # multiple labels per box (adds 0.5ms/img)
     merge = False  # use merge-NMS


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved NMS time limit scaling with batch size.

### 📊 Key Changes
- Adjusted the scaling factor for the NMS time limit from 0.03 to 0.05 per batch size (bs).

### 🎯 Purpose & Impact
- Aimed at better performance scaling with larger batch sizes during Non-Maximum Suppression (NMS).
- Potentially increases processing time allowance for NMS proportionally to batch size, leading to fewer early exits on larger batches.
- Impact may be smoother performance for users with varying batch sizes, but could also result in slightly longer inference times on larger batches. 🕒💡