### PR TITLE
Add option to remove all boxes that are trimmed during augmentation

### DIFF
--- a/train.py
+++ b/train.py
@@ -251,7 +251,8 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                                        rank=-1,
                                        workers=workers * 2,
                                        pad=0.5,
-                                       prefix=colorstr('val: '))[0]
+                                       prefix=colorstr('val: '),
+                                       rm_trimmed=rm_trimmed)[0]
 
         if not resume:
             labels = np.concatenate(dataset.labels, 0)

--- a/train.py
+++ b/train.py
@@ -62,9 +62,10 @@ WORLD_SIZE = int(os.getenv('WORLD_SIZE', 1))
 
 
 def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictionary
-    save_dir, epochs, batch_size, weights, single_cls, evolve, data, cfg, resume, noval, nosave, workers, freeze = \
+    save_dir, epochs, batch_size, weights, single_cls, evolve, data, cfg, resume, noval, nosave, workers, freeze, \
+        rm_trimmed = \
         Path(opt.save_dir), opt.epochs, opt.batch_size, opt.weights, opt.single_cls, opt.evolve, opt.data, opt.cfg, \
-        opt.resume, opt.noval, opt.nosave, opt.workers, opt.freeze
+        opt.resume, opt.noval, opt.nosave, opt.workers, opt.freeze, opt.rm_trimmed
     callbacks.run('on_pretrain_routine_start')
 
     # Directories
@@ -509,6 +510,7 @@ def parse_opt(known=False):
     parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
     parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
+    parser.add_argument('--rm-trimmed', action='store_true', help='Remove all boxes that a trimmed by augmentation.')
 
     # Weights & Biases arguments
     parser.add_argument('--entity', default=None, help='W&B: Entity')

--- a/train.py
+++ b/train.py
@@ -233,7 +233,8 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                                               image_weights=opt.image_weights,
                                               quad=opt.quad,
                                               prefix=colorstr('train: '),
-                                              shuffle=True)
+                                              shuffle=True,
+                                              rm_trimmed=rm_trimmed)
     mlc = int(np.concatenate(dataset.labels, 0)[:, 0].max())  # max label class
     nb = len(train_loader)  # number of batches
     assert mlc < nc, f'Label class {mlc} exceeds nc={nc} in {data}. Possible class labels are 0-{nc - 1}'

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -208,10 +208,10 @@ def random_perspective(im,
             new = np.concatenate((x.min(1), y.min(1), x.max(1), y.max(1))).reshape(4, n).T
 
         if rm_trimmed:
-            # remove all labels which are not more than 97% inside the images.
+            # remove all labels which are not more than 95% inside the images.
             box = np.array([0, 0, im.shape[1], im.shape[0]], dtype=np.float32)
             ioa = bbox_ioa(box, new)  # intersection over area
-            j = ioa >= 0.97
+            j = ioa >= 0.95  # 95%, because boxes do not surround the object perfectly
             new = new[j]
             targets = targets[j]
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -179,7 +179,6 @@ def random_perspective(im,
     # ax[0].imshow(im[:, :, ::-1])  # base
     # ax[1].imshow(im2[:, :, ::-1])  # warped
 
-
     # Transform label coordinates
     n = len(targets)
     if n:

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -208,7 +208,7 @@ def random_perspective(im,
             new = np.concatenate((x.min(1), y.min(1), x.max(1), y.max(1))).reshape(4, n).T
 
         if rm_trimmed:
-            # remove all labels which are not more than 95% inside the images.
+            # remove all boxes which are not more than 95% inside the images.
             box = np.array([0, 0, im.shape[1], im.shape[0]], dtype=np.float32)
             ioa = bbox_ioa(box, new)  # intersection over area
             j = ioa >= 0.95  # 95%, because boxes do not surround the object perfectly

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -129,7 +129,8 @@ def random_perspective(im,
                        scale=.1,
                        shear=10,
                        perspective=0.0,
-                       border=(0, 0)):
+                       border=(0, 0),
+                       rm_trimmed=False):
     # torchvision.transforms.RandomAffine(degrees=(-10, 10), translate=(0.1, 0.1), scale=(0.9, 1.1), shear=(-10, 10))
     # targets = [cls, xyxy]
 
@@ -204,6 +205,14 @@ def random_perspective(im,
             x = xy[:, [0, 2, 4, 6]]
             y = xy[:, [1, 3, 5, 7]]
             new = np.concatenate((x.min(1), y.min(1), x.max(1), y.max(1))).reshape(4, n).T
+
+            if rm_trimmed:
+                # remove all labeles which are not more than 97% inside the images.
+                box = np.array([0, 0, im.shape[1], im.shape[0]], dtype=np.float32)
+                ioa = bbox_ioa(box, new)  # intersection over area
+                j = ioa >= 0.97
+                new = new[j]
+                targets = targets[j]
 
             # clip
             new[:, [0, 2]] = new[:, [0, 2]].clip(0, width)

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -729,16 +729,17 @@ class LoadImagesAndLabels(Dataset):
 
         # Augment
         img4, labels4, segments4 = copy_paste(img4, labels4, segments4, p=self.hyp['copy_paste'])
-        img4, labels4 = random_perspective(img4,
-                                           labels4,
-                                           segments4,
-                                           degrees=self.hyp['degrees'],
-                                           translate=self.hyp['translate'],
-                                           scale=self.hyp['scale'],
-                                           shear=self.hyp['shear'],
-                                           perspective=self.hyp['perspective'],
-                                           border=self.mosaic_border, # border to remove
-                                           rm_trimmed=self.rm_trimmed)
+        img4, labels4 = random_perspective(
+            img4,
+            labels4,
+            segments4,
+            degrees=self.hyp['degrees'],
+            translate=self.hyp['translate'],
+            scale=self.hyp['scale'],
+            shear=self.hyp['shear'],
+            perspective=self.hyp['perspective'],
+            border=self.mosaic_border,  # border to remove
+            rm_trimmed=self.rm_trimmed)
 
         return img4, labels4
 

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -106,7 +106,8 @@ def create_dataloader(path,
                       image_weights=False,
                       quad=False,
                       prefix='',
-                      shuffle=False):
+                      shuffle=False,
+                      rm_trimmed=False):
     if rect and shuffle:
         LOGGER.warning('WARNING: --rect is incompatible with DataLoader shuffle, setting shuffle=False')
         shuffle = False
@@ -123,7 +124,8 @@ def create_dataloader(path,
             stride=int(stride),
             pad=pad,
             image_weights=image_weights,
-            prefix=prefix)
+            prefix=prefix,
+            rm_trimmed=rm_trimmed)
 
     batch_size = min(batch_size, len(dataset))
     nd = torch.cuda.device_count()  # number of CUDA devices
@@ -411,7 +413,8 @@ class LoadImagesAndLabels(Dataset):
                  single_cls=False,
                  stride=32,
                  pad=0.0,
-                 prefix=''):
+                 prefix='',
+                 rm_trimmed=False):
         self.img_size = img_size
         self.augment = augment
         self.hyp = hyp
@@ -422,6 +425,7 @@ class LoadImagesAndLabels(Dataset):
         self.stride = stride
         self.path = path
         self.albumentations = Albumentations() if augment else None
+        self.rm_trimmed = rm_trimmed
 
         try:
             f = []  # image files
@@ -614,7 +618,8 @@ class LoadImagesAndLabels(Dataset):
                                                  translate=hyp['translate'],
                                                  scale=hyp['scale'],
                                                  shear=hyp['shear'],
-                                                 perspective=hyp['perspective'])
+                                                 perspective=hyp['perspective'],
+                                                 rm_trimmed=self.rm_trimmed)
 
         nl = len(labels)  # number of labels
         if nl:
@@ -732,7 +737,8 @@ class LoadImagesAndLabels(Dataset):
                                            scale=self.hyp['scale'],
                                            shear=self.hyp['shear'],
                                            perspective=self.hyp['perspective'],
-                                           border=self.mosaic_border)  # border to remove
+                                           border=self.mosaic_border, # border to remove
+                                           rm_trimmed=self.rm_trimmed)
 
         return img4, labels4
 
@@ -808,7 +814,8 @@ class LoadImagesAndLabels(Dataset):
                                            scale=self.hyp['scale'],
                                            shear=self.hyp['shear'],
                                            perspective=self.hyp['perspective'],
-                                           border=self.mosaic_border)  # border to remove
+                                           border=self.mosaic_border,
+                                           rm_trimmed=self.rm_trimmed)  # border to remove
 
         return img9, labels9
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -721,7 +721,7 @@ def xyn2xy(x, w=640, h=640, padw=0, padh=0):
 def segment2box(segment, width=640, height=640, rm_trimmed=False):
     # Convert 1 segment label to 1 box label, applying inside-image constraint, i.e. (xy1, xy2, ...) to (xyxy)
     x, y = segment.T  # segment xy
-    if not rm_trimmed:
+    if not rm_trimmed:  # code to remove trimmed boxes needs coordinates outside the image
         inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
         x, y, = x[inside], y[inside]
     return np.array([x.min(), y.min(), x.max(), y.max()]) if any(x) else np.zeros((1, 4))  # xyxy

--- a/utils/general.py
+++ b/utils/general.py
@@ -718,11 +718,12 @@ def xyn2xy(x, w=640, h=640, padw=0, padh=0):
     return y
 
 
-def segment2box(segment, width=640, height=640):
+def segment2box(segment, width=640, height=640, rm_trimmed=False):
     # Convert 1 segment label to 1 box label, applying inside-image constraint, i.e. (xy1, xy2, ...) to (xyxy)
     x, y = segment.T  # segment xy
-    inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
-    x, y, = x[inside], y[inside]
+    if not rm_trimmed:
+        inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
+        x, y, = x[inside], y[inside]
     return np.array([x.min(), y.min(), x.max(), y.max()]) if any(x) else np.zeros((1, 4))  # xyxy
 
 


### PR DESCRIPTION
Hello :)

I am working on a detection project and had the problem, that I needed as much augmentation as possible and at the same time only wanted to detect the objects that are completely inside the image.

I searched the repository and the code for a solution and realized, that I have to implement it myself. Now I want to offer it to everyone. 

**Short description:**
I added a "--rm-trimmed" parser argument, which is then passed to the random_perspective function. There I added a few lines of code which use the implanted intersection over area function to check if the box is completely inside the image. I used 95% as a threshold, as the boxes are in most cases not perfectly around the object (I did a few tests and 95% felt the most natural but I forgot to save the images). The code is only run if the "--rm-trimmed" argument is added. If it is not added, nothing new happens. 
My proposed changes do not affect training, if the argument is not added, therefore it does not affect runtime in those cases. The increased runtime, if the argument is added, is neglectable. 
It also works for segments. In the segment2box function, I added an if-statement, which takes care of keeping values outside the image if the trimmed boxes should be removed, otherwise it works as usual.
Because I use 95% as the threshold, the boxes still have to be clipped.

This feature is not relevant for most projects but I am sure, there are some people who maybe need it.

**Here is an example:**
- Original boxes
![original](https://user-images.githubusercontent.com/62239991/175525237-ccd3bafd-999b-4dea-aa0a-98aa3fc2ed7b.png)
- Trimmed boxes removed
![--rm-trimmed](https://user-images.githubusercontent.com/62239991/175525267-1c20e13c-f693-41a8-a615-ce73240b4223.png)
_(It does not make a lot of sense to use --rm-trimmed here. It is just an illustration. You can see, that every box is kept the same, except those which are not completely inside the image.)_

In the future, the --rm-trimmed argument could be upgraded by adding a value as a threshold, as some people may only want to remove the boxes that are only 50% outside the image.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Implement an option to filter out augmented bounding boxes that are significantly trimmed by image augmentations.

### 📊 Key Changes
- Added `rm_trimmed` argument to various functions within augmentation and data loading utilities.
- New `rm_trimmed` flag in CLI to activate this feature when running train.py.
- Augmented bounding boxes that are not at least 95% contained within the image boundaries can now be discarded.

### 🎯 Purpose & Impact
- **Purpose:** To improve model training by optionally removing bounding boxes that are mostly outside the image after augmentation, as these may provide noisy signals during training.
- **Impact:** Helps users to potentially improve the performance of their models with a cleaner dataset for training. Users should be aware that enabling this feature may result in losing information from larger objects that are often clipped by the image borders. 🚀👀