### PR TITLE
`logging.ERROR` on `RANK` not in (0, 1)

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -85,7 +85,7 @@ def set_logging(name=None, verbose=VERBOSE):
         for h in logging.root.handlers:
             logging.root.removeHandler(h)  # remove all handlers associated with the root logger object
     rank = int(os.getenv('RANK', -1))  # rank in world for Multi-GPU trainings
-    level = logging.INFO if verbose and rank in {-1, 0} else logging.WARNING
+    level = logging.INFO if verbose and rank in {-1, 0} else logging.ERROR
     log = logging.getLogger(name)
     log.setLevel(level)
     handler = logging.StreamHandler()


### PR DESCRIPTION
Improve DDP console response in https://github.com/ultralytics/yolov5/issues/8283

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging level control in multi-GPU training environments.

### 📊 Key Changes
- Changed the default logging level from `WARNING` to `ERROR` for non-verbose modes or non-primary GPUs in distributed training.

### 🎯 Purpose & Impact
- The purpose is to reduce console output clutter by only showing errors by default on non-primary GPUs during distributed training.
- Users can expect a cleaner console with less noise during training sessions, making it easier to spot and address errors when they occur. 🚀