### PR TITLE
Update Objects365.yaml

### DIFF
--- a/data/Objects365.yaml
+++ b/data/Objects365.yaml
@@ -109,6 +109,6 @@ download: |
                           x, y, w, h = a['bbox']  # bounding box in xywh (xy top-left corner)
                           xyxy = np.array([x, y, x + w, y + h])[None]  # pixels(1,4)
                           x, y, w, h = xyxy2xywhn(xyxy, w=width, h=height, clip=True)[0]  # normalized and clipped
-                          file.write(f"{cid} {x:.5f} {y:.5f} {w:.5f} {h:.5f}\n")
+                          file.write(f"{a['category_id']} {x:.5f} {y:.5f} {w:.5f} {h:.5f}\n")
               except Exception as e:
                   print(e)


### PR DESCRIPTION
Error in get label from obj365 dataset

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement in Objects365 dataset configuration file for clarity in object categorization.

### 📊 Key Changes
- The bounding box annotation now uses `a['category_id']` instead of a previously undefined `cid` variable.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To fix a bug that prevents correct annotation due to an undefined variable.
- 💥 **Impact**: Improves the accuracy of object labeling in the dataset, which will likely lead to better training results for models using Objects365 data. Users will experience fewer errors during data preprocessing.