### PR TITLE
cURL download double quotes

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -551,7 +551,7 @@ def download(url, dir='.', unzip=True, delete=True, curl=False, threads=1, retry
             for i in range(retry + 1):
                 if curl:
                     s = 'sS' if threads > 1 else ''  # silent
-                    r = os.system(f"curl -{s}L '{url}' -o '{f}' --retry 9 -C -")  # curl download
+                    r = os.system(f'curl -{s}L "{url}" -o "{f}" --retry 9 -C -')  # curl download with retry, continue
                     success = r == 0
                 else:
                     torch.hub.download_url_to_file(url, f, progress=threads == 1)  # torch download


### PR DESCRIPTION
Attempt to resolve Windows issues

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved file download reliability in YOLOv5's utility script.

### 📊 Key Changes
- Modified the command used to download files with `curl`, changing single quotes to double quotes around parameters.

### 🎯 Purpose & Impact
- The change is intended to prevent potential issues with the previous quote usage when downloading files, ensuring better compatibility and stability.
- Users might experience more robust downloads, especially in environments where the single-quote syntax could lead to errors.