### PR TITLE
Raise error on suffix-less model path

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -441,6 +441,8 @@ class DetectMultiBackend(nn.Module):
                 output_details = interpreter.get_output_details()  # outputs
             elif tfjs:
                 raise Exception('ERROR: YOLOv5 TF.js inference is not supported')
+            else:
+                raise Exception(f'ERROR: {w} is not a supported format')
         self.__dict__.update(locals())  # assign all variables to self
 
     def forward(self, im, augment=False, visualize=False, val=False):


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

This PR raises an Exception when the model passed into `DetectMultiBackend` does not have a suffix.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enforced format support validation in YOLOv5 TensorFlow model conversion.

### 📊 Key Changes
- Added an error raise condition for unsupported format checks during model conversion in TensorFlow.

### 🎯 Purpose & Impact
- **Purpose**: Ensures that the user is informed if they attempt to use an unsupported export format when converting YOLOv5 models using the TensorFlow wrapper.
- **Impact**: Provides clearer error messaging, preventing potential confusion and troubleshooting time for users. It ensures users only work with compatible formats, enhancing overall user experience with the model conversion process. 🛠️🔍