### PR TITLE
Improve `--local_rank` arg comment

### DIFF
--- a/train.py
+++ b/train.py
@@ -504,7 +504,13 @@ def parse_opt(known=False):
     parser.add_argument('--patience', type=int, default=100, help='EarlyStopping patience (epochs without improvement)')
     parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
-    parser.add_argument('--local_rank', type=int, default=-1, help='DDP parameter, do not modify')
+    parser.add_argument('--local_rank', type=int, default=-1, 
+                    help="""DDP parameter, do not modify.
+                    This parameter is passed automatically when using multi-gpu mode.
+                    This should be -1 when using single-GPU or when using validation and test dataloaders. 
+                    Local Rank for each GPU is like the index of GPU. It specifies which GPU we are using.
+                    Pytorch Automatically passes this parameter. """)
+    )
 
     # Weights & Biases arguments
     parser.add_argument('--entity', default=None, help='W&B: Entity')

--- a/train.py
+++ b/train.py
@@ -504,13 +504,14 @@ def parse_opt(known=False):
     parser.add_argument('--patience', type=int, default=100, help='EarlyStopping patience (epochs without improvement)')
     parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
-    parser.add_argument('--local_rank', type=int, default=-1, 
-                    help="""DDP parameter, do not modify.
+    parser.add_argument('--local_rank',
+                        type=int,
+                        default=-1,
+                        help="""DDP parameter, do not modify.
                     This parameter is passed automatically when using multi-gpu mode.
-                    This should be -1 when using single-GPU or when using validation and test dataloaders. 
+                    This should be -1 when using single-GPU or when using validation and test dataloaders.
                     Local Rank for each GPU is like the index of GPU. It specifies which GPU we are using.
                     Pytorch Automatically passes this parameter. """)
-    
 
     # Weights & Biases arguments
     parser.add_argument('--entity', default=None, help='W&B: Entity')

--- a/train.py
+++ b/train.py
@@ -510,7 +510,7 @@ def parse_opt(known=False):
                     This should be -1 when using single-GPU or when using validation and test dataloaders. 
                     Local Rank for each GPU is like the index of GPU. It specifies which GPU we are using.
                     Pytorch Automatically passes this parameter. """)
-    )
+    
 
     # Weights & Biases arguments
     parser.add_argument('--entity', default=None, help='W&B: Entity')

--- a/train.py
+++ b/train.py
@@ -504,14 +504,7 @@ def parse_opt(known=False):
     parser.add_argument('--patience', type=int, default=100, help='EarlyStopping patience (epochs without improvement)')
     parser.add_argument('--freeze', nargs='+', type=int, default=[0], help='Freeze layers: backbone=10, first3=0 1 2')
     parser.add_argument('--save-period', type=int, default=-1, help='Save checkpoint every x epochs (disabled if < 1)')
-    parser.add_argument('--local_rank',
-                        type=int,
-                        default=-1,
-                        help="""DDP parameter, do not modify.
-                    This parameter is passed automatically when using multi-gpu mode.
-                    This should be -1 when using single-GPU or when using validation and test dataloaders.
-                    Local Rank for each GPU is like the index of GPU. It specifies which GPU we are using.
-                    Pytorch Automatically passes this parameter. """)
+    parser.add_argument('--local_rank', type=int, default=-1, help='Automatic DDP Multi-GPU argument, do not modify')
 
     # Weights & Biases arguments
     parser.add_argument('--entity', default=None, help='W&B: Entity')


### PR DESCRIPTION
Hi, 
It took me to a while to understand why this parameter exists and what it does. I thought maybe adding this to help string would be a good idea. 


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in clarity for the Distributed Data Parallel (DDP) command-line argument description.

### 📊 Key Changes
- Modified the help description for the `--local_rank` argument in the training script's argument parser.

### 🎯 Purpose & Impact
- 🎓 Enhanced clarity: The new help text for the `--local_rank` argument makes it clear that it is used for automatic configuration in multi-GPU setups with Distributed Data Parallel (DDP).
- 🔄 Minimal impact on end-users: This change mainly affects user understanding; it does not impact the script's functionality. It's particularly helpful for developers or users working with multi-GPU training configurations.