### PR TITLE
Allow detect.py to use video size for initial window size

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -106,8 +106,7 @@ def run(
 
     # Run inference
     model.warmup(imgsz=(1 if pt else bs, 3, *imgsz))  # warmup
-    dt, seen = [0.0, 0.0, 0.0], 0
-    open_windows = []
+    seen, windows, dt = 0, [], [0.0, 0.0, 0.0]
     for path, im, im0s, vid_cap, s in dataset:
         t1 = time_sync()
         im = torch.from_numpy(im).to(device)
@@ -174,8 +173,8 @@ def run(
             # Stream results
             im0 = annotator.result()
             if view_img:
-                if p not in open_windows:
-                    open_windows.append(p)
+                if p not in windows:
+                    windows.append(p)
                     cv2.namedWindow(str(p), cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)  # allow window resize (Linux)
                     cv2.resizeWindow(str(p), im0.shape[1], im0.shape[0])
                 cv2.imshow(str(p), im0)

--- a/detect.py
+++ b/detect.py
@@ -107,6 +107,7 @@ def run(
     # Run inference
     model.warmup(imgsz=(1 if pt else bs, 3, *imgsz))  # warmup
     dt, seen = [0.0, 0.0, 0.0], 0
+    open_windows = []
     for path, im, im0s, vid_cap, s in dataset:
         t1 = time_sync()
         im = torch.from_numpy(im).to(device)
@@ -173,7 +174,10 @@ def run(
             # Stream results
             im0 = annotator.result()
             if view_img:
-                cv2.namedWindow(str(p), cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)  # allow window resize (Linux)
+                if p not in open_windows:
+                    open_windows.append(p)
+                    cv2.namedWindow(str(p), cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)  # allow window resize (Linux)
+                    cv2.resizeWindow(str(p), im0.shape[1], im0.shape[0])
                 cv2.imshow(str(p), im0)
                 cv2.waitKey(1)  # 1 millisecond
 


### PR DESCRIPTION
It appeared that there was a bug introduced in #8318 that caused the `detect.py` window to be opened with a smaller shape than the video content. 

I have talked to @RyanHir (author of #8318) and the change introduced in the previous PR was unexpected. In the discussion held in #8318 it was claimed that `namedWindow()` had to be called in the loop, but this does not appear to be the case and can instead be called once.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to visualization and efficiency in the YOLOv5 detection script.

### 📊 Key Changes
- Initialized an empty list `windows` to keep track of created OpenCV windows.
- Updated window creation logic to check if a window has already been created before initializing a new one.

### 🎯 Purpose & Impact
- **Avoid Redundancy:** Prevents the unnecessary creation of multiple windows for the same output stream, which can clutter the screen and consume more system resources.
- **Optimize Viewing Experience:** Ensures that each newly created OpenCV window is resized to match the dimensions of the output image, providing a more consistent and user-friendly display.
- **Impact to Users:** Users will have a cleaner interface when running detection in real-time with the view enabled, leading to better performance and a more intuitive display of detection results.