### PR TITLE
[Classifier]: Fix `normalize()` and `denormalize()` for ImageNet stats

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -3,7 +3,7 @@
 Train a YOLOv5 classifier model on a classification dataset
 
 Usage - train:
-    $ python classifier.py --model yolov5n --data mnist --epochs 1 --img 128
+    $ python path/to/classifier.py --model yolov5s --data mnist --epochs 5 --img 128
 
 Usage - inference:
     from classifier import *

--- a/classifier.py
+++ b/classifier.py
@@ -265,11 +265,6 @@ def imshow(img, labels=None, pred=None, names=None, nmax=64, verbose=False, f=Pa
     ax = ax.ravel() if m > 1 else [ax]
     plt.subplots_adjust(wspace=0.05, hspace=0.05)
     for i in range(n):
-        # im = blocks[i].squeeze().permute((1, 2, 0)).numpy().clip(0.0, 1.0)
-        # print(im.min(), im.max())
-        # TODO: Replace line with permanent normalize(), denormalize() updates based on IMAGENET_MEAN/STD
-        # img_n = cv2.normalize(src=im, dst=None, alpha=0, beta=255, norm_type=cv2.NORM_MINMAX, dtype=cv2.CV_8U)
-        # TODO: Replace line with permanent normalize(), denormalize() updates based on IMAGENET_MEAN/STD
         ax[i].imshow(blocks[i].squeeze().permute((1, 2, 0)).numpy().clip(0.0, 1.0))
         ax[i].axis('off')
         if labels is not None:
@@ -291,7 +286,7 @@ if __name__ == '__main__':
     parser.add_argument('--model', type=str, default='yolov5s', help='initial weights path')
     parser.add_argument('--data', type=str, default='mnist', help='cifar10, cifar100, mnist or mnist-fashion')
     parser.add_argument('--hyp', type=str, default='data/hyps/hyp.scratch-low.yaml', help='hyperparameters path')
-    parser.add_argument('--epochs', type=int, default=20)
+    parser.add_argument('--epochs', type=int, default=10)
     parser.add_argument('--batch-size', type=int, default=128, help='total batch size for all GPUs')
     parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=128, help='train, val image size (pixels)')
     parser.add_argument('--nosave', action='store_true', help='only save final checkpoint')

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -9,6 +9,7 @@ import random
 import cv2
 import numpy as np
 import torchvision.transforms as T
+import torchvision.transforms.functional as TF
 
 from utils.general import LOGGER, check_version, colorstr, resample_segments, segment2box
 from utils.metrics import bbox_ioa
@@ -46,6 +47,18 @@ class Albumentations:
             new = self.transform(image=im, bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
             im, labels = new['image'], np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
         return im, labels
+
+
+def normalize(x, mean=IMAGENET_MEAN, std=IMAGENET_STD):
+    # Denormalize RGB images x per ImageNet stats in BCHW format, i.e. = (x - mean) / std
+    return TF.normalize(x, mean, std, inplace=True)
+
+
+def denormalize(x, mean=IMAGENET_MEAN, std=IMAGENET_STD):
+    # Denormalize RGB images x per ImageNet stats in BCHW format, i.e. = x * std + mean
+    for i in range(3):
+        x[:, i] = x[:, i] * std[i] + mean[i]
+    return x
 
 
 def augment_hsv(im, hgain=0.5, sgain=0.5, vgain=0.5):


### PR DESCRIPTION
Fix `normalize()` and `denormalize()` for ImageNet stats

@AyushExel 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image normalization and codebase flexibility in the classifier script.

### 📊 Key Changes
- Changed example usage command to point to the new recommended model (`yolov5s`) and increased default epochs from 1 to 5.
- Added `torch.hub` import as `hub` for efficiency.
- Moved augmentations `normalize` and `denormalize` functions to `utils/augmentations.py`, standardizing with the ImageNet mean and standard deviation.
- Removed old, inline `normalize` and `denormalize` lambda functions in `classifier.py`.
- Refactored the model loading code to use `hub.load` to include a `force_reload` parameter, ensuring the latest models are used.
- Updated `imshow` function to correctly show the images post-normalization.

### 🎯 Purpose & Impact
- **Consistency:** Use of ImageNet normalization standards makes the classifier more consistent with common practices, improving interoperability with other pre-trained models.
- **Stability:** The removal of inline, repeated code makes the classifier module cleaner and less prone to errors.
- **Up-to-date models:** With the `force_reload` parameter, users are guaranteed to use the latest pre-trained models from the repository.
- **Enhanced visualization:** Updated visualization capabilities in `imshow` allow users to see images in their true form, normalized or not, enhancing the understanding of model outputs.