### PR TITLE
Add `--hard-fail` argument to benchmarks for CI errors

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -39,7 +39,7 @@ jobs:
           pip list
       - name: Run benchmarks
         run: |
-          python utils/benchmarks.py --weights ${{ matrix.model }}.pt --img 320 --hard-fail 0 1 2 3 4 6 7 8
+          python utils/benchmarks.py --weights ${{ matrix.model }}.pt --img 320 --hard-fail
 
   Tests:
     timeout-minutes: 60

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -39,7 +39,7 @@ jobs:
           pip list
       - name: Run benchmarks
         run: |
-          python utils/benchmarks.py --weights ${{ matrix.model }}.pt --img 320
+          python utils/benchmarks.py --weights ${{ matrix.model }}.pt --img 320 --hard-fail 0 1 2 3 6 7 8
 
   Tests:
     timeout-minutes: 60

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -39,7 +39,7 @@ jobs:
           pip list
       - name: Run benchmarks
         run: |
-          python utils/benchmarks.py --weights ${{ matrix.model }}.pt --img 320 --hard-fail 0 1 2 3 6 7 8
+          python utils/benchmarks.py --weights ${{ matrix.model }}.pt --img 320 --hard-fail 0 1 2 3 4 6 7 8
 
   Tests:
     timeout-minutes: 60

--- a/export.py
+++ b/export.py
@@ -436,9 +436,9 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
                 r'"Identity.?.?": {"name": "Identity.?.?"}, '
                 r'"Identity.?.?": {"name": "Identity.?.?"}, '
                 r'"Identity.?.?": {"name": "Identity.?.?"}}}', r'{"outputs": {"Identity": {"name": "Identity"}, '
-                                                               r'"Identity_1": {"name": "Identity_1"}, '
-                                                               r'"Identity_2": {"name": "Identity_2"}, '
-                                                               r'"Identity_3": {"name": "Identity_3"}}}', json)
+                r'"Identity_1": {"name": "Identity_1"}, '
+                r'"Identity_2": {"name": "Identity_2"}, '
+                r'"Identity_3": {"name": "Identity_3"}}}', json)
             j.write(subst)
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')

--- a/export.py
+++ b/export.py
@@ -75,18 +75,18 @@ from utils.torch_utils import select_device
 def export_formats():
     # YOLOv5 export formats
     x = [
-        ['PyTorch', '-', '.pt', True],
-        ['TorchScript', 'torchscript', '.torchscript', True],
-        ['ONNX', 'onnx', '.onnx', True],
-        ['OpenVINO', 'openvino', '_openvino_model', False],
-        ['TensorRT', 'engine', '.engine', True],
-        ['CoreML', 'coreml', '.mlmodel', False],
-        ['TensorFlow SavedModel', 'saved_model', '_saved_model', True],
-        ['TensorFlow GraphDef', 'pb', '.pb', True],
-        ['TensorFlow Lite', 'tflite', '.tflite', False],
-        ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False],
-        ['TensorFlow.js', 'tfjs', '_web_model', False],]
-    return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'GPU'])
+        ['PyTorch', '-', '.pt', True, True],
+        ['TorchScript', 'torchscript', '.torchscript', True, True],
+        ['ONNX', 'onnx', '.onnx', True, True],
+        ['OpenVINO', 'openvino', '_openvino_model', True, False],
+        ['TensorRT', 'engine', '.engine', False, True],
+        ['CoreML', 'coreml', '.mlmodel', True, False],
+        ['TensorFlow SavedModel', 'saved_model', '_saved_model', True, True],
+        ['TensorFlow GraphDef', 'pb', '.pb', True, True],
+        ['TensorFlow Lite', 'tflite', '.tflite', True, False],
+        ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
+        ['TensorFlow.js', 'tfjs', '_web_model', False, False],]
+    return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'CPU', 'GPU'])
 
 
 def export_torchscript(model, im, file, optimize, prefix=colorstr('TorchScript:')):
@@ -436,9 +436,9 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
                 r'"Identity.?.?": {"name": "Identity.?.?"}, '
                 r'"Identity.?.?": {"name": "Identity.?.?"}, '
                 r'"Identity.?.?": {"name": "Identity.?.?"}}}', r'{"outputs": {"Identity": {"name": "Identity"}, '
-                r'"Identity_1": {"name": "Identity_1"}, '
-                r'"Identity_2": {"name": "Identity_2"}, '
-                r'"Identity_3": {"name": "Identity_3"}}}', json)
+                                                               r'"Identity_1": {"name": "Identity_1"}, '
+                                                               r'"Identity_2": {"name": "Identity_2"}, '
+                                                               r'"Identity_3": {"name": "Identity_3"}}}', json)
             j.write(subst)
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -26,6 +26,7 @@ Usage:
 """
 
 import argparse
+import platform
 import sys
 import time
 from pathlib import Path
@@ -58,12 +59,13 @@ def run(
 ):
     y, t = [], time.time()
     device = select_device(device)
-    for i, (name, f, suffix, cpu,
-            gpu) in export.export_formats().iterrows():  # index, (name, file, suffix, gpu-capable)
+    for i, (name, f, suffix, cpu, gpu) in export.export_formats().iterrows():  # index, (name, file, suffix, CPU, GPU)
         try:
             assert i != 9, 'Edge TPU not supported'
             assert i != 10, 'TF.js not supported'
-            assert cpu or 'cpu' not in device.type, f'{name} inference not supported on CPU'
+            if cpu:
+                assert 'cpu' in device.type, f'{name} inference not supported on CPU'
+                assert i != 5 or platform.system() == 'Darwin', f'{name} inference only supported on macOS>=10.13'
             assert gpu or 'gpu' not in device.type, f'{name} inference not supported on GPU'
 
             # Export

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -61,12 +61,12 @@ def run(
     device = select_device(device)
     for i, (name, f, suffix, cpu, gpu) in export.export_formats().iterrows():  # index, (name, file, suffix, CPU, GPU)
         try:
-            assert i != 9, 'Edge TPU not supported'
-            assert i != 10, 'TF.js not supported'
-            if cpu:
-                assert 'cpu' in device.type, f'{name} inference not supported on CPU'
-                assert i != 5 or platform.system() == 'Darwin', f'{name} inference only supported on macOS>=10.13'
-            assert gpu or 'gpu' not in device.type, f'{name} inference not supported on GPU'
+            assert i not in (9, 10), f'{name} inference not supported'  # Edge TPU and TF.js are unsupported
+            assert i != 5 or platform.system() == 'Darwin', f'{name} inference only supported on macOS>=10.13'
+            if 'cpu' in device.type:
+                assert cpu, f'{name} inference not supported on CPU'
+            if 'cuda' in device.type:
+                assert gpu, f'{name} inference not supported on GPU'
 
             # Export
             if f == '-':

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -80,7 +80,7 @@ def run(
         except Exception as e:
             LOGGER.warning(f'WARNING: Benchmark failure for {name}: {e}')
             if i in hard_fail:
-                Exception(e)
+                raise Exception(e)
             y.append([name, None, None, None])  # mAP, t_inference
         if pt_only and i == 0:
             break  # break after PyTorch

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -54,6 +54,7 @@ def run(
         half=False,  # use FP16 half-precision inference
         test=False,  # test exports only
         pt_only=False,  # test PyTorch only
+        hard_fail=[],  # throw error for formats: --hard-fail 0, or 0 2 3
 ):
     y, t = [], time.time()
     device = select_device(device)
@@ -78,6 +79,8 @@ def run(
             y.append([name, round(file_size(w), 1), round(metrics[3], 4), round(speeds[1], 2)])  # MB, mAP, t_inference
         except Exception as e:
             LOGGER.warning(f'WARNING: Benchmark failure for {name}: {e}')
+            if i in hard_fail:
+                Exception(e)
             y.append([name, None, None, None])  # mAP, t_inference
         if pt_only and i == 0:
             break  # break after PyTorch
@@ -102,6 +105,7 @@ def test(
         half=False,  # use FP16 half-precision inference
         test=False,  # test exports only
         pt_only=False,  # test PyTorch only
+        hard_fail=[],  # throw error for formats: --hard-fail 0, or 0 2 3
 ):
     y, t = [], time.time()
     device = select_device(device)
@@ -134,6 +138,7 @@ def parse_opt():
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--test', action='store_true', help='test exports only')
     parser.add_argument('--pt-only', action='store_true', help='test PyTorch only')
+    parser.add_argument('--hard-fail', nargs='+', default=[], help='throw error for formats: --hard-fail 0, or 0 2 3')
     opt = parser.parse_args()
     opt.data = check_yaml(opt.data)  # check YAML
     print_args(vars(opt))

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -58,8 +58,7 @@ def run(
 ):
     y, t = [], time.time()
     device = select_device(device)
-    for i, (
-            name, f, suffix, cpu,
+    for i, (name, f, suffix, cpu,
             gpu) in export.export_formats().iterrows():  # index, (name, file, suffix, gpu-capable)
         try:
             assert i != 9, 'Edge TPU not supported'


### PR DESCRIPTION
Will cause CI to fail on a benchmark failure (currently no hard errors are thrown, only warnings).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved error handling and model exporting options in YOLOv5 workflows.

### 📊 Key Changes
- Added `--hard-fail` option in benchmarking script to enable throwing errors for benchmark failures.
- Modified export options to specify support for CPU and GPU, and included assertions for CPU-specific and macOS-only support.
- Added support for the `--hard-fail` flag in the Continuous Integration (CI) benchmarking workflow.

### 🎯 Purpose & Impact
- 🎯 **Error Handling**: With the `--hard-fail` option, developers can more easily detect and handle issues during automated benchmarking, leading to more robust CI processes.
- 💻 **CPU/GPU Support**: The differentiation between CPU and GPU support in the export options ensures users have clearer information regarding model deployment capabilities, potentially reducing confusion and unexpected errors.
- 🛠️ **CI/CD Improvements**: The new flag in the CI workflow allows for stricter testing standards, which can lead to higher code quality and more reliable model performance after new changes are integrated.