### PR TITLE
Assert `--optimize` not used with cuda device

### DIFF
--- a/export.py
+++ b/export.py
@@ -492,6 +492,8 @@ def run(
     # Checks
     imgsz *= 2 if len(imgsz) == 1 else 1  # expand
     assert nc == len(names), f'Model class count {nc} != len(names) {len(names)}'
+    if optimize:
+        assert device.type != 'cuda', '--optimize not compatible with cuda devices, i.e. use --device cpu'
 
     # Input
     gs = int(max(model.stride))  # grid size (max stride)


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

TorchScript throws a lot of errors complaining about mobile-optimized models not working with CUDA devices when trying to use a mobile-optimized cuda-export-device model, regardless of whether the model is ran on cpu or a cuda device. This PR prevents that from occurring by ensuring that `--optimize` cannot be used with a cuda export device.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improve export script by enforcing CPU device usage during optimization.

### 📊 Key Changes
- Added a condition to assert that the `--optimize` flag requires `--device cpu`.

### 🎯 Purpose & Impact
- 🎯 **Purpose:** Ensures users avoid compatibility issues when using the `--optimize` option by running the model optimization on CPU only.
- 💡 **Impact:** Prevents potential errors for those attempting to optimize models with CUDA-enabled devices, leading to a smoother user experience when optimizing YOLOv5 models for deployment.