### PR TITLE
Add --save-pr to save precision and recall matrixes

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -26,7 +26,7 @@ def smooth(y, f=0.05):
     return np.convolve(yp, np.ones(nf) / nf, mode='valid')  # y-smoothed
 
 
-def ap_per_class(tp, conf, pred_cls, target_cls, plot=False, save_dir='.', names=(), eps=1e-16):
+def ap_per_class(tp, conf, pred_cls, target_cls, plot=False, save_dir='.', save_pr=False, names=(), eps=1e-16):
     """ Compute the average precision, given the recall and precision curves.
     Source: https://github.com/rafaelpadilla/Object-Detection-Metrics.
     # Arguments
@@ -85,6 +85,11 @@ def ap_per_class(tp, conf, pred_cls, target_cls, plot=False, save_dir='.', names
         plot_mc_curve(px, f1, Path(save_dir) / 'F1_curve.png', names, ylabel='F1')
         plot_mc_curve(px, p, Path(save_dir) / 'P_curve.png', names, ylabel='Precision')
         plot_mc_curve(px, r, Path(save_dir) / 'R_curve.png', names, ylabel='Recall')
+
+    if save_pr:
+        np.save(Path(save_dir) / 'P.npy', p)
+        np.save(Path(save_dir) / 'R.npy', r)
+        np.save(Path(save_dir) / 'F1.npy', f1)
 
     i = smooth(f1.mean(0), 0.1).argmax()  # max F1 index
     p, r, f1 = p[:, i], r[:, i], f1[:, i]

--- a/val.py
+++ b/val.py
@@ -119,6 +119,7 @@ def run(
         model=None,
         dataloader=None,
         save_dir=Path(''),
+        save_pr=False,
         plots=True,
         callbacks=Callbacks(),
         compute_loss=None,
@@ -263,7 +264,7 @@ def run(
     # Compute metrics
     stats = [torch.cat(x, 0).cpu().numpy() for x in zip(*stats)]  # to numpy
     if len(stats) and stats[0].any():
-        tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats, plot=plots, save_dir=save_dir, names=names)
+        tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats, plot=plots, save_dir=save_dir, save_pr=save_pr, names=names)
         ap50, ap = ap[:, 0], ap.mean(1)  # AP@0.5, AP@0.5:0.95
         mp, mr, map50, map = p.mean(), r.mean(), ap50.mean(), ap.mean()
         nt = np.bincount(stats[3].astype(int), minlength=nc)  # number of targets per class
@@ -345,6 +346,7 @@ def parse_opt():
     parser.add_argument('--save-hybrid', action='store_true', help='save label+prediction hybrid results to *.txt')
     parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
     parser.add_argument('--save-json', action='store_true', help='save a COCO-JSON results file')
+    parser.add_argument('--save-pr', action='store_true', help='save precision and recall matrixes')
     parser.add_argument('--project', default=ROOT / 'runs/val', help='save to project/name')
     parser.add_argument('--name', default='exp', help='save to project/name')
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')

--- a/val.py
+++ b/val.py
@@ -264,7 +264,11 @@ def run(
     # Compute metrics
     stats = [torch.cat(x, 0).cpu().numpy() for x in zip(*stats)]  # to numpy
     if len(stats) and stats[0].any():
-        tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats, plot=plots, save_dir=save_dir, save_pr=save_pr, names=names)
+        tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats,
+                                                      plot=plots,
+                                                      save_dir=save_dir,
+                                                      save_pr=save_pr,
+                                                      names=names)
         ap50, ap = ap[:, 0], ap.mean(1)  # AP@0.5, AP@0.5:0.95
         mp, mr, map50, map = p.mean(), r.mean(), ap50.mean(), ap.mean()
         nt = np.bincount(stats[3].astype(int), minlength=nc)  # number of targets per class


### PR DESCRIPTION
This PR adds the option `--save-pr` to val.py for exporting precision and recall matrixes, i.e. `P.npy`/`R.npy`/`F1.npy`. So one could examine the PR curve numerically in varying confidence values, other than the confidence value corresponding to the max F1 score.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement to the model evaluation process with options to save precision-recall data.

### 📊 Key Changes
- Added `save_pr` parameter to the `ap_per_class` function in `utils/metrics.py`.
- Included additional code to save precision (P), recall (R), and F1 score numpy arrays if `save_pr` is `True`.
- Updated `val.py` to accept the `--save-pr` command-line argument and pass this option through to the evaluation functions.

### 🎯 Purpose & Impact
- **Purpose**: Provide users with the ability to save detailed precision and recall data for further analysis after model evaluation.
- **Impact**: Users can now perform in-depth analysis on the precision-recall metrics, which is useful for optimizing model thresholds, understanding performance across different classes, and preparing detailed reports. This feature adds transparency and enables more customized performance evaluation for developers and researchers using YOLOv5.