### PR TITLE
Docker GPU pip install `opencv-python<4.6.0.66`

### DIFF
--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -17,7 +17,7 @@ COPY requirements.txt .
 RUN python -m pip install --upgrade pip
 # RUN pip uninstall -y torch torchvision torchtext Pillow
 RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
-    opencv-python<<4.6.0.66 \
+    opencv-python<=4.5.5 \
     --extra-index-url https://download.pytorch.org/whl/cu113
 
 # Create working directory

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -14,10 +14,10 @@ RUN apt update && apt install --no-install-recommends -y zip htop screen libgl1-
 
 # Install pip packages
 COPY requirements.txt .
-RUN python -m pip install --upgrade pip
+#RUN python -m pip install --upgrade pip
 # RUN pip uninstall -y torch torchvision torchtext Pillow
-RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
-    --extra-index-url https://download.pytorch.org/whl/cu113
+#RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
+#    --extra-index-url https://download.pytorch.org/whl/cu113
 
 # Create working directory
 RUN mkdir -p /usr/src/app

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -17,7 +17,7 @@ COPY requirements.txt .
 RUN python -m pip install --upgrade pip
 # RUN pip uninstall -y torch torchvision torchtext Pillow
 RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
-    'opencv-python<4.6.0.66' \
+    'opencv-python'<4.6.0.66 \
     --extra-index-url https://download.pytorch.org/whl/cu113
 
 # Create working directory

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -10,13 +10,13 @@ RUN rm -rf /opt/pytorch  # remove 1.2GB dir
 ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/
 
 # Install linux packages
-RUN apt update && apt install --no-install-recommends -y zip htop screen libgl1-mesa-glx
+RUN apt update && apt install -y zip htop screen libgl1-mesa-glx
 
 # Install pip packages
 COPY requirements.txt .
 #RUN python -m pip install --upgrade pip
 # RUN pip uninstall -y torch torchvision torchtext Pillow
-#RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
+RUN pip install --no-cache -r requirements.txt # albumentations wandb gsutil notebook Pillow>=9.1.0 \
 #    --extra-index-url https://download.pytorch.org/whl/cu113
 
 # Create working directory

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -15,9 +15,9 @@ RUN apt update && apt install --no-install-recommends -y zip htop screen libgl1-
 # Install pip packages
 COPY requirements.txt .
 RUN python -m pip install --upgrade pip
-RUN pip uninstall -y torch torchvision torchtext Pillow
+# RUN pip uninstall -y torch torchvision torchtext Pillow
 RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
-    opencv-python<4.6.0.66 \
+    opencv-python<<4.6.0.66 \
     --extra-index-url https://download.pytorch.org/whl/cu113
 
 # Create working directory

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -10,14 +10,15 @@ RUN rm -rf /opt/pytorch  # remove 1.2GB dir
 ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/
 
 # Install linux packages
-RUN apt update && apt install -y zip htop screen libgl1-mesa-glx
+RUN apt update && apt install --no-install-recommends -y zip htop screen libgl1-mesa-glx
 
 # Install pip packages
 COPY requirements.txt .
-#RUN python -m pip install --upgrade pip
-# RUN pip uninstall -y torch torchvision torchtext Pillow
-RUN pip install --no-cache -r requirements.txt # albumentations wandb gsutil notebook Pillow>=9.1.0 \
-#    --extra-index-url https://download.pytorch.org/whl/cu113
+RUN python -m pip install --upgrade pip
+RUN pip uninstall -y torch torchvision torchtext Pillow
+RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
+    opencv-python<4.6.0.66 \
+    --extra-index-url https://download.pytorch.org/whl/cu113
 
 # Create working directory
 RUN mkdir -p /usr/src/app

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -17,7 +17,7 @@ COPY requirements.txt .
 RUN python -m pip install --upgrade pip
 # RUN pip uninstall -y torch torchvision torchtext Pillow
 RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
-    opencv-python<=4.5.5 \
+    'opencv-python<4.6.0.66' \
     --extra-index-url https://download.pytorch.org/whl/cu113
 
 # Create working directory

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt update && apt install --no-install-recommends -y zip htop screen libgl1-
 # Install pip packages
 COPY requirements.txt .
 RUN python -m pip install --upgrade pip
-RUN pip uninstall -y Pillow  # torch torchvision torchtext
+RUN pip uninstall -y torch torchvision torchtext Pillow
 RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
     'opencv-python<4.6.0.66' \
     --extra-index-url https://download.pytorch.org/whl/cu113

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt update && apt install --no-install-recommends -y zip htop screen libgl1-
 # Install pip packages
 COPY requirements.txt .
 RUN python -m pip install --upgrade pip
-RUN pip uninstall -y torch torchvision torchtext Pillow
+# RUN pip uninstall -y torch torchvision torchtext Pillow
 RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
     --extra-index-url https://download.pytorch.org/whl/cu113
 

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -17,7 +17,7 @@ COPY requirements.txt .
 RUN python -m pip install --upgrade pip
 # RUN pip uninstall -y torch torchvision torchtext Pillow
 RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
-    'opencv-python'<4.6.0.66 \
+    'opencv-python<4.6.0.66' \
     --extra-index-url https://download.pytorch.org/whl/cu113
 
 # Create working directory

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt update && apt install --no-install-recommends -y zip htop screen libgl1-
 # Install pip packages
 COPY requirements.txt .
 RUN python -m pip install --upgrade pip
-# RUN pip uninstall -y torch torchvision torchtext Pillow
+RUN pip uninstall -y Pillow  # torch torchvision torchtext
 RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
     'opencv-python<4.6.0.66' \
     --extra-index-url https://download.pytorch.org/whl/cu113


### PR DESCRIPTION
Resolves `AttributeError: partially initialized module 'cv2' has no attribute '_registerMatType' (most likely due to a circular import)` with cv2 4.6.0.66

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of the YOLOv5 Docker image by specifying OpenCV version.

### 📊 Key Changes
- Added explicit OpenCV Python version requirement in the Dockerfile.

### 🎯 Purpose & Impact
- 🚀 Ensures compatibility: By fixing the OpenCV version, potential compatibility issues with future releases are pre-empted.
- 🔧 More stable builds: This can help in maintaining more stable builds for YOLOv5 Docker images.
- 💡 User confidence: Users can be confident that the Docker image will work out-of-the-box without version conflicts.