### PR TITLE
Add File Size (MB) column to benchmarks

### DIFF
--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -75,7 +75,7 @@ def run(
             result = val.run(data, w, batch_size, imgsz, plots=False, device=device, task='benchmark', half=half)
             metrics = result[0]  # metrics (mp, mr, map50, map, *losses(box, obj, cls))
             speeds = result[2]  # times (preprocess, inference, postprocess)
-            y.append([name, file_size(w), round(metrics[3], 4), round(speeds[1], 2)])  # mAP, t_inference
+            y.append([name, round(file_size(w), 1), round(metrics[3], 4), round(speeds[1], 2)])  # MB, mAP, t_inference
         except Exception as e:
             LOGGER.warning(f'WARNING: Benchmark failure for {name}: {e}')
             y.append([name, None, None, None])  # mAP, t_inference

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -41,7 +41,7 @@ if str(ROOT) not in sys.path:
 import export
 import val
 from utils import notebook_init
-from utils.general import LOGGER, check_yaml, print_args, file_size
+from utils.general import LOGGER, check_yaml, file_size, print_args
 from utils.torch_utils import select_device
 
 

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -41,7 +41,7 @@ if str(ROOT) not in sys.path:
 import export
 import val
 from utils import notebook_init
-from utils.general import LOGGER, check_yaml, print_args
+from utils.general import LOGGER, check_yaml, print_args, file_size
 from utils.torch_utils import select_device
 
 
@@ -75,10 +75,10 @@ def run(
             result = val.run(data, w, batch_size, imgsz, plots=False, device=device, task='benchmark', half=half)
             metrics = result[0]  # metrics (mp, mr, map50, map, *losses(box, obj, cls))
             speeds = result[2]  # times (preprocess, inference, postprocess)
-            y.append([name, round(metrics[3], 4), round(speeds[1], 2)])  # mAP, t_inference
+            y.append([name, file_size(w), round(metrics[3], 4), round(speeds[1], 2)])  # mAP, t_inference
         except Exception as e:
             LOGGER.warning(f'WARNING: Benchmark failure for {name}: {e}')
-            y.append([name, None, None])  # mAP, t_inference
+            y.append([name, None, None, None])  # mAP, t_inference
         if pt_only and i == 0:
             break  # break after PyTorch
 
@@ -86,7 +86,8 @@ def run(
     LOGGER.info('\n')
     parse_opt()
     notebook_init()  # print system info
-    py = pd.DataFrame(y, columns=['Format', 'mAP@0.5:0.95', 'Inference time (ms)'] if map else ['Format', 'Export', ''])
+    c = ['Format', 'Size (MB)', 'mAP@0.5:0.95', 'Inference time (ms)'] if map else ['Format', 'Export', '', '']
+    py = pd.DataFrame(y, columns=c)
     LOGGER.info(f'\nBenchmarks complete ({time.time() - t:.2f}s)')
     LOGGER.info(str(py if map else py.iloc[:, :2]))
     return py


### PR DESCRIPTION
Adds a file size column to benchmarks output, i.e.:

```bash
Benchmarks complete (97.27s)
                   Format  Size (MB)  mAP@0.5:0.95  Inference time (ms)
0                 PyTorch        3.9        0.2927                50.13
1             TorchScript        7.4        0.2927                57.51
2                    ONNX        7.2        0.2927                34.06
3                OpenVINO        7.5        0.2927                17.43
4                TensorRT        NaN           NaN                  NaN
5                  CoreML        NaN           NaN                  NaN
6   TensorFlow SavedModel        7.3        0.2927                64.48
7     TensorFlow GraphDef        7.3        0.2927                68.57
8         TensorFlow Lite        3.7        0.2933                18.20
9     TensorFlow Edge TPU        NaN           NaN                  NaN
10          TensorFlow.js        NaN           NaN                  NaN

```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of benchmarking output with model file size metric.

### 📊 Key Changes
- Added `file_size()` function call to include the file size of the model in the benchmark results.
- Adjusted benchmark result data structure to incorporate model file size.
- Updated DataFrame columns to reflect the new structure with model file size information.

### 🎯 Purpose & Impact
- **Purpose**: To provide users with more comprehensive information on model performance by including model size alongside accuracy (mAP) and inference time.
- **Impact**: Users can now consider model size when evaluating model performance, which is particularly important for deploying models on resource-constrained environments. 📉📲