### PR TITLE
Add `pip install wheel` to avoid legacy `setup.py install`

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -77,7 +77,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.python-version }}-pip-
       - name: Install requirements
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel
           pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
           python --version
           pip --version

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -32,7 +32,7 @@ jobs:
       #    restore-keys: ${{ runner.os }}-Benchmarks-
       - name: Install requirements
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel
           pip install -r requirements.txt coremltools openvino-dev tensorflow-cpu --extra-index-url https://download.pytorch.org/whl/cpu
           python --version
           pip --version

--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apt update && apt install --no-install-recommends -y zip htop screen libgl1-
 
 # Install pip packages
 COPY requirements.txt .
-RUN python -m pip install --upgrade pip
+RUN python -m pip install --upgrade pip wheel
 RUN pip uninstall -y torch torchvision torchtext Pillow
 RUN pip install --no-cache -r requirements.txt albumentations wandb gsutil notebook Pillow>=9.1.0 \
     'opencv-python<4.6.0.66' \

--- a/utils/docker/Dockerfile-arm64
+++ b/utils/docker/Dockerfile-arm64
@@ -17,7 +17,7 @@ RUN apt install --no-install-recommends -y python3-pip git zip curl htop gcc \
 
 # Install pip packages
 COPY requirements.txt .
-RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade pip wheel
 RUN pip install --no-cache -r requirements.txt gsutil notebook \
     tensorflow-aarch64
     # tensorflowjs \

--- a/utils/docker/Dockerfile-cpu
+++ b/utils/docker/Dockerfile-cpu
@@ -16,7 +16,7 @@ RUN apt install --no-install-recommends -y python3-pip git zip curl htop libgl1-
 
 # Install pip packages
 COPY requirements.txt .
-RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade pip wheel
 RUN pip install --no-cache -r requirements.txt albumentations gsutil notebook \
     coremltools onnx onnx-simplifier onnxruntime openvino-dev tensorflow-cpu tensorflowjs \
     --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
Seeing these messages in linux CI which is confusing me.
<img width="784" alt="Screen Shot 2022-07-16 at 4 16 20 PM" src="https://user-images.githubusercontent.com/26833433/179358624-579a65f9-c742-45cb-80ba-368a05d7022f.png">



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to Python package installation process for better dependency management 🧱🔄

### 📊 Key Changes
- `wheel` package is now installed alongside the latest `pip` when setting up environments.
- Modifications affect Continuous Integration (CI) testing workflow and various Dockerfiles (default, ARM64, CPU).

### 🎯 Purpose & Impact
- **Purpose:** Ensure smooth installation of dependencies and avoid potential issues with package builds. 🛠️ 
- **Impact:** Users and developers who build YOLOv5 from source should experience more consistent and reliable installations, especially for complex packages that require compiling. Some CI processes might also run faster with these improvements. 🚀💻