### PR TITLE
val.py `assert ncm == nc` fix

### DIFF
--- a/val.py
+++ b/val.py
@@ -164,7 +164,7 @@ def run(
     if not training:
         if pt and not single_cls:  # check --weights are trained on --data
             ncm = model.model.nc
-            assert ncm == nc, f'{weights[0]} ({ncm} classes) trained on different --data than what you passed ({nc} ' \
+            assert ncm == nc, f'{weights} ({ncm} classes) trained on different --data than what you passed ({nc} ' \
                               f'classes). Pass correct combination of --weights and --data that are trained together.'
         model.warmup(imgsz=(1 if pt else batch_size, 3, imgsz, imgsz))  # warmup
         pad = 0.0 if task in ('speed', 'benchmark') else 0.5


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced error message for model and dataset class mismatch in validation script.

### 📊 Key Changes
- Modified the assertion error message in `val.py` to display the complete `weights` array when a class mismatch is detected.

### 🎯 Purpose & Impact
- **Purpose:** To provide a more informative error message to users when their model's number of classes doesn't match the dataset classes during validation.
- **Impact:** This change will help users quickly identify issues when using datasets with a different number of classes than the model was trained on, improving debugging and user experience. ⚙️🔍