### PR TITLE
Reject webcam inference on Colab/Kaggle

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -83,7 +83,7 @@ def exif_transpose(image):
             5: Image.TRANSPOSE,
             6: Image.ROTATE_270,
             7: Image.TRANSVERSE,
-            8: Image.ROTATE_90, }.get(orientation)
+            8: Image.ROTATE_90,}.get(orientation)
         if method is not None:
             image = image.transpose(method)
             del exif[0x0112]

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -322,8 +322,8 @@ class LoadStreams:
                 s = pafy.new(s).getbest(preftype="mp4").url  # YouTube URL
             s = eval(s) if s.isnumeric() else s  # i.e. s = '0' local webcam
             if s == 0:
-                assert not is_colab(), '--source 0 webcam inference is not supported on Colab notebooks'
-                assert not is_kaggle(), '--source 0 webcam inference is not supported on Kaggle notebooks'
+                assert not is_colab(), '--source 0 webcam unsupported on Colab. Rerun command in a local environment.'
+                assert not is_kaggle(), '--source 0 webcam unsupported on Kaggle. Rerun command in a local environment.'
             cap = cv2.VideoCapture(s)
             assert cap.isOpened(), f'{st}Failed to open {s}'
             w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -28,7 +28,7 @@ from tqdm import tqdm
 
 from utils.augmentations import Albumentations, augment_hsv, copy_paste, letterbox, mixup, random_perspective
 from utils.general import (DATASETS_DIR, LOGGER, NUM_THREADS, check_dataset, check_requirements, check_yaml, clean_str,
-                           cv2, segments2boxes, xyn2xy, xywh2xyxy, xywhn2xyxy, xyxy2xywhn)
+                           cv2, is_colab, is_kaggle, segments2boxes, xyn2xy, xywh2xyxy, xywhn2xyxy, xyxy2xywhn)
 from utils.torch_utils import torch_distributed_zero_first
 
 # Parameters
@@ -83,7 +83,7 @@ def exif_transpose(image):
             5: Image.TRANSPOSE,
             6: Image.ROTATE_270,
             7: Image.TRANSVERSE,
-            8: Image.ROTATE_90,}.get(orientation)
+            8: Image.ROTATE_90, }.get(orientation)
         if method is not None:
             image = image.transpose(method)
             del exif[0x0112]
@@ -321,6 +321,9 @@ class LoadStreams:
                 import pafy
                 s = pafy.new(s).getbest(preftype="mp4").url  # YouTube URL
             s = eval(s) if s.isnumeric() else s  # i.e. s = '0' local webcam
+            if s == 0:
+                assert not is_colab(), '--source 0 webcam inference is not supported on Colab notebooks'
+                assert not is_kaggle(), '--source 0 webcam inference is not supported on Kaggle notebooks'
             cap = cv2.VideoCapture(s)
             assert cap.isOpened(), f'{st}Failed to open {s}'
             w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))


### PR DESCRIPTION
Improve user error understanding for https://github.com/ultralytics/yolov5/issues/8180

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced environment compatibility checks for webcam usage in `yolov5` data loaders.

### 📊 Key Changes
- Added `is_colab` and `is_kaggle` utility functions.
- Included assertions to prevent usage of a local webcam source (`--source 0`) in unsupported environments like Colab or Kaggle.

### 🎯 Purpose & Impact
- 🎭 **Ensure Compatibility:** Prevents users from attempting to use webcams in environments where it's not supported, avoiding confusion and potential errors.
- ⚠️ **User-Friendly Errors:** Provides clear error messages prompting users to run their commands in a local environment when appropriate.
- 🛠️ **Streamlined Experience:** Promotes a smoother user experience by guiding users away from certain functionalities that won't work in specific environments like Google Colab or Kaggle notebooks.