### PR TITLE
Should we control the pwh range for bbox regression from (0, 4) to (1/4, 4) ?

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -65,11 +65,11 @@ class Detect(nn.Module):
                 y = x[i].sigmoid()
                 if self.inplace:
                     y[..., 0:2] = (y[..., 0:2] * 2 + self.grid[i]) * self.stride[i]  # xy
-                    y[..., 2:4] = (y[..., 2:4] * 2) ** 2 * self.anchor_grid[i]  # wh
+                    y[..., 2:4] = torch.exp(y[..., 2:4] * 2.7724 - 1.3862) * self.anchor_grid[i]  # wh
                 else:  # for YOLOv5 on AWS Inferentia https://github.com/ultralytics/yolov5/pull/2953
                     xy, wh, conf = y.split((2, 2, self.nc + 1), 4)  # y.tensor_split((2, 4, 5), 4)  # torch 1.8.0
                     xy = (xy * 2 + self.grid[i]) * self.stride[i]  # xy
-                    wh = (wh * 2) ** 2 * self.anchor_grid[i]  # wh
+                    wh = torch.exp(wh * 2.7724 - 1.3862) * self.anchor_grid[i]  # wh
                     y = torch.cat((xy, wh, conf), 4)
                 z.append(y.view(bs, -1, self.no))
 

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -136,7 +136,7 @@ class ComputeLoss:
 
                 # Regression
                 pxy = pxy.sigmoid() * 2 - 0.5
-                pwh = (pwh.sigmoid() * 2) ** 2 * anchors[i]
+                pwh = torch.exp(pwh.sigmoid() * 2.7724 - 1.3862) * anchors[i]
                 pbox = torch.cat((pxy, pwh), 1)  # predicted box
                 iou = bbox_iou(pbox, tbox[i], CIoU=True).squeeze()  # iou(prediction, target)
                 lbox += (1.0 - iou).mean()  # iou loss


### PR DESCRIPTION
![compare](https://user-images.githubusercontent.com/20749514/174544561-082a719b-789e-4d6d-a4bd-8926d5e7e16a.png)
where 2.7724 = 2 * 1.3862 = 2 * np.log(4), why not make the pwh in (1/4, 4) (instead of (0, 4)) for anchor_t=4? 
After which the bbox regression should be more stable, below is my personal projects for comparison(not the official yolov5):
![results](https://user-images.githubusercontent.com/20749514/174547046-5ae8944a-c0a3-4146-b077-5f11047607c1.png)



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved bounding box size prediction in YOLOv5 object detection models.

### 📊 Key Changes
- Altered the computation of the width and height for bounding box predictions from using a squared scale factor to using an exponential function.
- Updated the forward method in `yolo.py` and the loss calculation in `utils/loss.py`.

### 🎯 Purpose & Impact
- **Purpose**: To enhance the accuracy of bounding box predictions by refining the way width and height are calculated.
- **Impact**: Users can expect more accurate object detection, particularly in the size and scale of detected objects within an image. This may result in better performance for tasks where exact object dimensions are crucial. 🎯📈