### PR TITLE
Simplify and fix `--save-period` epoch 0

### DIFF
--- a/train.py
+++ b/train.py
@@ -423,7 +423,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                 torch.save(ckpt, last)
                 if best_fitness == fi:
                     torch.save(ckpt, best)
-                if (epoch > 0) and (opt.save_period > 0) and (epoch % opt.save_period == 0):
+                if opt.save_period > 0 and epoch % opt.save_period == 0:
                     torch.save(ckpt, w / f'epoch{epoch}.pt')
                 del ckpt
                 callbacks.run('on_model_save', last, epoch, final_epoch, best_fitness, fi)


### PR DESCRIPTION
Fix now allows for epoch 0 saving

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplified checkpoint saving condition during training in YOLOv5.

### 📊 Key Changes
- Removed the redundant epoch check `(epoch > 0)` from the condition that determines when to save a checkpoint during training.

### 🎯 Purpose & Impact
- 💡 **Purpose**: Streamlining the code to avoid unnecessary checks which can improve code readability and slight performance.
- 🔍 **Impact**: Users will not notice a difference in how the model saves checkpoints; however, the codebase itself is minimally cleaner and more efficient. There is no change in functionality, just a refactor of the condition logic.