### PR TITLE
Update stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,7 +32,9 @@ jobs:
             Thank you for your contributions to YOLOv5 🚀 and Vision AI ⭐!
 
           stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions YOLOv5 🚀 and Vision AI ⭐.'
-          days-before-stale: 30
-          days-before-close: 5
+          days-before-issue-stale: 30
+          days-before-issue-close: 10
+          days-before-pr-stale: 90
+          days-before-pr-close: 30
           exempt-issue-labels: 'documentation,tutorial,TODO'
           operations-per-run: 300  # The maximum number of operations per run, used to control rate limiting.


### PR DESCRIPTION
Update to keep PR's open longer before stale.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjusting GitHub Stale Bot configuration for issues and PRs 🤖✨

### 📊 Key Changes
- Split the stale and close days settings for issues and pull requests.
- Issues will now become stale after 30 days and closed after 10 days.
- Pull requests will become stale after 90 days and closed after 30 days.

### 🎯 Purpose & Impact
- 🛠️ **Customized management**: Differentiating between the management of issues and PRs allows for more tailored workflows.
- ⏰ **Extended evaluation time for PRs**: Developers have more time to review and work on PRs before they're marked as stale or closed.
- 🔄 **Increased operational limit**: More operations per bot run helps in managing a larger backlog of stale items.
- 🔓 **User benefit**: Contributors have clearer expectations and more time to respond to activity on their PRs, reducing the chance of valuable contributions getting closed prematurely.