### PR TITLE
Fix `OMP_NUM_THREADS=1` for macOS

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -52,7 +52,7 @@ np.set_printoptions(linewidth=320, formatter={'float_kind': '{:11.5g}'.format}) 
 pd.options.display.max_columns = 10
 cv2.setNumThreads(0)  # prevent OpenCV from multithreading (incompatible with PyTorch DataLoader)
 os.environ['NUMEXPR_MAX_THREADS'] = str(NUM_THREADS)  # NumExpr max threads
-os.environ['OMP_NUM_THREADS'] = str(NUM_THREADS)  # OpenMP max threads (PyTorch and SciPy)
+os.environ['OMP_NUM_THREADS'] = '1' if platform.system() == 'darwin' else str(NUM_THREADS)  # OpenMP (PyTorch and SciPy)
 
 
 def is_kaggle():


### PR DESCRIPTION
Resolves https://github.com/ultralytics/yolov5/issues/8623

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in thread management for macOS within the YOLOv5 codebase.

### 📊 Key Changes
- Modified the environment variable setting for `OMP_NUM_THREADS` based on the operating system.
- For macOS (`darwin`), this variable is hardcoded to `'1'`, indicating a single thread.
- For other operating systems, it continues to follow the `NUM_THREADS` setting.

### 🎯 Purpose & Impact
- Enhances compatibility and stability of YOLOv5 on macOS by preventing multithreading issues specific to the platform.
- Likely to improve the user experience on macOS by eliminating potential crashes or performance bottlenecks due to threading conflicts.
- Users on other platforms should see no change in performance or behavior, maintaining the expected multithreading capabilities.