### PR TITLE
TRT `--half` fix autocast images to FP16

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -441,7 +441,7 @@ class DetectMultiBackend(nn.Module):
     def forward(self, im, augment=False, visualize=False, val=False):
         # YOLOv5 MultiBackend inference
         b, ch, h, w = im.shape  # batch, channel, height, width
-        if self.fp16:
+        if self.fp16 and im.dtype != torch.float16:
             im = im.half()  # to FP16
 
         if self.pt:  # PyTorch

--- a/models/common.py
+++ b/models/common.py
@@ -441,6 +441,9 @@ class DetectMultiBackend(nn.Module):
     def forward(self, im, augment=False, visualize=False, val=False):
         # YOLOv5 MultiBackend inference
         b, ch, h, w = im.shape  # batch, channel, height, width
+        if self.fp16:
+            im = im.half()  # to FP16
+
         if self.pt:  # PyTorch
             y = self.model(im, augment=augment, visualize=visualize)[0]
         elif self.jit:  # TorchScript


### PR DESCRIPTION
Resolves bug raised in https://github.com/ultralytics/yolov5/issues/7822

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Implementing automatic FP16 (half precision) image casting in YOLOv5 for improved efficiency.

### 📊 Key Changes
- Added a conditional check to automatically convert input images to FP16 before inference if the model is set to use FP16 and the images aren't already in that format.

### 🎯 Purpose & Impact
- **Purpose**: This change is intended to ensure that the model uses the correct precision for image inputs to match the model's operating precision mode (FP16 in this case), which wasn't explicitly enforced before.
- **Impact**: Users can expect more consistent and possibly faster performance, especially on hardware that benefits from half-precision computations. This is particularly relevant for GPUs that are optimized for FP16 operations, leading to more efficient utilization of resources. 🚀