### PR TITLE
Add coco-minitrain

### DIFF
--- a/data/coco_minitrain.yaml
+++ b/data/coco_minitrain.yaml
@@ -1,0 +1,45 @@
+# YOLOv5 🚀 by Ultralytics, GPL-3.0 license
+# COCO 2017 dataset http://cocodataset.org by Microsoft
+# Example usage: python train.py --data coco.yaml
+# parent
+# ├── yolov5
+# └── datasets
+#     └── coco  ← downloads here (20.1 GB)
+
+
+# Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
+path: ../datasets/coco_minitrain  # dataset root dir
+train: train2017.txt  # train images (relative to 'path') 118287 images
+val: val2017.txt  # val images (relative to 'path') 5000 images
+test: test-dev2017.txt  # 20288 of 40670 images, submit to https://competitions.codalab.org/competitions/20794
+
+# Classes
+nc: 80  # number of classes
+names: ['person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train', 'truck', 'boat', 'traffic light',
+        'fire hydrant', 'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog', 'horse', 'sheep', 'cow',
+        'elephant', 'bear', 'zebra', 'giraffe', 'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
+        'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat', 'baseball glove', 'skateboard', 'surfboard',
+        'tennis racket', 'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl', 'banana', 'apple',
+        'sandwich', 'orange', 'broccoli', 'carrot', 'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
+        'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop', 'mouse', 'remote', 'keyboard', 'cell phone',
+        'microwave', 'oven', 'toaster', 'sink', 'refrigerator', 'book', 'clock', 'vase', 'scissors', 'teddy bear',
+        'hair drier', 'toothbrush']  # class names
+
+
+# Download script/URL (optional)
+download: |
+  from utils.general import download, Path
+
+
+  # Download labels
+  segments = False  # segment or box labels
+  dir = Path(yaml['path'])  # dataset root dir
+  url = 'https://github.com/ultralytics/yolov5/releases/download/v1.0/'
+  urls = [url + ('coco2017labels-segments.zip' if segments else 'coco2017labels.zip')]  # labels
+  download(urls, dir=dir.parent)
+
+  # Download data
+  urls = ['http://images.cocodataset.org/zips/train2017.zip',  # 19G, 118k images
+          'http://images.cocodataset.org/zips/val2017.zip',  # 1G, 5k images
+          'http://images.cocodataset.org/zips/test2017.zip']  # 7G, 41k images (optional)
+  download(urls, dir=dir / 'images', threads=3)

--- a/train.py
+++ b/train.py
@@ -10,6 +10,7 @@ Tutorial: https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data
 Usage:
     $ python path/to/train.py --data coco128.yaml --weights yolov5s.pt --img 640  # from pretrained (RECOMMENDED)
     $ python path/to/train.py --data coco128.yaml --weights '' --cfg yolov5s.yaml --img 640  # from scratch
+    $ python path/to/train.py --data coco-minitrain.yaml --weights yolov5s.pt --img 640 --coco_mini --coco_mini_samples 25000 # sample 25000 images from coco
 """
 
 import argparse
@@ -30,6 +31,7 @@ import yaml
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim import SGD, Adam, AdamW, lr_scheduler
 from tqdm import tqdm
+from utils.coco_minitrain.sample_download_utils import sample_coco, download_sampled_images, update_labels
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory
@@ -216,6 +218,28 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     if opt.sync_bn and cuda and RANK != -1:
         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model).to(device)
         LOGGER.info('Using SyncBatchNorm()')
+
+
+
+    dataset_root_path = train_path[:train_path.rindex('/')]
+
+    if opt.coco_mini:
+        print('\n\n train.py - train() - opt.coco_mini: ', opt.coco_mini)
+
+        # Prepare dataset
+        coco_root_path = dataset_root_path.replace('coco-minitrain', 'coco')
+
+        cmd = 'rm -r {}/*.cache'.format(coco_root_path)
+        os.system(cmd); print(cmd)
+
+        print('coco_root_path: ', coco_root_path)
+        print('dataset_root_path: ', dataset_root_path)
+        cmd = 'scp -r {}/* {}'.format(coco_root_path, dataset_root_path)
+        os.system(cmd); print(cmd)
+
+        sample_coco(dataset_root_path, opt.coco_mini_samples)
+        download_sampled_images(dataset_root_path)
+        update_labels(dataset_root_path)
 
     # Trainloader
     train_loader, dataset = create_dataloader(train_path,
@@ -515,6 +539,8 @@ def parse_opt(known=False):
     parser.add_argument('--upload_dataset', nargs='?', const=True, default=False, help='W&B: Upload data, "val" option')
     parser.add_argument('--bbox_interval', type=int, default=-1, help='W&B: Set bounding-box image logging interval')
     parser.add_argument('--artifact_alias', type=str, default='latest', help='W&B: Version of dataset artifact to use')
+    parser.add_argument('--coco_mini', action='store_true', help='whether to sample a subset of coco for training')
+    parser.add_argument('--coco_mini_samples', type=int, default=25000, help='number of training samples from COCO with the same distribution')
 
     opt = parser.parse_known_args()[0] if known else parser.parse_args()
     return opt

--- a/train.py
+++ b/train.py
@@ -31,7 +31,8 @@ import yaml
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim import SGD, Adam, AdamW, lr_scheduler
 from tqdm import tqdm
-from utils.coco_minitrain.sample_download_utils import sample_coco, download_sampled_images, update_labels
+
+from utils.coco_minitrain.sample_download_utils import download_sampled_images, sample_coco, update_labels
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory
@@ -219,8 +220,6 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model).to(device)
         LOGGER.info('Using SyncBatchNorm()')
 
-
-
     dataset_root_path = train_path[:train_path.rindex('/')]
 
     if opt.coco_mini:
@@ -229,13 +228,15 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
         # Prepare dataset
         coco_root_path = dataset_root_path.replace('coco-minitrain', 'coco')
 
-        cmd = 'rm -r {}/*.cache'.format(coco_root_path)
-        os.system(cmd); print(cmd)
+        cmd = f'rm -r {coco_root_path}/*.cache'
+        os.system(cmd)
+        print(cmd)
 
         print('coco_root_path: ', coco_root_path)
         print('dataset_root_path: ', dataset_root_path)
-        cmd = 'scp -r {}/* {}'.format(coco_root_path, dataset_root_path)
-        os.system(cmd); print(cmd)
+        cmd = f'scp -r {coco_root_path}/* {dataset_root_path}'
+        os.system(cmd)
+        print(cmd)
 
         sample_coco(dataset_root_path, opt.coco_mini_samples)
         download_sampled_images(dataset_root_path)
@@ -540,7 +541,10 @@ def parse_opt(known=False):
     parser.add_argument('--bbox_interval', type=int, default=-1, help='W&B: Set bounding-box image logging interval')
     parser.add_argument('--artifact_alias', type=str, default='latest', help='W&B: Version of dataset artifact to use')
     parser.add_argument('--coco_mini', action='store_true', help='whether to sample a subset of coco for training')
-    parser.add_argument('--coco_mini_samples', type=int, default=25000, help='number of training samples from COCO with the same distribution')
+    parser.add_argument('--coco_mini_samples',
+                        type=int,
+                        default=25000,
+                        help='number of training samples from COCO with the same distribution')
 
     opt = parser.parse_known_args()[0] if known else parser.parse_args()
     return opt

--- a/train.py
+++ b/train.py
@@ -10,7 +10,7 @@ Tutorial: https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data
 Usage:
     $ python path/to/train.py --data coco128.yaml --weights yolov5s.pt --img 640  # from pretrained (RECOMMENDED)
     $ python path/to/train.py --data coco128.yaml --weights '' --cfg yolov5s.yaml --img 640  # from scratch
-    $ python path/to/train.py --data coco-minitrain.yaml --weights yolov5s.pt --img 640 --coco_mini --coco_mini_samples 25000 # sample 25000 images from coco
+    $ python path/to/train.py --data coco_minitrain.yaml --weights yolov5s.pt --img 640 --coco_mini --coco_mini_samples 25000 # sample 25000 images from coco
 """
 
 import argparse
@@ -226,7 +226,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
         print('\n\n train.py - train() - opt.coco_mini: ', opt.coco_mini)
 
         # Prepare dataset
-        coco_root_path = dataset_root_path.replace('coco-minitrain', 'coco')
+        coco_root_path = dataset_root_path.replace('coco_minitrain', 'coco')
 
         cmd = f'rm -r {coco_root_path}/*.cache'
         os.system(cmd)

--- a/utils/coco_minitrain/README.md
+++ b/utils/coco_minitrain/README.md
@@ -1,0 +1,1 @@
+coco-minitrain scripts are borrowed from https://github.com/giddyyupp/coco-minitrain.

--- a/utils/coco_minitrain/csv_to_coco_json.py
+++ b/utils/coco_minitrain/csv_to_coco_json.py
@@ -1,0 +1,48 @@
+import json
+import argparse
+from dataloader import CocoDataset, CSVDataset
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser(description='Pascal CSV to COCO JSON format converter.')
+
+    parser.add_argument('--csv_train', help='Sampled minitrain csv file.', default="mscoco_sampled_0.1131.csv")
+    parser.add_argument('--csv_classes', help='COCO class labels csv file.', default="coco_class_labels.csv")
+    parser.add_argument('--coco_path', help='Path to COCO dataset directory',
+                        default="/default/path/to/COCO2017/")
+    parser.add_argument('--save_json_file_name', help='Save file name', default="mini_coco.json")
+
+    parser = parser.parse_args(args)
+
+    dataset_train = CocoDataset(parser.coco_path, set_name='train2017')
+    dataset_csv = CSVDataset(train_file=parser.csv_train, class_list=parser.csv_classes)
+
+    keys = []
+    # get all keys in coco train set, total image count!
+    for k, v in dataset_train.coco.imgToAnns.items():
+        keys.append(k)
+
+    main_dict = {}
+    annots = []
+    imgs = []
+
+    # select first N image
+    for i in dataset_csv.image_names:
+        im_id = int(i[:-4])
+        for ann in dataset_train.coco.imgToAnns[im_id]:
+            annots.append(ann)
+        imgs.append(dataset_train.coco.imgs[im_id])
+
+    main_dict['images'] = imgs
+    main_dict['annotations'] = annots
+    main_dict['categories'] = dataset_train.coco.dataset['categories']
+    main_dict['info'] = dataset_train.coco.dataset['info']
+    main_dict['licenses'] = dataset_train.coco.dataset['licenses']
+
+    # dump to json
+    with open(parser.save_json_file_name, 'w') as fp:
+        json.dump(main_dict, fp)
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/coco_minitrain/csv_to_coco_json.py
+++ b/utils/coco_minitrain/csv_to_coco_json.py
@@ -1,5 +1,6 @@
-import json
 import argparse
+import json
+
 from dataloader import CocoDataset, CSVDataset
 
 
@@ -8,8 +9,7 @@ def main(args=None):
 
     parser.add_argument('--csv_train', help='Sampled minitrain csv file.', default="mscoco_sampled_0.1131.csv")
     parser.add_argument('--csv_classes', help='COCO class labels csv file.', default="coco_class_labels.csv")
-    parser.add_argument('--coco_path', help='Path to COCO dataset directory',
-                        default="/default/path/to/COCO2017/")
+    parser.add_argument('--coco_path', help='Path to COCO dataset directory', default="/default/path/to/COCO2017/")
     parser.add_argument('--save_json_file_name', help='Save file name', default="mini_coco.json")
 
     parser = parser.parse_args(args)

--- a/utils/coco_minitrain/dataloader.py
+++ b/utils/coco_minitrain/dataloader.py
@@ -1,0 +1,336 @@
+import sys
+import os
+import torch
+import numpy as np
+import csv
+import math
+
+from torch.utils.data import Dataset
+from pycocotools.coco import COCO
+
+import skimage.io
+import skimage.transform
+import skimage.color
+import skimage
+
+from PIL import Image
+
+
+class CocoDataset(Dataset):
+    """Coco dataset."""
+
+    def __init__(self, root_dir, set_name='train2017', transform=None):
+        """
+        Args:
+            root_dir (string): COCO directory.
+            transform (callable, optional): Optional transform to be applied
+                on a sample.
+        """
+        self.root_dir = root_dir
+        self.set_name = set_name
+        self.transform = transform
+
+        self.coco      = COCO(os.path.join(self.root_dir, 'annotations', 'instances_' + self.set_name + '.json'))
+        self.image_ids = self.coco.getImgIds()
+
+        self.load_classes()
+
+    def load_classes(self):
+        # load class names (name -> label)
+        categories = self.coco.loadCats(self.coco.getCatIds())
+        categories.sort(key=lambda x: x['id'])
+
+        self.classes             = {}
+        self.coco_labels         = {}
+        self.coco_labels_inverse = {}
+        for c in categories:
+            self.coco_labels[len(self.classes)] = c['id']
+            self.coco_labels_inverse[c['id']] = len(self.classes)
+            self.classes[c['name']] = len(self.classes)
+
+        # also load the reverse (label -> name)
+        self.labels = {}
+        for key, value in self.classes.items():
+            self.labels[value] = key
+
+    def __len__(self):
+        return len(self.image_ids)
+
+    def __getitem__(self, idx):
+
+        img = self.load_image(idx)
+        annot = self.load_annotations(idx)
+        sample = {'img': img, 'annot': annot}
+        if self.transform:
+            sample = self.transform(sample)
+
+        return sample
+
+    def load_image(self, image_index):
+        image_info = self.coco.loadImgs(self.image_ids[image_index])[0]
+        path       = os.path.join(self.root_dir, 'images', self.set_name, image_info['file_name'])
+        img = skimage.io.imread(path)
+
+        if len(img.shape) == 2:
+            img = skimage.color.gray2rgb(img)
+
+        return img.astype(np.float32)/255.0
+
+    def load_annotations(self, image_index):
+        # get ground truth annotations
+        annotations_ids = self.coco.getAnnIds(imgIds=self.image_ids[image_index], iscrowd=False)
+        annotations     = np.zeros((0, 5))
+
+        # some images appear to miss annotations (like image with id 257034)
+        if len(annotations_ids) == 0:
+            return annotations
+
+        # parse annotations
+        coco_annotations = self.coco.loadAnns(annotations_ids)
+        for idx, a in enumerate(coco_annotations):
+
+            # some annotations have basically no width / height, skip them
+            if a['bbox'][2] < 1 or a['bbox'][3] < 1:
+                continue
+
+            annotation        = np.zeros((1, 5))
+            annotation[0, :4] = a['bbox']
+            annotation[0, 4]  = self.coco_label_to_label(a['category_id'])
+            annotations       = np.append(annotations, annotation, axis=0)
+
+        # transform from [x, y, w, h] to [x1, y1, x2, y2]
+        #annotations[:, 2] = annotations[:, 0] + annotations[:, 2]
+        #annotations[:, 3] = annotations[:, 1] + annotations[:, 3]
+
+        return annotations
+
+    def coco_label_to_label(self, coco_label):
+        return self.coco_labels_inverse[coco_label]
+
+    def label_to_coco_label(self, label):
+        return self.coco_labels[label]
+
+    def image_aspect_ratio(self, image_index):
+        image = self.coco.loadImgs(self.image_ids[image_index])[0]
+        return float(image['width']) / float(image['height'])
+
+    def num_classes(self):
+        return 80
+
+
+class CSVDataset(Dataset):
+    """CSV dataset."""
+
+    def __init__(self, train_file, class_list, transform=None):
+        """
+        Args:
+            train_file (string): CSV file with training annotations
+            annotations (string): CSV file with class list
+            test_file (string, optional): CSV file with testing annotations
+        """
+        self.train_file = train_file
+        self.class_list = class_list
+        self.transform = transform
+
+        # parse the provided class file
+        try:
+            with self._open_for_csv(self.class_list) as file:
+                self.classes = self.load_classes(csv.reader(file, delimiter=','))
+        except ValueError as e:
+            raise(ValueError('invalid CSV class file: {}: {}'.format(self.class_list, e)), None)
+
+        self.labels = {}
+        for key, value in self.classes.items():
+            self.labels[value] = key
+
+        # csv with img_path, x1, y1, x2, y2, class_name
+        try:
+            with self._open_for_csv(self.train_file) as file:
+                self.image_data = self._read_annotations(csv.reader(file, delimiter=','), self.classes)
+        except ValueError as e:
+            raise(ValueError('invalid CSV annotations file: {}: {}'.format(self.train_file, e)), None)
+        self.image_names = list(self.image_data.keys())
+
+    def _parse(self, value, function, fmt):
+        """
+        Parse a string into a value, and format a nice ValueError if it fails.
+        Returns `function(value)`.
+        Any `ValueError` raised is catched and a new `ValueError` is raised
+        with message `fmt.format(e)`, where `e` is the caught `ValueError`.
+        """
+        try:
+            return function(value)
+        except ValueError as e:
+            raise(ValueError(fmt.format(e)), None)
+
+    def _open_for_csv(self, path):
+        """
+        Open a file with flags suitable for csv.reader.
+        This is different for python2 it means with mode 'rb',
+        for python3 this means 'r' with "universal newlines".
+        """
+        if sys.version_info[0] < 3:
+            return open(path, 'rb')
+        else:
+            return open(path, 'r', newline='')
+
+    def load_classes(self, csv_reader):
+        result = {}
+
+        for line, row in enumerate(csv_reader):
+            line += 1
+
+            try:
+                class_name, class_id = row
+            except ValueError:
+                raise(ValueError('line {}: format should be \'class_name,class_id\''.format(line)), None)
+            class_id = self._parse(class_id, int, 'line {}: malformed class ID: {{}}'.format(line))
+
+            if class_name in result:
+                raise ValueError('line {}: duplicate class name: \'{}\''.format(line, class_name))
+            result[class_name] = class_id
+        return result
+
+    def __len__(self):
+        return len(self.image_names)
+
+    def __getitem__(self, idx):
+
+        img = self.load_image(idx)
+        annot = self.load_annotations(idx)
+        sample = {'img': img, 'annot': annot}
+        if self.transform:
+            sample = self.transform(sample)
+
+        return sample
+
+    def load_image(self, image_index):
+        img = skimage.io.imread(self.image_names[image_index])
+
+        if len(img.shape) == 2:
+            img = skimage.color.gray2rgb(img)
+
+        return img.astype(np.float32)/255.0
+
+    def load_annotations(self, image_index):
+        # get ground truth annotations
+        annotation_list = self.image_data[self.image_names[image_index]]
+        annotations     = np.zeros((0, 5))
+
+        # some images appear to miss annotations (like image with id 257034)
+        if len(annotation_list) == 0:
+            return annotations
+
+        # parse annotations
+        for idx, a in enumerate(annotation_list):
+            # some annotations have basically no width / height, skip them
+            x1 = a['x1']
+            x2 = a['x2']
+            y1 = a['y1']
+            y2 = a['y2']
+
+            if (x2-x1) < 1 or (y2-y1) < 1:
+                continue
+
+            annotation        = np.zeros((1, 5))
+            
+            annotation[0, 0] = x1
+            annotation[0, 1] = y1
+            annotation[0, 2] = x2
+            annotation[0, 3] = y2
+
+            annotation[0, 4]  = self.name_to_label(a['class'])
+            annotations       = np.append(annotations, annotation, axis=0)
+
+        return annotations
+
+    def _read_annotations(self, csv_reader, classes):
+        result = {}
+        for line, row in enumerate(csv_reader):
+            line += 1
+
+            try:
+                img_file, x1, y1, x2, y2, class_name = row[:6]
+            except ValueError:
+                raise(ValueError('line {}: format should be \'img_file,x1,y1,x2,y2,class_name\' or \'img_file,,,,,\''.format(line)), None)
+
+            if img_file not in result:
+                result[img_file] = []
+
+            # If a row contains only an image path, it's an image without annotations.
+            if (x1, y1, x2, y2, class_name) == ('', '', '', '', ''):
+                continue
+
+            x1 = self._parse(math.ceil(float(x1)), int, 'line {}: malformed x1: {{}}'.format(line))
+            y1 = self._parse(math.ceil(float(y1)), int, 'line {}: malformed y1: {{}}'.format(line))
+            x2 = self._parse(math.ceil(float(x2)), int, 'line {}: malformed x2: {{}}'.format(line))
+            y2 = self._parse(math.ceil(float(y2)), int, 'line {}: malformed y2: {{}}'.format(line))
+
+            x2 = x2 + x1
+            y2 = y2 + y1
+
+            # Check that the bounding box is valid.
+            if x2 <= x1:
+                raise ValueError('line {}: x2 ({}) must be higher than x1 ({})'.format(line, x2, x1))
+            if y2 <= y1:
+                raise ValueError('line {}: y2 ({}) must be higher than y1 ({})'.format(line, y2, y1))
+
+            # check if the current class name is correctly present
+            if class_name not in classes:
+                raise ValueError('line {}: unknown class name: \'{}\' (classes: {})'.format(line, class_name, classes))
+
+            result[img_file].append({'x1': x1, 'x2': x2, 'y1': y1, 'y2': y2, 'class': class_name})
+        return result
+
+    def name_to_label(self, name):
+        return self.classes[name]
+
+    def label_to_name(self, label):
+        return self.labels[label]
+
+    def num_classes(self):
+        return max(self.classes.values()) + 1
+
+    def image_aspect_ratio(self, image_index):
+        image = Image.open(self.image_names[image_index])
+        return float(image.width) / float(image.height)
+
+
+def collater(data):
+
+    imgs = [s['img'] for s in data]
+    annots = [s['annot'] for s in data]
+    scales = [s['scale'] for s in data]
+        
+    widths = [int(s.shape[0]) for s in imgs]
+    heights = [int(s.shape[1]) for s in imgs]
+    batch_size = len(imgs)
+
+    max_width = np.array(widths).max()
+    max_height = np.array(heights).max()
+
+    padded_imgs = torch.zeros(batch_size, max_width, max_height, 3)
+
+    for i in range(batch_size):
+        img = imgs[i]
+        padded_imgs[i, :int(img.shape[0]), :int(img.shape[1]), :] = img
+
+    max_num_annots = max(annot.shape[0] for annot in annots)
+    
+    if max_num_annots > 0:
+
+        annot_padded = torch.ones((len(annots), max_num_annots, 5)) * -1
+
+        if max_num_annots > 0:
+            for idx, annot in enumerate(annots):
+                #print(annot.shape)
+                if annot.shape[0] > 0:
+                    annot_padded[idx, :annot.shape[0], :] = annot
+    else:
+        annot_padded = torch.ones((len(annots), 1, 5)) * -1
+
+
+    padded_imgs = padded_imgs.permute(0, 3, 1, 2)
+
+    return {'img': padded_imgs, 'annot': annot_padded, 'scale': scales}
+

--- a/utils/coco_minitrain/sample_download_utils.py
+++ b/utils/coco_minitrain/sample_download_utils.py
@@ -1,0 +1,258 @@
+'''
+Ref: https://github.com/giddyyupp/coco-minitrain
+'''
+import os
+import json
+import argparse
+from random import shuffle
+from pycocotools.coco import COCO
+import wget
+import concurrent.futures
+import pathlib
+import glob
+
+from utils.coco_minitrain.dataloader import CocoDataset
+from utils.coco_minitrain.sampler_utils import get_coco_object_size_info, get_coco_class_object_counts
+
+# default area ranges defined in coco
+areaRng = [32 ** 2, 96 ** 2, 1e5 ** 2]
+
+def sample_coco(coco_path, sample_image_count):
+	run_count = 10
+	train_path = coco_path + '/train2017.txt'
+	save_file_name = 'instances_train2017_minicoco'
+	save_format = 'json'
+
+	annotations_path = coco_path + '/annotations'
+	train_annotations_path = annotations_path + '/instances_train2017.json'
+	if not os.path.exists(train_annotations_path):
+		cmd = 'wget https://huggingface.co/datasets/merve/coco/resolve/main/annotations/instances_train2017.json -P {}'.format(annotations_path)
+		os.system(cmd)
+		print(train_annotations_path, 'downloaded!')
+
+	print('sample_coco.py - sample_coco() - coco_path: ', coco_path) # debug
+	dataset_train = CocoDataset(coco_path, set_name='train2017')
+
+	# get coco class based object counts
+	annot_dict = get_coco_class_object_counts(dataset_train)
+	# print(f"COCO object counts in each class:\n{annot_dict}")
+
+	# here extract object sizes.
+	size_dict = get_coco_object_size_info(dataset_train)
+	# print(f"COCO object counts in each class for different sizes (S,M,L):\n{size_dict}")
+
+	# now sample!!
+	imgs_best_sample = {}
+	ratio_list = []
+	best_diff = 1000000
+	keys = []
+	# get all keys in coco train set, total image count!
+	for k, v in dataset_train.coco.imgToAnns.items():
+		keys.append(k)
+
+	for rr in range(run_count):
+		imgs = {}
+
+		# shuffle keys
+		shuffle(keys)
+
+		# select first N images
+		# print('sample_image_count: ', type(sample_image_count))
+		for i in keys[:sample_image_count]:
+			imgs[i] = dataset_train.coco.imgToAnns[i]
+
+		# now check for category based annotations
+		# annot_sampled = np.zeros(90, int)
+		annot_sampled = {}
+		for k, v in imgs.items():
+			for it in v:
+				area = it['bbox'][2] * it['bbox'][3]
+				cat = it['category_id']
+				if area < areaRng[0]:
+					kk = str(cat) + "_S"
+				elif area < areaRng[1]:
+					kk = str(cat) + "_M"
+				else:
+					kk = str(cat) + "_L"
+
+				if kk in annot_sampled:
+					annot_sampled[kk] += 1
+				else:
+					annot_sampled[kk] = 1
+		# print(f"Sampled Annotations dict:\n {annot_sampled}")
+
+		# calculate ratios
+		ratios_obj_count = {}
+		# ratios_obj_size = {}
+
+		failed_run = False
+		for k, v in size_dict.items():
+			if not k in annot_sampled:
+				failed_run = True
+				break
+
+			ratios_obj_count[k] = annot_sampled[k] / float(v)
+		if failed_run:
+			continue
+
+		ratio_list.append(ratios_obj_count)
+
+		min_ratio = min(ratios_obj_count.values())
+		max_ratio = max(ratios_obj_count.values())
+
+		diff = max_ratio - min_ratio
+
+		if diff < best_diff:
+			best_diff = diff
+			imgs_best_sample = imgs
+
+		print(f"Best difference:{best_diff}")
+
+	if save_format == 'csv':
+		# now write to csv file
+		save_file_path = annotations_path + '/' + save_file_name + '.csv'
+		csv_file = open(save_file_path, 'w')
+		write_str = ""
+
+		for k, v in imgs_best_sample.items():
+			f_name = dataset_train.coco.imgs[k]['file_name']
+			for ann in v:
+				bbox = ann['bbox']
+				class_id = ann['category_id']
+				write_str = f_name + ',' + str(bbox[0]) + ',' + str(bbox[1]) + ',' + str(bbox[2]) + ',' + str(
+					bbox[3]) + ',' + \
+							str(dataset_train.labels[dataset_train.coco_labels_inverse[class_id]]) + ',' + '0' + '\n'
+
+				csv_file.write(write_str)
+
+		csv_file.close()
+		print('\n', save_file_path, 'saved!')
+
+	elif save_format == 'json':
+		mini_coco = {}
+		annots = []
+		imgs = []
+		# add headers like info, licenses etc.
+		mini_coco["info"] = dataset_train.coco.dataset['info']
+		mini_coco["licenses"] = dataset_train.coco.dataset['licenses']
+		mini_coco["categories"] = dataset_train.coco.dataset['categories']
+
+		for k, v in imgs_best_sample.items():
+			f_name = dataset_train.coco.imgs[k]['file_name']
+			im_id = int(f_name[:-4])
+			for ann in dataset_train.coco.imgToAnns[im_id]:
+				annots.append(ann)
+			imgs.append(dataset_train.coco.imgs[im_id])
+
+		mini_coco['images'] = imgs
+		mini_coco['annotations'] = annots
+
+		save_file_path = annotations_path + '/' + save_file_name + '.json'
+		with open(save_file_path, 'w') as f:
+			json.dump(mini_coco, f); print('\n', save_file_path, 'saved!')
+
+
+def download_sampled_images(coco_path):
+    output_dir = coco_path + '/images/train2017'
+    if os.path.exists(output_dir):
+        output_dir_ORI = output_dir + '_ORI'
+        cmd = 'mv {} {}'.format(output_dir, output_dir_ORI)
+        print('Preparing', output_dir, '...')
+        os.system(cmd); print(cmd)
+    annotation = coco_path + '/annotations/instances_train2017_minicoco.json'
+    root = pathlib.Path().absolute()
+    print('coco_download.py - root: ', root)
+
+    ann_file = root / annotation
+    print('coco_download.py - ann_file: ', ann_file)
+
+    out_p = pathlib.Path(output_dir)
+    out_p.mkdir(parents=True, exist_ok=True)
+
+    if not os.fsdecode(ann_file).endswith(".json"):
+        assert "Only support COCO style JSON file"
+
+    try:
+        coco = COCO(os.fsdecode(ann_file))
+        img_ids = list(coco.imgs.keys())
+
+    except FileNotFoundError:
+        raise
+
+    def download_images(id):
+        try:
+            start_url = "http://images.cocodataset.org/train2017"
+            filename = "{0:0>12d}".format(id)
+            filename = filename + ".jpg"
+            full_url = f"{start_url}/{filename}"
+            wget.download(full_url, out=output_dir)
+        except Exception as e:
+            print(f"The download exception is {e}", flush=True)
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        executor.map(download_images, img_ids)
+
+    # Remove the original images folder
+    if os.path.exists(output_dir):
+        cmd = 'rm -r {}'.format(output_dir_ORI)
+        os.system(cmd); print(cmd)
+
+def update_labels(coco_path):
+    img_path = coco_path + '/images/train2017'
+    print('\n\n img_path: ', img_path)
+
+    img_id_ls = []
+    for img_path in glob.glob(img_path + '/*.jpg'):
+        print(img_path)
+        img_id = img_path[img_path.rindex('/') + 1 : img_path.index('.jpg')]
+        print(img_id)
+        # e.g. 000000443453
+        img_id_ls.append(img_id)
+
+        print(len(img_id_ls)) # 25000
+
+    print('---------------------------')
+
+    txt_path = coco_path + '/train2017.txt'
+    print(txt_path)
+    txt_path_ORI = coco_path + '/train2017_ORI.txt'
+    if not os.path.exists(txt_path_ORI):
+        cmd = 'scp {} {}'.format(txt_path, txt_path_ORI); os.system(cmd); print(cmd)
+        cmd = 'rm {}'.format(txt_path); os.system(cmd); print(cmd)
+        cmd = 'touch {}'.format(txt_path); os.system(cmd); print(cmd)
+
+    label_root_path = coco_path + '/labels'
+    print(label_root_path)
+    # label_root_path_ORI = coco_path + '/labels_ORI'
+    label_train_folder = label_root_path + '/train2017'
+    label_train_folder_ORI = label_root_path + '/train2017_ORI'
+    if not os.path.exists(label_train_folder_ORI):
+        cmd = 'scp -r {} {}'.format(label_train_folder, label_train_folder_ORI); os.system(cmd); print(cmd)
+        cmd = 'rm -r {}'.format(label_train_folder); os.system(cmd); print(cmd)
+        os.makedirs(label_train_folder)
+
+    print('---------------------------')
+
+    txt_file = open(txt_path, 'w')
+    for img_id in img_id_ls:
+        # ----------------------
+        #  Update train2017.txt
+        # ----------------------
+        line_to_write = './images/train2017/{}.jpg\n'.format(img_id)
+        txt_file.write(line_to_write)
+        print(line_to_write, 'written!')
+
+        # ---------------------------
+        #  Update labels/train2017/*
+        # ---------------------------
+        # label_train_path = label_root_path + '/train2017/' + img_id + '.txt'
+        label_train_path = label_train_folder + '/' + img_id + '.txt'
+        # label_path_ORI = label_root_path_ORI + '/train2017/' + img_id + '.txt'
+        label_train_path_ORI = label_train_folder_ORI + '/' + img_id + '.txt'
+        # cmd = 'scp {} {}'.format(label_path_ORI, label_path); os.system(cmd); print(print)
+        cmd = 'scp {} {}'.format(label_train_path_ORI, label_train_path); os.system(cmd); print(print)
+        print(cmd)
+
+    # Clean intermediate folders
+    cmd = 'rm -r {}'.format(txt_path_ORI); os.system(cmd); print(cmd)
+    cmd = 'rm -r {}'.format(label_train_folder_ORI); os.system(cmd); print(cmd)

--- a/utils/coco_minitrain/sample_download_utils.py
+++ b/utils/coco_minitrain/sample_download_utils.py
@@ -1,164 +1,168 @@
 '''
 Ref: https://github.com/giddyyupp/coco-minitrain
 '''
-import os
-import json
 import argparse
-from random import shuffle
-from pycocotools.coco import COCO
-import wget
 import concurrent.futures
-import pathlib
 import glob
+import json
+import os
+import pathlib
+from random import shuffle
+
+import wget
+from pycocotools.coco import COCO
 
 from utils.coco_minitrain.dataloader import CocoDataset
-from utils.coco_minitrain.sampler_utils import get_coco_object_size_info, get_coco_class_object_counts
+from utils.coco_minitrain.sampler_utils import get_coco_class_object_counts, get_coco_object_size_info
 
 # default area ranges defined in coco
 areaRng = [32 ** 2, 96 ** 2, 1e5 ** 2]
 
+
 def sample_coco(coco_path, sample_image_count):
-	run_count = 10
-	train_path = coco_path + '/train2017.txt'
-	save_file_name = 'instances_train2017_minicoco'
-	save_format = 'json'
+    run_count = 10
+    train_path = coco_path + '/train2017.txt'
+    save_file_name = 'instances_train2017_minicoco'
+    save_format = 'json'
 
-	annotations_path = coco_path + '/annotations'
-	train_annotations_path = annotations_path + '/instances_train2017.json'
-	if not os.path.exists(train_annotations_path):
-		cmd = 'wget https://huggingface.co/datasets/merve/coco/resolve/main/annotations/instances_train2017.json -P {}'.format(annotations_path)
-		os.system(cmd)
-		print(train_annotations_path, 'downloaded!')
+    annotations_path = coco_path + '/annotations'
+    train_annotations_path = annotations_path + '/instances_train2017.json'
+    if not os.path.exists(train_annotations_path):
+        cmd = f'wget https://huggingface.co/datasets/merve/coco/resolve/main/annotations/instances_train2017.json -P {annotations_path}'
+        os.system(cmd)
+        print(train_annotations_path, 'downloaded!')
 
-	print('sample_coco.py - sample_coco() - coco_path: ', coco_path) # debug
-	dataset_train = CocoDataset(coco_path, set_name='train2017')
+    print('sample_coco.py - sample_coco() - coco_path: ', coco_path)  # debug
+    dataset_train = CocoDataset(coco_path, set_name='train2017')
 
-	# get coco class based object counts
-	annot_dict = get_coco_class_object_counts(dataset_train)
-	# print(f"COCO object counts in each class:\n{annot_dict}")
+    # get coco class based object counts
+    annot_dict = get_coco_class_object_counts(dataset_train)
+    # print(f"COCO object counts in each class:\n{annot_dict}")
 
-	# here extract object sizes.
-	size_dict = get_coco_object_size_info(dataset_train)
-	# print(f"COCO object counts in each class for different sizes (S,M,L):\n{size_dict}")
+    # here extract object sizes.
+    size_dict = get_coco_object_size_info(dataset_train)
+    # print(f"COCO object counts in each class for different sizes (S,M,L):\n{size_dict}")
 
-	# now sample!!
-	imgs_best_sample = {}
-	ratio_list = []
-	best_diff = 1000000
-	keys = []
-	# get all keys in coco train set, total image count!
-	for k, v in dataset_train.coco.imgToAnns.items():
-		keys.append(k)
+    # now sample!!
+    imgs_best_sample = {}
+    ratio_list = []
+    best_diff = 1000000
+    keys = []
+    # get all keys in coco train set, total image count!
+    for k, v in dataset_train.coco.imgToAnns.items():
+        keys.append(k)
 
-	for rr in range(run_count):
-		imgs = {}
+    for rr in range(run_count):
+        imgs = {}
 
-		# shuffle keys
-		shuffle(keys)
+        # shuffle keys
+        shuffle(keys)
 
-		# select first N images
-		# print('sample_image_count: ', type(sample_image_count))
-		for i in keys[:sample_image_count]:
-			imgs[i] = dataset_train.coco.imgToAnns[i]
+        # select first N images
+        # print('sample_image_count: ', type(sample_image_count))
+        for i in keys[:sample_image_count]:
+            imgs[i] = dataset_train.coco.imgToAnns[i]
 
-		# now check for category based annotations
-		# annot_sampled = np.zeros(90, int)
-		annot_sampled = {}
-		for k, v in imgs.items():
-			for it in v:
-				area = it['bbox'][2] * it['bbox'][3]
-				cat = it['category_id']
-				if area < areaRng[0]:
-					kk = str(cat) + "_S"
-				elif area < areaRng[1]:
-					kk = str(cat) + "_M"
-				else:
-					kk = str(cat) + "_L"
+        # now check for category based annotations
+        # annot_sampled = np.zeros(90, int)
+        annot_sampled = {}
+        for k, v in imgs.items():
+            for it in v:
+                area = it['bbox'][2] * it['bbox'][3]
+                cat = it['category_id']
+                if area < areaRng[0]:
+                    kk = str(cat) + "_S"
+                elif area < areaRng[1]:
+                    kk = str(cat) + "_M"
+                else:
+                    kk = str(cat) + "_L"
 
-				if kk in annot_sampled:
-					annot_sampled[kk] += 1
-				else:
-					annot_sampled[kk] = 1
-		# print(f"Sampled Annotations dict:\n {annot_sampled}")
+                if kk in annot_sampled:
+                    annot_sampled[kk] += 1
+                else:
+                    annot_sampled[kk] = 1
+        # print(f"Sampled Annotations dict:\n {annot_sampled}")
 
-		# calculate ratios
-		ratios_obj_count = {}
-		# ratios_obj_size = {}
+        # calculate ratios
+        ratios_obj_count = {}
+        # ratios_obj_size = {}
 
-		failed_run = False
-		for k, v in size_dict.items():
-			if not k in annot_sampled:
-				failed_run = True
-				break
+        failed_run = False
+        for k, v in size_dict.items():
+            if not k in annot_sampled:
+                failed_run = True
+                break
 
-			ratios_obj_count[k] = annot_sampled[k] / float(v)
-		if failed_run:
-			continue
+            ratios_obj_count[k] = annot_sampled[k] / float(v)
+        if failed_run:
+            continue
 
-		ratio_list.append(ratios_obj_count)
+        ratio_list.append(ratios_obj_count)
 
-		min_ratio = min(ratios_obj_count.values())
-		max_ratio = max(ratios_obj_count.values())
+        min_ratio = min(ratios_obj_count.values())
+        max_ratio = max(ratios_obj_count.values())
 
-		diff = max_ratio - min_ratio
+        diff = max_ratio - min_ratio
 
-		if diff < best_diff:
-			best_diff = diff
-			imgs_best_sample = imgs
+        if diff < best_diff:
+            best_diff = diff
+            imgs_best_sample = imgs
 
-		print(f"Best difference:{best_diff}")
+        print(f"Best difference:{best_diff}")
 
-	if save_format == 'csv':
-		# now write to csv file
-		save_file_path = annotations_path + '/' + save_file_name + '.csv'
-		csv_file = open(save_file_path, 'w')
-		write_str = ""
+    if save_format == 'csv':
+        # now write to csv file
+        save_file_path = annotations_path + '/' + save_file_name + '.csv'
+        csv_file = open(save_file_path, 'w')
+        write_str = ""
 
-		for k, v in imgs_best_sample.items():
-			f_name = dataset_train.coco.imgs[k]['file_name']
-			for ann in v:
-				bbox = ann['bbox']
-				class_id = ann['category_id']
-				write_str = f_name + ',' + str(bbox[0]) + ',' + str(bbox[1]) + ',' + str(bbox[2]) + ',' + str(
-					bbox[3]) + ',' + \
-							str(dataset_train.labels[dataset_train.coco_labels_inverse[class_id]]) + ',' + '0' + '\n'
+        for k, v in imgs_best_sample.items():
+            f_name = dataset_train.coco.imgs[k]['file_name']
+            for ann in v:
+                bbox = ann['bbox']
+                class_id = ann['category_id']
+                write_str = f_name + ',' + str(bbox[0]) + ',' + str(bbox[1]) + ',' + str(bbox[2]) + ',' + str(
+                 bbox[3]) + ',' + \
+                   str(dataset_train.labels[dataset_train.coco_labels_inverse[class_id]]) + ',' + '0' + '\n'
 
-				csv_file.write(write_str)
+                csv_file.write(write_str)
 
-		csv_file.close()
-		print('\n', save_file_path, 'saved!')
+        csv_file.close()
+        print('\n', save_file_path, 'saved!')
 
-	elif save_format == 'json':
-		mini_coco = {}
-		annots = []
-		imgs = []
-		# add headers like info, licenses etc.
-		mini_coco["info"] = dataset_train.coco.dataset['info']
-		mini_coco["licenses"] = dataset_train.coco.dataset['licenses']
-		mini_coco["categories"] = dataset_train.coco.dataset['categories']
+    elif save_format == 'json':
+        mini_coco = {}
+        annots = []
+        imgs = []
+        # add headers like info, licenses etc.
+        mini_coco["info"] = dataset_train.coco.dataset['info']
+        mini_coco["licenses"] = dataset_train.coco.dataset['licenses']
+        mini_coco["categories"] = dataset_train.coco.dataset['categories']
 
-		for k, v in imgs_best_sample.items():
-			f_name = dataset_train.coco.imgs[k]['file_name']
-			im_id = int(f_name[:-4])
-			for ann in dataset_train.coco.imgToAnns[im_id]:
-				annots.append(ann)
-			imgs.append(dataset_train.coco.imgs[im_id])
+        for k, v in imgs_best_sample.items():
+            f_name = dataset_train.coco.imgs[k]['file_name']
+            im_id = int(f_name[:-4])
+            for ann in dataset_train.coco.imgToAnns[im_id]:
+                annots.append(ann)
+            imgs.append(dataset_train.coco.imgs[im_id])
 
-		mini_coco['images'] = imgs
-		mini_coco['annotations'] = annots
+        mini_coco['images'] = imgs
+        mini_coco['annotations'] = annots
 
-		save_file_path = annotations_path + '/' + save_file_name + '.json'
-		with open(save_file_path, 'w') as f:
-			json.dump(mini_coco, f); print('\n', save_file_path, 'saved!')
+        save_file_path = annotations_path + '/' + save_file_name + '.json'
+        with open(save_file_path, 'w') as f:
+            json.dump(mini_coco, f)
+            print('\n', save_file_path, 'saved!')
 
 
 def download_sampled_images(coco_path):
     output_dir = coco_path + '/images/train2017'
     if os.path.exists(output_dir):
         output_dir_ORI = output_dir + '_ORI'
-        cmd = 'mv {} {}'.format(output_dir, output_dir_ORI)
+        cmd = f'mv {output_dir} {output_dir_ORI}'
         print('Preparing', output_dir, '...')
-        os.system(cmd); print(cmd)
+        os.system(cmd)
+        print(cmd)
     annotation = coco_path + '/annotations/instances_train2017_minicoco.json'
     root = pathlib.Path().absolute()
     print('coco_download.py - root: ', root)
@@ -182,7 +186,7 @@ def download_sampled_images(coco_path):
     def download_images(id):
         try:
             start_url = "http://images.cocodataset.org/train2017"
-            filename = "{0:0>12d}".format(id)
+            filename = f"{id:0>12d}"
             filename = filename + ".jpg"
             full_url = f"{start_url}/{filename}"
             wget.download(full_url, out=output_dir)
@@ -194,8 +198,10 @@ def download_sampled_images(coco_path):
 
     # Remove the original images folder
     if os.path.exists(output_dir):
-        cmd = 'rm -r {}'.format(output_dir_ORI)
-        os.system(cmd); print(cmd)
+        cmd = f'rm -r {output_dir_ORI}'
+        os.system(cmd)
+        print(cmd)
+
 
 def update_labels(coco_path):
     img_path = coco_path + '/images/train2017'
@@ -204,12 +210,12 @@ def update_labels(coco_path):
     img_id_ls = []
     for img_path in glob.glob(img_path + '/*.jpg'):
         print(img_path)
-        img_id = img_path[img_path.rindex('/') + 1 : img_path.index('.jpg')]
+        img_id = img_path[img_path.rindex('/') + 1:img_path.index('.jpg')]
         print(img_id)
         # e.g. 000000443453
         img_id_ls.append(img_id)
 
-        print(len(img_id_ls)) # 25000
+        print(len(img_id_ls))  # 25000
 
     print('---------------------------')
 
@@ -217,9 +223,15 @@ def update_labels(coco_path):
     print(txt_path)
     txt_path_ORI = coco_path + '/train2017_ORI.txt'
     if not os.path.exists(txt_path_ORI):
-        cmd = 'scp {} {}'.format(txt_path, txt_path_ORI); os.system(cmd); print(cmd)
-        cmd = 'rm {}'.format(txt_path); os.system(cmd); print(cmd)
-        cmd = 'touch {}'.format(txt_path); os.system(cmd); print(cmd)
+        cmd = f'scp {txt_path} {txt_path_ORI}'
+        os.system(cmd)
+        print(cmd)
+        cmd = f'rm {txt_path}'
+        os.system(cmd)
+        print(cmd)
+        cmd = f'touch {txt_path}'
+        os.system(cmd)
+        print(cmd)
 
     label_root_path = coco_path + '/labels'
     print(label_root_path)
@@ -227,8 +239,12 @@ def update_labels(coco_path):
     label_train_folder = label_root_path + '/train2017'
     label_train_folder_ORI = label_root_path + '/train2017_ORI'
     if not os.path.exists(label_train_folder_ORI):
-        cmd = 'scp -r {} {}'.format(label_train_folder, label_train_folder_ORI); os.system(cmd); print(cmd)
-        cmd = 'rm -r {}'.format(label_train_folder); os.system(cmd); print(cmd)
+        cmd = f'scp -r {label_train_folder} {label_train_folder_ORI}'
+        os.system(cmd)
+        print(cmd)
+        cmd = f'rm -r {label_train_folder}'
+        os.system(cmd)
+        print(cmd)
         os.makedirs(label_train_folder)
 
     print('---------------------------')
@@ -238,7 +254,7 @@ def update_labels(coco_path):
         # ----------------------
         #  Update train2017.txt
         # ----------------------
-        line_to_write = './images/train2017/{}.jpg\n'.format(img_id)
+        line_to_write = f'./images/train2017/{img_id}.jpg\n'
         txt_file.write(line_to_write)
         print(line_to_write, 'written!')
 
@@ -250,9 +266,15 @@ def update_labels(coco_path):
         # label_path_ORI = label_root_path_ORI + '/train2017/' + img_id + '.txt'
         label_train_path_ORI = label_train_folder_ORI + '/' + img_id + '.txt'
         # cmd = 'scp {} {}'.format(label_path_ORI, label_path); os.system(cmd); print(print)
-        cmd = 'scp {} {}'.format(label_train_path_ORI, label_train_path); os.system(cmd); print(print)
+        cmd = f'scp {label_train_path_ORI} {label_train_path}'
+        os.system(cmd)
+        print(print)
         print(cmd)
 
     # Clean intermediate folders
-    cmd = 'rm -r {}'.format(txt_path_ORI); os.system(cmd); print(cmd)
-    cmd = 'rm -r {}'.format(label_train_folder_ORI); os.system(cmd); print(cmd)
+    cmd = f'rm -r {txt_path_ORI}'
+    os.system(cmd)
+    print(cmd)
+    cmd = f'rm -r {label_train_folder_ORI}'
+    os.system(cmd)
+    print(cmd)

--- a/utils/coco_minitrain/sampler_utils.py
+++ b/utils/coco_minitrain/sampler_utils.py
@@ -2,8 +2,8 @@
 Ref: https://github.com/giddyyupp/coco-minitrain
 '''
 
-def get_coco_object_size_info(dataset_train,
-                              areaRng = [32 ** 2, 96 ** 2, 1e5 ** 2]):
+
+def get_coco_object_size_info(dataset_train, areaRng=[32 ** 2, 96 ** 2, 1e5 ** 2]):
     size_dict = {}
 
     for k, v in dataset_train.coco.anns.items():

--- a/utils/coco_minitrain/sampler_utils.py
+++ b/utils/coco_minitrain/sampler_utils.py
@@ -1,0 +1,36 @@
+'''
+Ref: https://github.com/giddyyupp/coco-minitrain
+'''
+
+def get_coco_object_size_info(dataset_train,
+                              areaRng = [32 ** 2, 96 ** 2, 1e5 ** 2]):
+    size_dict = {}
+
+    for k, v in dataset_train.coco.anns.items():
+        # aa = Counter(v)
+        area = v['bbox'][2] * v['bbox'][3]
+        cat = v['category_id']
+        if area < areaRng[0]:
+            kk = str(cat) + "_S"
+        elif area < areaRng[1]:
+            kk = str(cat) + "_M"
+        else:
+            kk = str(cat) + "_L"
+
+        # update counts
+        if kk in size_dict:
+            size_dict[kk] += 1
+        else:
+            size_dict[kk] = 1
+
+    return size_dict
+
+
+def get_coco_class_object_counts(dataset_train):
+    annot_dict = {}
+
+    for k, v in dataset_train.coco.catToImgs.items():
+        # aa = Counter(v)
+        annot_dict[k] = len(v)
+
+    return annot_dict

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -110,6 +110,8 @@ def create_dataloader(path,
     if rect and shuffle:
         LOGGER.warning('WARNING: --rect is incompatible with DataLoader shuffle, setting shuffle=False')
         shuffle = False
+
+    # DEBUG
     with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
         dataset = LoadImagesAndLabels(
             path,

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -110,8 +110,6 @@ def create_dataloader(path,
     if rect and shuffle:
         LOGGER.warning('WARNING: --rect is incompatible with DataLoader shuffle, setting shuffle=False')
         shuffle = False
-
-    # DEBUG
     with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
         dataset = LoadImagesAndLabels(
             path,


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

Incorporate the code from https://github.com/giddyyupp/coco-minitrain. The purpose of this pull request is to enable yolov5 to train on a smaller coco dataset without days to fasten training duration. The original authors claim that the resampled dataset follows the same distribution of COCO: [STATS](https://github.com/giddyyupp/coco-minitrain/blob/master/STATS.md).


**Open Issue: Training models on coco-minitrain** https://github.com/ultralytics/yolov5/issues/8263

Usage is provided in the first few lines in ```train.py```:
```
python path/to/train.py --data coco-minitrain.yaml --weights yolov5s.pt --img 640 --coco_mini --coco_mini_samples 25000
```
where we can define the number of samples ```25000``` from COCO. 


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Implementation of COCO mini-training dataset support in YOLOv5.

### 📊 Key Changes
- Added `coco_minitrain.yaml` to configure training with a smaller COCO dataset sample.
- Updated `train.py` to handle a new `--coco_mini` argument and additional logic for preparing and using the mini dataset.
- Introduced utility scripts and data handling in `utils/coco_minitrain` to support mini dataset creation, sampling, and preparation.

### 🎯 Purpose & Impact
- Provides a way to train YOLOv5 on a subset (*mini* version) of the COCO dataset, requiring less computational resources.
- The mini dataset maintains a similar distribution of object classes, allowing users with limited resources to train and experiment with the model effectively.
- Helps in faster iterations for testing and development purposes without the need for the complete COCO dataset.