### PR TITLE
Prefer MPS over CPU if available

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -41,7 +41,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
     name = Path(name)
     path = name.with_suffix('.pt') if name.suffix == '' and not name.is_dir() else name  # checkpoint path
     try:
-        device = select_device(('0' if torch.cuda.is_available() else 'cpu') if device is None else device)
+        device = select_device(device)
 
         if pretrained and channels == 3 and classes == 80:
             model = DetectMultiBackend(path, device=device)  # download/load FP32 model

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -62,8 +62,7 @@ def select_device(device='', batch_size=0, newline=True):
         assert torch.cuda.is_available() and torch.cuda.device_count() >= len(device.replace(',', '')), \
             f"Invalid CUDA '--device {device}' requested, use '--device cpu' or pass valid CUDA device(s)"
 
-    cuda = not cpu and torch.cuda.is_available()
-    if cuda:
+    if not cpu and torch.cuda.is_available():  # prefer GPU if available
         devices = device.split(',') if device else '0'  # range(torch.cuda.device_count())  # i.e. 0,1,6,7
         n = len(devices)  # device count
         if n > 1 and batch_size > 0:  # check batch_size is divisible by device_count
@@ -72,15 +71,18 @@ def select_device(device='', batch_size=0, newline=True):
         for i, d in enumerate(devices):
             p = torch.cuda.get_device_properties(i)
             s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / (1 << 20):.0f}MiB)\n"  # bytes to MB
-    elif mps:
+        arg = 'cuda:0'
+    elif not cpu and hasattr(torch, 'has_mps') and torch.backends.mps.is_available():  # prefer MPS if available
         s += 'MPS\n'
-    else:
+        arg = 'mps'
+    else:  # revert to CPU
         s += 'CPU\n'
+        arg = 'cpu'
 
     if not newline:
         s = s.rstrip()
     LOGGER.info(s.encode().decode('ascii', 'ignore') if platform.system() == 'Windows' else s)  # emoji-safe
-    return torch.device('cuda:0' if cuda else 'mps' if mps else 'cpu')
+    return torch.device(arg)
 
 
 def time_sync():

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -72,7 +72,7 @@ def select_device(device='', batch_size=0, newline=True):
             p = torch.cuda.get_device_properties(i)
             s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / (1 << 20):.0f}MiB)\n"  # bytes to MB
         arg = 'cuda:0'
-    elif not cpu and hasattr(torch, 'has_mps') and torch.backends.mps.is_available():  # prefer MPS if available
+    elif not cpu and getattr(torch, 'has_mps', False) and torch.backends.mps.is_available():  # prefer MPS if available
         s += 'MPS\n'
         arg = 'mps'
     else:  # revert to CPU


### PR DESCRIPTION
Attempts to prefer Apple MPS if supported and available over CPU for all YOLOv5 ops. May resolve https://github.com/ultralytics/yolov5/pull/8207

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements in device selection logic for YOLOv5 model loading.

### 📊 Key Changes
- Refactored device selection code in `hubconf.py` by removing a redundant check that defaulted to CUDA if available.
- Updated `select_device()` function in `utils/torch_utils.py`:
  - Simplified the CUDA device selection condition.
  - Included a check for Apple's Metal Performance Shaders (MPS), leveraging GPU-like acceleration if available and not on CPU.
  - Automatically defaults to using the CPU if neither CUDA nor MPS is available.
  - Cleaned up code readability and documented preference order (CUDA > MPS > CPU).

### 🎯 Purpose & Impact
- 🎨 Streamlines the device selection process for users, offering a clearer logic flow.
- 🏃‍♂️ Speeds up initial loading of the YOLOv5 model by prioritizing GPU usage when available for better performance.
- 🍏 Exploits MPS on compatible Apple devices, enhancing performance on Mac hardware where MPS is supported.
- 🆕 Ensures compatibility across a wider range of devices by properly handling device options and fallbacks.
- 💻 Users without GPU support will automatically fall back to CPU without needing extra configuration.