### PR TITLE
Avoid FP64 ops for MPS support in train.py

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -644,7 +644,7 @@ def labels_to_class_weights(labels, nc=80):
         return torch.Tensor()
 
     labels = np.concatenate(labels, 0)  # labels.shape = (866643, 5) for COCO
-    classes = labels[:, 0].astype(np.int)  # labels = [class xywh]
+    classes = labels[:, 0].astype(int)  # labels = [class xywh]
     weights = np.bincount(classes, minlength=nc)  # occurrences per class
 
     # Prepend gridpoint count (for uCE training)
@@ -654,13 +654,13 @@ def labels_to_class_weights(labels, nc=80):
     weights[weights == 0] = 1  # replace empty bins with 1
     weights = 1 / weights  # number of targets per class
     weights /= weights.sum()  # normalize
-    return torch.from_numpy(weights)
+    return torch.from_numpy(weights).float()
 
 
 def labels_to_image_weights(labels, nc=80, class_weights=np.ones(80)):
     # Produces image weights based on class_weights and image contents
     # Usage: index = random.choices(range(n), weights=image_weights, k=1)  # weighted image sample
-    class_counts = np.array([np.bincount(x[:, 0].astype(np.int), minlength=nc) for x in labels])
+    class_counts = np.array([np.bincount(x[:, 0].astype(int), minlength=nc) for x in labels])
     return (class_weights.reshape(1, nc) * class_counts).sum(1)
 
 


### PR DESCRIPTION
Resolves https://github.com/ultralytics/yolov5/pull/7878#issuecomment-1177952614

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of data types in weight computation functions. 

### 📊 Key Changes
- Changed `np.int` to the built-in Python `int` for type casting in `labels_to_class_weights` and `labels_to_image_weights`.
- Ensured returned weights are of type `float` in `labels_to_class_weights`.

### 🎯 Purpose & Impact
- 📈 **Consistency**: Using Python's built-in `int` type may offer more consistent behavior across different platforms and versions of Python.
- 🔍 **Precision**: Ensuring weights are in floating-point format (`float`) enables more precise calculations, especially important when weights are used in loss calculations or gradients during model training.
- 🚀 **User Experience**: These backend changes ensure more reliable and accurate training processes for users, although most might not notice the subtle changes directly.