### PR TITLE
Pin CI `protobuf==3.20.1`

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt coremltools openvino-dev tensorflow-cpu --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements.txt protobuf==3.20.1 coremltools openvino-dev tensorflow-cpu --extra-index-url https://download.pytorch.org/whl/cpu
           python --version
           pip --version
           pip list
@@ -78,7 +78,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements.txt protobuf==3.20.1 --extra-index-url https://download.pytorch.org/whl/cpu
           python --version
           pip --version
           pip list


### PR DESCRIPTION
Resolve protobuf 4 issues.
https://pypi.org/project/protobuf/#history

<img width="1649" alt="Screen Shot 2022-05-28 at 10 49 23 AM" src="https://user-images.githubusercontent.com/26833433/170818263-8bee6bc0-96aa-46e3-b55f-741542dcc6d1.png">



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved dependency stability in CI workflows

### 📊 Key Changes
- Pinned `protobuf` library to version `3.20.1` in CI testing workflow configuration

### 🎯 Purpose & Impact
- **Stability**: Ensures a specific version of `protobuf` is used during continuous integration, preventing issues related to automatic upgrades
- **Consistency**: Guarantees that the testing environment is consistent, leading to more reliable test outcomes
- **User Satisfaction**: Reduces the likelihood of unexpected errors for users when the package goes through CI, as the testing process remains stable over time 🛠️