### PR TITLE
Update tutorial.ipynb

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -1105,8 +1105,8 @@
         "# TensorRT \n",
         "# https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html#installing-pip\n",
         "!pip install -U nvidia-tensorrt --index-url https://pypi.ngc.nvidia.com  # install\n",
-        "!python export.py --weights yolov5s.pt --include engine --imgsz 640 640 --device 0  # export\n",
-        "!python detect.py --weights yolov5s.engine --imgsz 640 640 --device 0  # inference"
+        "!python export.py --weights yolov5s.pt --include engine --imgsz 640 --device 0  # export\n",
+        "!python detect.py --weights yolov5s.engine --imgsz 640 --device 0  # inference"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Simplify TensorRT image size example 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to YOLOv5 tutorial for simplified TensorRT model export and inference image size specification.

### 📊 Key Changes
- Changed the image size parameter in the TensorRT section of the YOLOv5 tutorial notebook from `--imgsz 640 640` to `--imgsz 640` for both model export and inference commands.

### 🎯 Purpose & Impact
- **Consistency**: Ensures the image size argument is uniformly specified across the tutorial, which helps prevent confusion or errors.
- **Ease of Use**: Simplifies the command for users, making it easier to understand and execute.
- **Potential Impact**: Could lead to fewer user mistakes and a smoother experience for those new to YOLOv5 or TensorRT, facilitating better adoption and usability of the tutorial.