### PR TITLE
Allow preview resize in detect.py

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -173,7 +173,7 @@ def run(
             # Stream results
             im0 = annotator.result()
             if view_img:
-                cv2.namedWindow(str(p), cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)
+                cv2.namedWindow(str(p), cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)  # allow window resize (Linux)
                 cv2.imshow(str(p), im0)
                 cv2.waitKey(1)  # 1 millisecond
 

--- a/detect.py
+++ b/detect.py
@@ -57,6 +57,7 @@ def run(
         max_det=1000,  # maximum detections per image
         device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
         view_img=False,  # show results
+        viewsz=[],       # resized results
         save_txt=False,  # save results to *.txt
         save_conf=False,  # save confidences in --save-txt labels
         save_crop=False,  # save cropped prediction boxes
@@ -173,7 +174,12 @@ def run(
             # Stream results
             im0 = annotator.result()
             if view_img:
-                cv2.imshow(str(p), im0)
+                if len(viewsz) == 1:
+                    cv2.imshow(str(p), cv2.resize(im0, (viewsz[0], viewsz[0])))
+                elif len(viewsz) == 2:
+                    cv2.imshow(str(p), cv2.resize(im0, (viewsz[0], viewsz[1])))
+                else:
+                    cv2.imshow(str(p), im0)
                 cv2.waitKey(1)  # 1 millisecond
 
             # Save results (image with detections)
@@ -219,6 +225,7 @@ def parse_opt():
     parser.add_argument('--max-det', type=int, default=1000, help='maximum detections per image')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--view-img', action='store_true', help='show results')
+    parser.add_argument('--viewsz', '--view-size', nargs='+', type=int, default=[], help='result resize shape h,w')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
     parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
     parser.add_argument('--save-crop', action='store_true', help='save cropped prediction boxes')

--- a/detect.py
+++ b/detect.py
@@ -57,7 +57,6 @@ def run(
         max_det=1000,  # maximum detections per image
         device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
         view_img=False,  # show results
-        viewsz=[],       # resized results
         save_txt=False,  # save results to *.txt
         save_conf=False,  # save confidences in --save-txt labels
         save_crop=False,  # save cropped prediction boxes
@@ -174,12 +173,8 @@ def run(
             # Stream results
             im0 = annotator.result()
             if view_img:
-                if len(viewsz) == 1:
-                    cv2.imshow(str(p), cv2.resize(im0, (viewsz[0], viewsz[0])))
-                elif len(viewsz) == 2:
-                    cv2.imshow(str(p), cv2.resize(im0, (viewsz[0], viewsz[1])))
-                else:
-                    cv2.imshow(str(p), im0)
+                cv2.namedWindow(str(p), cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)
+                cv2.imshow(str(p), im0)
                 cv2.waitKey(1)  # 1 millisecond
 
             # Save results (image with detections)
@@ -225,7 +220,6 @@ def parse_opt():
     parser.add_argument('--max-det', type=int, default=1000, help='maximum detections per image')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--view-img', action='store_true', help='show results')
-    parser.add_argument('--viewsz', '--view-size', nargs='+', type=int, default=[], help='result resize shape h,w')
     parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
     parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
     parser.add_argument('--save-crop', action='store_true', help='save cropped prediction boxes')


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

This change is purely visual. Currently when running the detect.py script with a high resolution video, it will open a preview windows which may be bigger than the screen that the content is being viewed on. ~~This PR is simply resizing the content after annotation if the user requests the preview to be resized.~~ This PR will allow for the preview to be resized by dragging. 

Tested on Ubuntu 20.04


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced display flexibility during image detection in YOLOv5.

### 📊 Key Changes
- Added a new line in the `detect.py` script that enables window resizing for image displays on Linux systems.

### 🎯 Purpose & Impact
- The purpose of the change is to improve user experience on Linux by allowing them to resize the detection result windows to their preference.
- Users now have better control over how they view detection outputs, which can be especially beneficial when working with images of varying sizes or when multitasking on their screens. 🖥️🔍