### PR TITLE
[Classifier]: Use all layers up to 13 or 11

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -47,7 +47,7 @@ from utils.dataloaders import create_classification_dataloader
 from utils.general import (LOGGER, check_file, check_git_status, check_requirements, check_version, colorstr, download,
                            increment_path, init_seeds, print_args)
 from utils.loggers import GenericLogger
-from utils.torch_utils import de_parallel, model_info, ModelEMA, select_device, torch_distributed_zero_first
+from utils.torch_utils import ModelEMA, de_parallel, model_info, select_device, torch_distributed_zero_first
 
 LOCAL_RANK = int(os.getenv('LOCAL_RANK', -1))  # https://pytorch.org/docs/stable/elastic/run.html
 RANK = int(os.getenv('RANK', -1))

--- a/classifier.py
+++ b/classifier.py
@@ -101,7 +101,7 @@ def train():
         model = hub.load('ultralytics/yolov5', opt.model, pretrained=pretrained, autoshape=False, force_reload=False)
         if isinstance(model, DetectMultiBackend):
             model = model.model  # unwrap DetectMultiBackend
-        model.model = model.model[:10] if opt.model.endswith('6') else model.model[:8]  # backbone
+        model.model = model.model[:13] if opt.model.endswith('6') else model.model[:11]  # backbone
         m = model.model[-1]  # last layer
         ch = m.conv.in_channels if hasattr(m, 'conv') else sum(x.in_channels for x in m.m)  # ch into module
         c = Classify(ch, nc)  # Classify()

--- a/classifier.py
+++ b/classifier.py
@@ -112,9 +112,9 @@ def train():
                 model = hub.load(repo1, opt.model, pretrained=pretrained, autoshape=False, force_reload=True)
             if isinstance(model, DetectMultiBackend):
                 model = model.model  # unwrap DetectMultiBackend
-            model.model = model.model[:13] if opt.model.endswith('6') else model.model[:11]  # backbone
+            model.model = model.model[:12] if opt.model.endswith('6') else model.model[:10]  # backbone
             m = model.model[-1]  # last layer
-            ch = m.conv.in_channels if hasattr(m, 'conv') else sum(x.in_channels for x in m.m)  # ch into module
+            ch = m.conv.in_channels if hasattr(m, 'conv') else m.cv1.conv.in_channels  # ch into module
             c = Classify(ch, nc)  # Classify()
             c.i, c.f, c.type = m.i, m.f, 'models.common.Classify'  # index, from, type
             model.model[-1] = c  # replace

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -85,7 +85,7 @@ def exif_transpose(image):
             5: Image.TRANSPOSE,
             6: Image.ROTATE_270,
             7: Image.TRANSVERSE,
-            8: Image.ROTATE_90, }.get(orientation)
+            8: Image.ROTATE_90,}.get(orientation)
         if method is not None:
             image = image.transpose(method)
             del exif[0x0112]
@@ -1134,15 +1134,14 @@ class ClassificationDataset(torchvision.datasets.ImageFolder):
         return sample, j
 
 
-def create_classification_dataloader(
-        path,
-        imgsz=224,
-        batch_size=16,
-        augment=True,
-        cache=False,
-        rank=-1,
-        workers=8,
-        shuffle=True):
+def create_classification_dataloader(path,
+                                     imgsz=224,
+                                     batch_size=16,
+                                     augment=True,
+                                     cache=False,
+                                     rank=-1,
+                                     workers=8,
+                                     shuffle=True):
     # Returns Dataloader object to be used with YOLOv5 Classifier
     with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
         dataset = ClassificationDataset(root=path, imgsz=imgsz, augment=augment, cache=cache)

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -1153,5 +1153,5 @@ def create_classification_dataloader(path,
                               batch_size=batch_size,
                               shuffle=shuffle and sampler is None,
                               num_workers=nw,
-                              pin_memory=True,
-                              sampler=sampler)
+                              sampler=sampler,
+                              pin_memory=True)


### PR DESCRIPTION
@AyushExel this updates the classifier models to use the full backbone. After this change I see a much more normal ~40% size reduction in YOLOv5s, from 7.2Mparams to 4.2Mparams on MNIST.

We need to test this branch first though on ImageNet before merging to verify improved performance.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements made to the model slicing for classification and minor code styling improvements.

### 📊 Key Changes
- Updated model slicing indices for selecting the backbone in `classifier.py`.
- Refined channel selection strategy to better suit more layer types.
- Small code styling changes in `dataloaders.py` for readability and consistency.

### 🎯 Purpose & Impact
- The modifications in slicing the model aim to improve the performance of the classifier when using different versions of YOLO models (e.g. 'v6' vs others).
- Adjusting the method of channel extraction increases the classifier’s compatibility with different kinds of layers—an important step for robustness and maintainability.
- Code style changes lead to better readability, making it easier for developers to comprehend and contribute to the project. 🛠️

These changes are likely to make the classifier more accurate and the codebase more user-friendly, though primarily affecting developers working on the project directly. 🎉