### PR TITLE
Increase NMS fixed time limit 300ms + 30ms/img

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -795,7 +795,7 @@ def non_max_suppression(prediction,
     # min_wh = 2  # (pixels) minimum box width and height
     max_wh = 7680  # (pixels) maximum box width and height
     max_nms = 30000  # maximum number of boxes into torchvision.ops.nms()
-    time_limit = 0.2 + 0.05 * bs  # seconds to quit after
+    time_limit = 0.3 + 0.03 * bs  # seconds to quit after
     redundant = True  # require redundant detections
     multi_label &= nc > 1  # multiple labels per box (adds 0.5ms/img)
     merge = False  # use merge-NMS

--- a/utils/general.py
+++ b/utils/general.py
@@ -795,7 +795,7 @@ def non_max_suppression(prediction,
     # min_wh = 2  # (pixels) minimum box width and height
     max_wh = 7680  # (pixels) maximum box width and height
     max_nms = 30000  # maximum number of boxes into torchvision.ops.nms()
-    time_limit = 0.1 + 0.05 * bs  # seconds to quit after
+    time_limit = 0.2 + 0.05 * bs  # seconds to quit after
     redundant = True  # require redundant detections
     multi_label &= nc > 1  # multiple labels per box (adds 0.5ms/img)
     merge = False  # use merge-NMS


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjustment of the non-max suppression time limit in YOLOv5.

### 📊 Key Changes
- Modified the time limit for non-max suppression from `0.1 + 0.05 * batch_size` to `0.3 + 0.03 * batch_size`.

### 🎯 Purpose & Impact
- 🕒 **Increases reliability**: Adjusting the time limit allows more time for non-max suppression to operate, which could reduce the risk of prematurely terminating the process in scenarios with high numbers of detections.
- 📈 **Improves performance for larger batches**: The change could potentially improve detection quality for larger batch sizes without significantly increasing the time spent on each image.
- 🔍 **Reduces potential for missed detections**: By allowing more time, particularly for larger images or batches, the update ensures that the algorithm has a sufficient window to identify and suppress overlapping bounding boxes, potentially increasing the accuracy of detections.