### PR TITLE
Fix `LoadImages()` with dataset YAML lists

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -189,7 +189,7 @@ class LoadImages:
             elif os.path.isfile(p):
                 files.append(p)  # files
             else:
-                raise Exception(f'ERROR: {p} does not exist')
+                raise FileNotFoundError(f'{p} does not exist')
 
         images = [x for x in files if x.split('.')[-1].lower() in IMG_FORMATS]
         videos = [x for x in files if x.split('.')[-1].lower() in VID_FORMATS]

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -176,7 +176,7 @@ class _RepeatSampler:
 class LoadImages:
     # YOLOv5 image/video dataloader, i.e. `python detect.py --source image.jpg/vid.mp4`
     def __init__(self, path, img_size=640, stride=32, auto=True):
-        if isinstance(path, list):
+        if isinstance(path, (list, tuple)):
             paths = [str(Path(p).resolve()) for p in path]  # list of paths
         else:
             paths = [str(Path(path).resolve())]  # os-agnostic absolute path

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -176,15 +176,20 @@ class _RepeatSampler:
 class LoadImages:
     # YOLOv5 image/video dataloader, i.e. `python detect.py --source image.jpg/vid.mp4`
     def __init__(self, path, img_size=640, stride=32, auto=True):
-        p = str(Path(path).resolve())  # os-agnostic absolute path
-        if '*' in p:
-            files = sorted(glob.glob(p, recursive=True))  # glob
-        elif os.path.isdir(p):
-            files = sorted(glob.glob(os.path.join(p, '*.*')))  # dir
-        elif os.path.isfile(p):
-            files = [p]  # files
+        if isinstance(path, list):
+            paths = [str(Path(p).resolve()) for p in path]  # list of paths
         else:
-            raise Exception(f'ERROR: {p} does not exist')
+            paths = [str(Path(path).resolve())]  # os-agnostic absolute path
+        files = []
+        for p in sorted(paths):
+            if '*' in p:
+                files.extend(sorted(glob.glob(p, recursive=True)))  # glob
+            elif os.path.isdir(p):
+                files.extend(sorted(glob.glob(os.path.join(p, '*.*'))))  # dir
+            elif os.path.isfile(p):
+                files.append(p)  # files
+            else:
+                raise Exception(f'ERROR: {p} does not exist')
 
         images = [x for x in files if x.split('.')[-1].lower() in IMG_FORMATS]
         videos = [x for x in files if x.split('.')[-1].lower() in VID_FORMATS]

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -176,12 +176,9 @@ class _RepeatSampler:
 class LoadImages:
     # YOLOv5 image/video dataloader, i.e. `python detect.py --source image.jpg/vid.mp4`
     def __init__(self, path, img_size=640, stride=32, auto=True):
-        if isinstance(path, (list, tuple)):
-            paths = [str(Path(p).resolve()) for p in path]  # list of paths
-        else:
-            paths = [str(Path(path).resolve())]  # os-agnostic absolute path
         files = []
-        for p in sorted(paths):
+        for p in sorted(path) if isinstance(path, (list, tuple)) else [path]:
+            p = str(Path(p).resolve())
             if '*' in p:
                 files.extend(sorted(glob.glob(p, recursive=True)))  # glob
             elif os.path.isdir(p):

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -439,7 +439,7 @@ class LoadImagesAndLabels(Dataset):
                         f += [x.replace('./', parent) if x.startswith('./') else x for x in t]  # local to global path
                         # f += [p.parent / x.lstrip(os.sep) for x in t]  # local to global path (pathlib)
                 else:
-                    raise Exception(f'{prefix}{p} does not exist')
+                    raise FileNotFoundError(f'{prefix}{p} does not exist')
             self.im_files = sorted(x.replace('/', os.sep) for x in f if x.split('.')[-1].lower() in IMG_FORMATS)
             # self.img_files = sorted([x for x in f if x.suffix[1:].lower() in IMG_FORMATS])  # pathlib
             assert self.im_files, f'{prefix}No images found'


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

When using the tflite export with a yolov5 dataset.yaml that contains a **list** of train/val paths rather than a single path, the tflite exporter fails with the message, `Expected str, bytes or os.PathLike object, not list` - this is because the return object from `check_dataset(data)['train']` is a list of strings if the `train` entry in the dataset.yaml is a list as well. 

This PR aims to correct this by allowing the input parameter `path` to be a list as well and simply extending the `files` list for subsequent paths.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced flexibility in specifying input sources for image and video processing in YOLOv5.

### 📊 Key Changes
- 🔄 The input path handling now supports lists or tuples of paths, rather than just a single path.
- 🔍 Updated file existence checks to use `FileNotFoundError` instead of generic `Exception`.

### 🎯 Purpose & Impact
- 👥 Allows users to input multiple sources at once, improving usability and efficiency.
- 🛠️ Provides a more descriptive error with `FileNotFoundError` to better guide users when input paths are incorrect.