### PR TITLE
config for diablo

### DIFF
--- a/data/coco128.yaml
+++ b/data/coco128.yaml
@@ -14,17 +14,9 @@ val: images/train2017  # val images (relative to 'path') 128 images
 test:  # test images (optional)
 
 # Classes
-nc: 80  # number of classes
-names: ['person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train', 'truck', 'boat', 'traffic light',
-        'fire hydrant', 'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog', 'horse', 'sheep', 'cow',
-        'elephant', 'bear', 'zebra', 'giraffe', 'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
-        'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat', 'baseball glove', 'skateboard', 'surfboard',
-        'tennis racket', 'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl', 'banana', 'apple',
-        'sandwich', 'orange', 'broccoli', 'carrot', 'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
-        'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop', 'mouse', 'remote', 'keyboard', 'cell phone',
-        'microwave', 'oven', 'toaster', 'sink', 'refrigerator', 'book', 'clock', 'vase', 'scissors', 'teddy bear',
-        'hair drier', 'toothbrush']  # class names
+nc: 3  # number of classes
+names: ['hero', 'mercenary','enemy']  # class names
 
 
 # Download script/URL (optional)
-download: https://ultralytics.com/assets/coco128.zip
+#download: https://ultralytics.com/assets/coco128.zip

--- a/models/yolov5s.yaml
+++ b/models/yolov5s.yaml
@@ -1,7 +1,7 @@
 # YOLOv5 🚀 by Ultralytics, GPL-3.0 license
 
 # Parameters
-nc: 80  # number of classes
+nc: 3  # number of classes
 depth_multiple: 0.33  # model depth multiple
 width_multiple: 0.50  # layer channel multiple
 anchors:


### PR DESCRIPTION
测试训练数据<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updating class information for COCO128 dataset and model configuration.

### 📊 Key Changes
- Reduced the number of target classes from 80 to 3 in `coco128.yaml`.
- Changed class names from general COCO classes to specific ones: `hero`, `mercenary`, and `enemy`.
- Adjusted the number of classes from 80 to 3 in `yolov5s.yaml`, to match the new dataset configuration.
- Commented out the download URL for the COCO128 dataset.

### 🎯 Purpose & Impact
- These changes tailor the YOLOv5 small model to a specialized task with fewer classes, potentially part of a custom use case or tutorial.
- The update will make it easier for users interested in similar specialized tasks to adapt the provided example configuration.
- The impact will be mostly on those who use the COCO128 dataset for training models, as they'll need to adjust to the new class structure if they pull the latest changes.