### PR TITLE
Fix bias warmup LR init

### DIFF
--- a/train.py
+++ b/train.py
@@ -335,7 +335,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                 accumulate = max(1, np.interp(ni, xi, [1, nbs / batch_size]).round())
                 for j, x in enumerate(optimizer.param_groups):
                     # bias lr falls from 0.1 to lr0, all other lrs rise from 0.0 to lr0
-                    x['lr'] = np.interp(ni, xi, [hyp['warmup_bias_lr'] if j == 2 else 0.0, x['initial_lr'] * lf(epoch)])
+                    x['lr'] = np.interp(ni, xi, [hyp['warmup_bias_lr'] if j == 0 else 0.0, x['initial_lr'] * lf(epoch)])
                     if 'momentum' in x:
                         x['momentum'] = np.interp(ni, xi, [hyp['warmup_momentum'], hyp['momentum']])
 


### PR DESCRIPTION
Per https://github.com/ultralytics/yolov5/issues/8352

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated learning rate configuration for bias parameters during warmup phase in training script.

### 📊 Key Changes
- Modified the learning rate (`lr`) setting for optimizer bias parameters during the initial warmup period of training.

### 🎯 Purpose & Impact
- **Purpose**: To correct the learning rate assignment for the bias parameters of the optimizer during the warmup period. Previously, the learning rate was applied incorrectly to a different parameter group.
- **Impact**: Ensures that the bias parameters receive the correct learning rate, which could lead to improved model performance and convergence during the early training phase. This change might impact how quickly and effectively models train, possibly yielding better accuracy or faster training times.