### PR TITLE
Add `thop>=0.1.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ seaborn>=0.11.0
 # Extras --------------------------------------
 ipython  # interactive notebook
 psutil  # system utilization
-thop  # FLOPs computation
+thop>=0.1.0  # FLOPs computation
 # albumentations>=1.0.3
 # pycocotools>=2.0  # COCO mAP
 # roboflow


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to FLOPs computation dependency in YOLOv5's requirements.

### 📊 Key Changes
- Updated the `thop` library version requirement from unspecified to `>=0.1.0` in `requirements.txt`.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To ensure that the Floating Point Operations Per Second (FLOPs) computation has a minimal version, likely for compatibility or to leverage new features.
- 🔍 **Impact**: Users may notice improved accuracy or functionality in FLOPs computation when using YOLOv5 for neural network efficiency analysis.
- 🛠 **User Action**: Developers need to update their environments to comply with the new version requirement for continued support and enhancements.