### PR TITLE
Update hubconf.py

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -41,7 +41,8 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
     name = Path(name)
     path = name.with_suffix('.pt') if name.suffix == '' and not name.is_dir() else name  # checkpoint path
     try:
-        device = select_device(('0' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu') if device is None else device)
+        device = select_device(('0' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available(
+        ) else 'cpu') if device is None else device)
 
         if pretrained and channels == 3 and classes == 80:
             model = DetectMultiBackend(path, device=device)  # download/load FP32 model

--- a/hubconf.py
+++ b/hubconf.py
@@ -41,7 +41,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
     name = Path(name)
     path = name.with_suffix('.pt') if name.suffix == '' and not name.is_dir() else name  # checkpoint path
     try:
-        device = select_device(('0' if torch.cuda.is_available() else 'cpu') if device is None else device)
+        device = select_device(('0' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu') if device is None else device)
 
         if pretrained and channels == 3 and classes == 80:
             model = DetectMultiBackend(path, device=device)  # download/load FP32 model


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Support for Apple's Metal Performance Shaders (MPS) backend added to the YOLOv5 model selection logic.

### 📊 Key Changes
- Updated the device selection logic in `hubconf.py`.
- Integrated a check for MPS (Metal Performance Shaders) availability.

### 🎯 Purpose & Impact
- **Purpose:** To extend YOLOv5 support to Apple Silicon (M1/M2 chips) by utilizing the MPS backend, which allows for GPU acceleration on macOS.
- **Impact:** Users with Apple Silicon devices can now leverage the performance benefits of their hardware when using YOLOv5, leading potentially to faster model inference and improved efficiency. 🍏💨