### PR TITLE
Update stale.yml to 300 ops per run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -35,4 +35,4 @@ jobs:
           days-before-stale: 30
           days-before-close: 5
           exempt-issue-labels: 'documentation,tutorial,TODO'
-          operations-per-run: 100  # The maximum number of operations per run, used to control rate limiting.
+          operations-per-run: 300  # The maximum number of operations per run, used to control rate limiting.


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved efficiency for managing stale issues and PRs in the Ultralytics GitHub repository.

### 📊 Key Changes
- Increased the `operations-per-run` setting from 100 to 300 in the stale GitHub Action.

### 🎯 Purpose & Impact
- **Purpose:** To enhance the stale bot's capability to manage issues and PRs without hitting the rate limit too quickly.
- **Impact:** This will allow more issues and pull requests to be processed in a single run, reducing the time needed to mark or close stale items. It should improve repository maintenance and help in keeping the project's issues and PRs more organized and up-to-date. 🚀