### PR TITLE
Fix FP32 TensorRT model export

### DIFF
--- a/export.py
+++ b/export.py
@@ -264,8 +264,8 @@ def export_engine(model, im, file, train, half, simplify, workspace=4, verbose=F
         for out in outputs:
             LOGGER.info(f'{prefix}\toutput "{out.name}" with shape {out.shape} and dtype {out.dtype}')
 
-        LOGGER.info(f'{prefix} building FP{16 if builder.platform_has_fast_fp16 else 32} engine in {f}')
-        if builder.platform_has_fast_fp16:
+        LOGGER.info(f'{prefix} building FP{16 if builder.platform_has_fast_fp16 and half else 32} engine in {f}')
+        if builder.platform_has_fast_fp16 and half:
             config.set_flag(trt.BuilderFlag.FP16)
         with builder.build_engine(network, config) as engine, open(f, 'wb') as t:
             t.write(engine.serialize())


### PR DESCRIPTION
Problem :- While exporting model as TensorRT, the code was using FP16 precision even without using "--half" flag with the export command. Hence, was unable to export FP32 precision models with the export command.

Fix :- Passed "half" variable to the if condition which means we will get FP16 model only if user has passed the "half" flag and the hardware supports FP16. Also modified the logger code to print appropriate precision being used. Just adding "half" variable, the bug has been resolved. Thanks 😄 

Have tested the code for FP16 and FP32 both. It's working.

Attaching screenshots.
![yolov5_trt_error](https://user-images.githubusercontent.com/37156032/171000813-aa26af84-e1ae-469d-ad49-2781352c17a4.png)

After fixing the code, we get,
![yolov5_trt_fp32export_fixed](https://user-images.githubusercontent.com/37156032/171000871-44f6935b-a085-4e1b-ab99-ebe1bc37ba48.png)





## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved TensorRT export flexibility regarding precision modes.

### 📊 Key Changes
- Adjusted the logging message to reflect the precision of the engine being built (FP16 or FP32).
- Conditional use of FP16 mode now also depends on the `half` flag.

### 🎯 Purpose & Impact
- **Purpose**: To ensure that the TensorRT engine uses the appropriate precision based on the model's requirements and the user's choice, providing better control over the trade-off between speed and accuracy.
- **Impact**: Users will have clearer information about the precision mode used during the engine build process and can influence the precision mode with the `half` setting, potentially improving performance on compatible hardware. 🚀