### PR TITLE
Link fuse() to AutoShape() for Hub models

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -36,7 +36,6 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
 
     if not verbose:
         LOGGER.setLevel(logging.WARNING)
-
     check_requirements(exclude=('tensorboard', 'thop', 'opencv-python'))
     name = Path(name)
     path = name.with_suffix('.pt') if name.suffix == '' and not name.is_dir() else name  # checkpoint path
@@ -44,7 +43,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
         device = select_device(device)
 
         if pretrained and channels == 3 and classes == 80:
-            model = DetectMultiBackend(path, device=device)  # download/load FP32 model
+            model = DetectMultiBackend(path, device=device, fuse=autoshape)  # download/load FP32 model
             # model = models.experimental.attempt_load(path, map_location=device)  # download/load FP32 model
         else:
             cfg = list((Path(__file__).parent / 'models').rglob(f'{path.stem}.yaml'))[0]  # model.yaml path

--- a/models/common.py
+++ b/models/common.py
@@ -305,7 +305,7 @@ class Concat(nn.Module):
 
 class DetectMultiBackend(nn.Module):
     # YOLOv5 MultiBackend class for python inference on various backends
-    def __init__(self, weights='yolov5s.pt', device=torch.device('cpu'), dnn=False, data=None, fp16=False):
+    def __init__(self, weights='yolov5s.pt', device=torch.device('cpu'), dnn=False, data=None, fp16=False, fuse=True):
         # Usage:
         #   PyTorch:              weights = *.pt
         #   TorchScript:                    *.torchscript
@@ -331,7 +331,7 @@ class DetectMultiBackend(nn.Module):
                 names = yaml.safe_load(f)['names']
 
         if pt:  # PyTorch
-            model = attempt_load(weights if isinstance(weights, list) else w, device=device)
+            model = attempt_load(weights if isinstance(weights, list) else w, device=device, inplace=True, fuse=fuse)
             stride = max(int(model.stride.max()), 32)  # model stride
             names = model.module.names if hasattr(model, 'module') else model.names  # get class names
             model.half() if fp16 else model.float()


### PR DESCRIPTION
This PR disables fusing for autoshape=False Hub models.

@AyushExel 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to model loading with optional layer fusion in `hubconf.py` and `DetectMultiBackend` class.

### 📊 Key Changes
- The `DetectMultiBackend` class has a new `fuse` parameter that controls whether model layers are fused beneficial for inference time. 
- In `hubconf.py`, the layer fusion is now linked to the `autoshape` parameter when preloading a model.

### 🎯 Purpose & Impact
- **Purpose**: To give users the option to speed up model inference by fusing the layers of the neural network when the model is loaded.
- **Impact**:
  - 🚀 Could improve inference speed by reducing the number of operations performed during a forward pass.
  - ✅ Offers a flexible choice to users: they can turn layer fusion on or off, potentially trading off between model speed and adaptability based on their requirements.