### PR TITLE
Add `--half` arguments to export.py Usage examples

### DIFF
--- a/export.py
+++ b/export.py
@@ -555,11 +555,12 @@ def run(
     # Finish
     f = [str(x) for x in f if x]  # filter out '' and None
     if any(f):
+        h = '--half' if half else ''  # --half FP16 inference arg
         LOGGER.info(f'\nExport complete ({time.time() - t:.2f}s)'
                     f"\nResults saved to {colorstr('bold', file.parent.resolve())}"
-                    f"\nDetect:          python detect.py --weights {f[-1]}"
+                    f"\nDetect:          python detect.py --weights {f[-1]} {h}"
+                    f"\nValidate:        python val.py --weights {f[-1]} {h}"
                     f"\nPyTorch Hub:     model = torch.hub.load('ultralytics/yolov5', 'custom', '{f[-1]}')"
-                    f"\nValidate:        python val.py --weights {f[-1]}"
                     f"\nVisualize:       https://netron.app")
     return f  # return list of exported files/dirs
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved export script guidance with half-precision support info.

### 📊 Key Changes
- Added a command line argument `--half` to include half-precision (FP16) inference in the post-export messages.
- Reorganized the post-export message to include the `--half` argument where applicable.

### 🎯 Purpose & Impact
- **Provide Clearer Guidance**: The messages displayed after exporting models now include instructions on how to perform inference in half-precision mode, making it clearer for users who want to use this feature. 
- **Enhanced User Experience**: Users get immediate, post-export instructions with the correct flags for half-precision, improving the ease of transition to testing and validation steps.
- **Potential Performance Boost**: The half-precision inference can potentially improve performance on supported hardware, offering faster inference times and reduced model size.

🏎💾✅