### PR TITLE
Check TensorBoard logger before adding graph

### DIFF
--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -102,7 +102,7 @@ class Loggers():
         # Callback runs on train batch end
         if plots:
             if ni == 0:
-                if not self.opt.sync_bn:  # --sync known issue https://github.com/ultralytics/yolov5/issues/3754
+                if self.tb and not self.opt.sync_bn:  # --sync known issue https://github.com/ultralytics/yolov5/issues/3754
                     with warnings.catch_warnings():
                         warnings.simplefilter('ignore')  # suppress jit trace warning
                         self.tb.add_graph(torch.jit.trace(de_parallel(model), imgs[0:1], strict=False), [])


### PR DESCRIPTION
Otherwise, an error is thrown if the tensorboard logger is not included.

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement to logging logic to prevent unnecessary warnings when using TensorBoard without sync_bn.

### 📊 Key Changes
- Added a check to ensure Tensorboard (`self.tb`) is active before processing graph additions.
- Maintains the previous condition to skip the graph addition step when `sync_bn` (synchronized batch normalization) is enabled.

### 🎯 Purpose & Impact
- The change aims to reduce unnecessary warnings about JIT trace issues when TensorBoard is not in use.
- Users will experience cleaner logs and avoid potential confusion caused by irrelevant warnings. This update should have no impact on model training or inference behavior, but it will improve the user experience for developers monitoring training progress with TensorBoard. 📈✨