### PR TITLE
fix(utils): missing edge when resample segments

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -738,6 +738,7 @@ def segments2boxes(segments):
 def resample_segments(segments, n=1000):
     # Up-sample an (n,2) segment
     for i, s in enumerate(segments):
+        s = np.concatenate((s, s[0:1, :]), axis=0)
         x = np.linspace(0, len(s) - 1, n)
         xp = np.arange(len(s))
         segments[i] = np.concatenate([np.interp(x, xp, s[:, i]) for i in range(2)]).reshape(2, -1).T  # segment xy


### PR DESCRIPTION
One small problem.  When resample segments, missing an edge from the last point to the first.
Eg: https://github.com/HRan2004/Yolo-ArbV2/blob/main/data/images/debug01.png
When the polygon is cut, the missing edge will lead to the wrong position of the GT box.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement to segment resampling in the YOLOv5 codebase.

### 📊 Key Changes
- Added a line of code to ensure that the first point of a segment is repeated at the end, completing the loop before resampling.

### 🎯 Purpose & Impact
- Ensures that closed segments (like those forming polygons) properly connect by including the starting point at the end before interpolation.
- This small but critical update may improve the accuracy of geometric operations or analyses performed on these segments.
- Users dealing with polygonal data representations will benefit from more accurate resampling, impacting tasks such as object detection or segmentation in images. 🌐✨