### PR TITLE
Fix Bug when reporting Recall / Precision / mAP

### DIFF
--- a/val.py
+++ b/val.py
@@ -219,7 +219,7 @@ def run(
         dt[2] += time_sync() - t3
 
         if targets.shape[0] > 0:
-            target_cls.append(targets[:,0])
+            target_cls.append(targets[:, 0])
 
         # Metrics
         for si, pred in enumerate(out):

--- a/val.py
+++ b/val.py
@@ -267,13 +267,14 @@ def run(
     # Compute metrics
     stats = [torch.cat(x, 0).cpu().numpy() for x in zip(*stats)]  # to numpy
     target_cls = [torch.cat(x, 0).cpu().numpy() for x in zip(*target_cls)]  # to numpy
+    stats.append(target_cls[0])
 
     if len(stats) and stats[0].any():
         tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats,
-                                                      target_cls=target_cls[0],
                                                       plot=plots,
                                                       save_dir=save_dir,
                                                       names=names)
+                                                      
         ap50, ap = ap[:, 0], ap.mean(1)  # AP@0.5, AP@0.5:0.95
         mp, mr, map50, map = p.mean(), r.mean(), ap50.mean(), ap.mean()
         nt = np.bincount(stats[3].astype(int), minlength=nc)  # number of targets per class

--- a/val.py
+++ b/val.py
@@ -248,7 +248,7 @@ def run(
                 correct = process_batch(predn, labelsn, iouv)
                 if plots:
                     confusion_matrix.process_batch(predn, labelsn)
-            stats.append((correct, pred[:, 4], pred[:, 5], labels[:, 0]))  # (correct, conf, pcls, tcls)
+            stats.append((correct, pred[:, 4], pred[:, 5]))  # (correct, conf, pcls)
 
             # Save/log
             if save_txt:

--- a/val.py
+++ b/val.py
@@ -219,7 +219,7 @@ def run(
         dt[2] += time_sync() - t3
 
         if targets.shape[0] > 0:
-            target_cls.append(targets)
+            target_cls.append(targets[:,0])
 
         # Metrics
         for si, pred in enumerate(out):

--- a/val.py
+++ b/val.py
@@ -220,7 +220,7 @@ def run(
 
         if targets.shape[0] > 0:
             target_cls.append(targets)
-        
+
         # Metrics
         for si, pred in enumerate(out):
             labels = targets[targets[:, 0] == si, 1:]
@@ -268,9 +268,12 @@ def run(
     stats = [torch.cat(x, 0).cpu().numpy() for x in zip(*stats)]  # to numpy
     target_cls = [torch.cat(x, 0).cpu().numpy() for x in zip(*target_cls)]  # to numpy
 
-
     if len(stats) and stats[0].any():
-        tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats,target_cls=target_cls[0], plot=plots, save_dir=save_dir, names=names)
+        tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats,
+                                                      target_cls=target_cls[0],
+                                                      plot=plots,
+                                                      save_dir=save_dir,
+                                                      names=names)
         ap50, ap = ap[:, 0], ap.mean(1)  # AP@0.5, AP@0.5:0.95
         mp, mr, map50, map = p.mean(), r.mean(), ap50.mean(), ap.mean()
         nt = np.bincount(stats[3].astype(int), minlength=nc)  # number of targets per class

--- a/val.py
+++ b/val.py
@@ -270,11 +270,8 @@ def run(
     stats.append(target_cls[0])
 
     if len(stats) and stats[0].any():
-        tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats,
-                                                      plot=plots,
-                                                      save_dir=save_dir,
-                                                      names=names)
-                                                      
+        tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats, plot=plots, save_dir=save_dir, names=names)
+
         ap50, ap = ap[:, 0], ap.mean(1)  # AP@0.5, AP@0.5:0.95
         mp, mr, map50, map = p.mean(), r.mean(), ap50.mean(), ap.mean()
         nt = np.bincount(stats[3].astype(int), minlength=nc)  # number of targets per class

--- a/val.py
+++ b/val.py
@@ -219,7 +219,7 @@ def run(
         dt[2] += time_sync() - t3
 
         if targets.shape[0] > 0:
-            target_cls.append(targets[:, 1])
+            target_cls.append(targets[:, 1].unsqueeze(0))
 
         # Metrics
         for si, pred in enumerate(out):
@@ -266,7 +266,7 @@ def run(
 
     # Compute metrics
     stats = [torch.cat(x, 0).cpu().numpy() for x in zip(*stats)]  # to numpy
-    target_cls = [torch.stack(x, 0).cpu().numpy() for x in zip(*target_cls)]  # to numpy
+    target_cls = [torch.cat(x, 0).cpu().numpy() for x in zip(*target_cls)]  # to numpy
     stats.append(target_cls[0])
 
     if len(stats) and stats[0].any():

--- a/val.py
+++ b/val.py
@@ -266,7 +266,7 @@ def run(
 
     # Compute metrics
     stats = [torch.cat(x, 0).cpu().numpy() for x in zip(*stats)]  # to numpy
-    target_cls = [torch.cat(x, 0).cpu().numpy() for x in zip(*target_cls)]  # to numpy
+    target_cls = [torch.stack(x, 0).cpu().numpy() for x in zip(*target_cls)]  # to numpy
     stats.append(target_cls[0])
 
     if len(stats) and stats[0].any():

--- a/val.py
+++ b/val.py
@@ -219,7 +219,7 @@ def run(
         dt[2] += time_sync() - t3
 
         if targets.shape[0] > 0:
-            target_cls.append(targets[:, 0])
+            target_cls.append(targets[:, 1])
 
         # Metrics
         for si, pred in enumerate(out):

--- a/val.py
+++ b/val.py
@@ -268,10 +268,8 @@ def run(
     stats = [torch.cat(x, 0).cpu().numpy() for x in zip(*stats)]  # to numpy
     target_cls = [torch.cat(x, 0).cpu().numpy() for x in zip(*target_cls)]  # to numpy
     stats.append(target_cls[0])
-
     if len(stats) and stats[0].any():
         tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats, plot=plots, save_dir=save_dir, names=names)
-
         ap50, ap = ap[:, 0], ap.mean(1)  # AP@0.5, AP@0.5:0.95
         mp, mr, map50, map = p.mean(), r.mean(), ap50.mean(), ap.mean()
         nt = np.bincount(stats[3].astype(int), minlength=nc)  # number of targets per class


### PR DESCRIPTION
There is a bug which I fully described in 
- #8669 

This PR fixes the bug. I explained in the issue completely. I have added a list called `target_cls` which keeps track of all labels. This shouldn't be inside for loop which examines `out`. After that we combine the `target_cls` into `stats` again. This is for code consistency and to make sure we have no problem anywhere else. 

> The core of the problem comes from the fact that we are looping over filtered results, which makes our metrics wrong. 

If you want more explanation, do not hesitate to tell me. 

Also fixes:
- #8374
- #7872 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced validation metrics logging for better model evaluation.

### 📊 Key Changes
- Added collection of target class IDs during model validation to obtain per-class metrics.
- Updated statistics calculation to include the newly collected target class information.
- Refined recorded statistics by removing a redundant element (the target class was recorded twice).

### 🎯 Purpose & Impact
- ✅ The changes aim to improve the model evaluation process by providing more detailed information on class-wise performance, which can be critical for fine-tuning and understanding model behavior.
- 🚀 Potential impact includes more informed decision-making for model improvements and clearer insights into how well the model is performing across different classes. This is especially useful when dealing with datasets that have a large number of classes or imbalanced classes.