### PR TITLE
Missing initialization of instance variable

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -432,8 +432,8 @@ class DetectMultiBackend(nn.Module):
                     LOGGER.info(f'Loading {w} for TensorFlow Lite inference...')
                     interpreter = Interpreter(model_path=w)  # load TFLite model
                 interpreter.allocate_tensors()  # allocate
-                input_details = interpreter.get_input_details()  # inputs
-                output_details = interpreter.get_output_details()  # outputs
+                self.input_details = interpreter.get_input_details()  # inputs
+                self.output_details = interpreter.get_output_details()  # outputs
             elif tfjs:
                 raise Exception('ERROR: YOLOv5 TF.js inference is not supported')
         self.__dict__.update(locals())  # assign all variables to self


### PR DESCRIPTION
In Lite or Edge TPU support, "self" keyword is missing in intializing "input_details" and "output_details".

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced TensorFlow Lite model integration in YOLOv5 codebase.

### 📊 Key Changes
- The variables `input_details` and `output_details` are converted to instance attributes by adding `self`.

### 🎯 Purpose & Impact
- 🎯 The purpose of this change is to ensure that `input_details` and `output_details` can be accessed across different methods within the class, increasing code modularity and flexibility.
- 🔍 This change impacts users by potentially providing a more stable and versatile integration when using YOLOv5 models with TensorFlow Lite, which may result in smoother development and deployment processes for mobile and edge devices.