### PR TITLE
Add warning emoji ⚠️ on `--conf > 0.001`

### DIFF
--- a/val.py
+++ b/val.py
@@ -38,7 +38,7 @@ from models.common import DetectMultiBackend
 from utils.callbacks import Callbacks
 from utils.dataloaders import create_dataloader
 from utils.general import (LOGGER, check_dataset, check_img_size, check_requirements, check_yaml,
-                           coco80_to_coco91_class, colorstr, increment_path, non_max_suppression, print_args,
+                           coco80_to_coco91_class, colorstr, emojis, increment_path, non_max_suppression, print_args,
                            scale_coords, xywh2xyxy, xyxy2xywh)
 from utils.metrics import ConfusionMatrix, ap_per_class, box_iou
 from utils.plots import output_to_target, plot_images, plot_val_study

--- a/val.py
+++ b/val.py
@@ -363,7 +363,7 @@ def main(opt):
 
     if opt.task in ('train', 'val', 'test'):  # run normally
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466
-            LOGGER.info(f'WARNING: confidence threshold {opt.conf_thres} >> 0.001 will produce invalid mAP values.')
+            LOGGER.info(emojis(f'WARNING: confidence threshold {opt.conf_thres} > 0.001 produces invalid results ⚠️'))
         run(**vars(opt))
 
     else:


### PR DESCRIPTION
User error persists despite warnings, adding more visible warning element. Addresses https://github.com/ultralytics/yolov5/issues/8004


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to validation script messaging with emojis.

### 📊 Key Changes
- Added `emojis` function call in the import section of `val.py`.
- Removed a LOGGER warning about an invalid mAP values due to high confidence threshold.

### 🎯 Purpose & Impact
- The inclusion of emojis aims to make the script's output more user-friendly and engaging.
- Removing the LOGGER warning about high confidence thresholds cleans up the output and may reduce confusion for users, who can now set higher confidence values without being warned of invalid mAP calculations.