### PR TITLE
Add requirements.txt `protobuf<=3.20.1`

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt protobuf==3.20.1 coremltools openvino-dev tensorflow-cpu --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements.txt coremltools openvino-dev tensorflow-cpu --extra-index-url https://download.pytorch.org/whl/cpu
           python --version
           pip --version
           pip list
@@ -78,7 +78,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt protobuf==3.20.1 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
           python --version
           pip --version
           pip list

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ scipy>=1.4.1  # Google Colab version
 torch>=1.7.0
 torchvision>=0.8.1
 tqdm>=4.41.0
-protobuf==3.20.1  # https://github.com/ultralytics/yolov5/pull/8015
+protobuf<=3.20.1  # https://github.com/ultralytics/yolov5/issues/8012
 
 # Logging -------------------------------------
 tensorboard>=2.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ scipy>=1.4.1  # Google Colab version
 torch>=1.7.0
 torchvision>=0.8.1
 tqdm>=4.41.0
+protobuf==3.20.1  # https://github.com/ultralytics/yolov5/pull/8015
 
 # Logging -------------------------------------
 tensorboard>=2.4.1


### PR DESCRIPTION
protobuf >=4 is unstable and breaking CI and training. Pinning to 3.20.1 temporarily to resolve. See https://github.com/ultralytics/yolov5/issues/8012

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved package dependency management in YOLOv5's CI and requirements.

### 📊 Key Changes
- Removed the fixed `protobuf==3.20.1` version from CI workflow files.
- Added `protobuf<=3.20.1` constraint to the `requirements.txt` file.

### 🎯 Purpose & Impact
- ⚙️ **Purpose:** The change standardizes the version constraint for `protobuf` across different setup configurations, ensuring compatibility and preventing potential issues as noted in a specific YOLOv5 GitHub issue.
- 🚀 **Impact:** Users can expect more consistent installations and fewer errors related to the `protobuf` package version when setting up YOLOv5, leading to a smoother experience.