### PR TITLE
`device_name="MYRIAD" for Intel NCS2` comment

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -366,7 +366,7 @@ class DetectMultiBackend(nn.Module):
             if not Path(w).is_file():  # if not *.xml
                 w = next(Path(w).glob('*.xml'))  # get *.xml file from *_openvino_model dir
             network = ie.read_model(model=w, weights=Path(w).with_suffix('.bin'))
-            executable_network = ie.compile_model(model=network, device_name="CPU")
+            executable_network = ie.compile_model(network, device_name="CPU")  # device_name="MYRIAD" for Intel NCS2
             output_layer = next(iter(executable_network.outputs))
             meta = Path(w).with_suffix('.yaml')
             if meta.exists():


### PR DESCRIPTION
Display device_name="MYRIAD" for Intel NCS2 option per user question in https://github.com/ultralytics/yolov5/issues/8154


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved argument compatibility in OpenVINO model compilation for YOLOv5.

### 📊 Key Changes
- 🛠 Removed the unnecessary `model=` keyword argument during the model compilation call for OpenVINO.
- 🏷 Added a comment to guide users for Intel Neural Compute Stick 2 (NCS2) usage.

### 🎯 Purpose & Impact
- 💡 **Purpose**: The simplification of the code makes it cleaner and potentially prevents confusion about the named argument usage when compiling models with OpenVINO.
- 🔍 **Impact**: Users running YOLOv5 models on different devices, especially those using Intel's NCS2, may benefit from a smoother setup process with this refined guide comment. Minimal impact on actual performance, but improved code maintainability and user experience.