### PR TITLE
Save empty *.txt files if no detection is found in detect.py

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -60,7 +60,7 @@ def run(
         save_txt=False,  # save results to *.txt
         save_conf=False,  # save confidences in --save-txt labels
         save_crop=False,  # save cropped prediction boxes
-        save_empty=False,  # save empty results to *.txt 
+        save_empty=False,  # save empty results to *.txt
         nosave=False,  # do not save images/videos
         classes=None,  # filter by class: --class 0, or --class 0 2 3
         agnostic_nms=False,  # class-agnostic NMS

--- a/detect.py
+++ b/detect.py
@@ -225,6 +225,7 @@ def parse_opt():
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
     parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
     parser.add_argument('--save-crop', action='store_true', help='save cropped prediction boxes')
+    parser.add_argument('--save-empty', action='store_true', help='save empty results to *.txt ')
     parser.add_argument('--nosave', action='store_true', help='do not save images/videos')
     parser.add_argument('--classes', nargs='+', type=int, help='filter by class: --classes 0, or --classes 0 2 3')
     parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS')

--- a/detect.py
+++ b/detect.py
@@ -60,7 +60,7 @@ def run(
         save_txt=False,  # save results to *.txt
         save_conf=False,  # save confidences in --save-txt labels
         save_crop=False,  # save cropped prediction boxes
-        save_empty=False  # save empty results to *.txt 
+        save_empty=False,  # save empty results to *.txt 
         nosave=False,  # do not save images/videos
         classes=None,  # filter by class: --class 0, or --class 0 2 3
         agnostic_nms=False,  # class-agnostic NMS

--- a/detect.py
+++ b/detect.py
@@ -60,6 +60,7 @@ def run(
         save_txt=False,  # save results to *.txt
         save_conf=False,  # save confidences in --save-txt labels
         save_crop=False,  # save cropped prediction boxes
+        save_empty=False  # save empty results to *.txt 
         nosave=False,  # do not save images/videos
         classes=None,  # filter by class: --class 0, or --class 0 2 3
         agnostic_nms=False,  # class-agnostic NMS
@@ -169,7 +170,9 @@ def run(
                         annotator.box_label(xyxy, label, color=colors(c, True))
                     if save_crop:
                         save_one_box(xyxy, imc, file=save_dir / 'crops' / names[c] / f'{p.stem}.jpg', BGR=True)
-
+            elif save_txt and save_empty:
+                with open(f'{txt_path}.txt', 'a') as f:
+                    pass
             # Stream results
             im0 = annotator.result()
             if view_img:


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

Allow exporting *.txt files from inferences that found no results. This is done to make management on our end easier to keep track of annotations and their corresponding image.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced detection output options with new `--save-empty` feature.

### 📊 Key Changes
- Added a new `save_empty` argument in `detect.py`
- Modified code to create an empty `.txt` file when `save_empty` is true and no detections are made

### 🎯 Purpose & Impact
- **Purpose:** Allows users to save empty detection results, which is useful for keeping track of images where no objects were detected.
- **Impact:** Users can better automate and streamline the processing and logging of datasets, especially when dealing with large numbers of images that may not contain detectable objects. It helps maintain consistency for further analysis, ensuring an output file is created for every input image.