### PR TITLE
Revert "Expose OpenVINO `batch_size` similarly to TensorRT"

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -366,7 +366,6 @@ class DetectMultiBackend(nn.Module):
             if not Path(w).is_file():  # if not *.xml
                 w = next(Path(w).glob('*.xml'))  # get *.xml file from *_openvino_model dir
             network = ie.read_model(model=w, weights=Path(w).with_suffix('.bin'))
-            batch_size = network.batch_size
             executable_network = ie.compile_model(network, device_name="CPU")  # device_name="MYRIAD" for Intel NCS2
             output_layer = next(iter(executable_network.outputs))
             meta = Path(w).with_suffix('.yaml')


### PR DESCRIPTION
Reverts ultralytics/yolov5#8437, resolves https://github.com/ultralytics/yolov5/issues/8509

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model compatibility with OpenVINO by removing unnecessary batch size setting.

### 📊 Key Changes
- Removed the line setting `batch_size` from the OpenVINO model loading section in `models/common.py`.

### 🎯 Purpose & Impact
- ⚙️ **Purpose**: To streamline the model-loading process for OpenVINO-backed models, ensuring there's no manual batch size configuration needed.
- 🚀 **Impact**: Offers a smoother integration with OpenVINO, potentially improving user experience by preventing batch size-related errors and making the process more foolproof for all users, including those less familiar with the intricacies of model deployment.