### PR TITLE
Remove `formats` variable to avoid `pd` conflict

### DIFF
--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -56,9 +56,8 @@ def run(
         pt_only=False,  # test PyTorch only
 ):
     y, t = [], time.time()
-    formats = export.export_formats()
     device = select_device(device)
-    for i, (name, f, suffix, gpu) in formats.iterrows():  # index, (name, file, suffix, gpu-capable)
+    for i, (name, f, suffix, gpu) in export.export_formats().iterrows():  # index, (name, file, suffix, gpu-capable)
         try:
             assert i != 9, 'Edge TPU not supported'
             assert i != 10, 'TF.js not supported'
@@ -104,9 +103,8 @@ def test(
         pt_only=False,  # test PyTorch only
 ):
     y, t = [], time.time()
-    formats = export.export_formats()
     device = select_device(device)
-    for i, (name, f, suffix, gpu) in formats.iterrows():  # index, (name, file, suffix, gpu-capable)
+    for i, (name, f, suffix, gpu) in export.export_formats().iterrows():  # index, (name, file, suffix, gpu-capable)
         try:
             w = weights if f == '-' else \
                 export.run(weights=weights, imgsz=[imgsz], include=[f], device=device, half=half)[-1]  # weights


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved clarity and fixed export conditions in `yolov5` model exporting and benchmark utilities.

### 📊 Key Changes
- Renamed variable `formats` to `fmts` for better readability in `export.py`.
- Modified conditional checks for half-precision (FP16) model conversions to be more explicit.
- Adjusted assertions to prevent simultaneous TFLite and TF.js export, ensuring users export one format at a time.
- Streamlined `formats` logic in benchmarking by calling `export.export_formats()` directly within loop iterations.

### 🎯 Purpose & Impact
- 🚀 The renaming of the variable improves code maintainability and understandability.
- 🛠️ More explicit conditionals reduce the potential for conversion errors when exporting models in different precision modes.
- ⛔️ Explicit assertions guide users to avoid incorrect usage scenarios, such as trying to export incompatible formats together, enhancing user experience and preventing confusion.
- 🧹 Inlining `export.export_formats()` calls simplifies the code and may slightly improve performance in benchmarks by reducing redundancy.

Overall, these changes contribute to a cleaner and more user-friendly codebase with better guidance on model exporting procedures.