### PR TITLE
Set `torch.cuda.manual_seed_all()` for DDP

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -209,8 +209,8 @@ def init_seeds(seed=0, deterministic=False):
     np.random.seed(seed)
     torch.manual_seed(seed)
     cudnn.benchmark, cudnn.deterministic = (False, True) if seed == 0 else (True, False)
-    # torch.cuda.manual_seed(seed)
-    # torch.cuda.manual_seed_all(seed)  # for multi GPU, exception safe
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)  # for multi GPU, exception safe
 
 
 def intersect_dicts(da, db, exclude=()):

--- a/utils/general.py
+++ b/utils/general.py
@@ -203,7 +203,7 @@ def init_seeds(seed=0, deterministic=False):
     if deterministic and check_version(torch.__version__, '1.12.0'):  # https://github.com/ultralytics/yolov5/pull/8213
         torch.use_deterministic_algorithms(True)
         os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':4096:8'
-        # os.environ['PYTHONHASHSEED'] = str(seed)
+        os.environ['PYTHONHASHSEED'] = str(seed)
 
     random.seed(seed)
     np.random.seed(seed)

--- a/utils/general.py
+++ b/utils/general.py
@@ -210,7 +210,7 @@ def init_seeds(seed=0, deterministic=False):
     torch.manual_seed(seed)
     cudnn.benchmark, cudnn.deterministic = (False, True) if seed == 0 else (True, False)
     torch.cuda.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)  # for multi GPU, exception safe
+    torch.cuda.manual_seed_all(seed)  # for Multi-GPU, exception safe
 
 
 def intersect_dicts(da, db, exclude=()):


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced reproducibility in model training by ensuring consistent random seed settings.

### 📊 Key Changes
- Uncommented the setting of `PYTHONHASHSEED` to ensure a fixed hash seed.
- Reactivated CUDA random seed settings with `torch.cuda.manual_seed` and `torch.cuda.manual_seed_all` for single and multi-GPU setups.

### 🎯 Purpose & Impact
- 🎲 **Consistency**: These changes guarantee that experiments with the same seed are reproducible, which is critical for research and benchmarking.
- 🏗 **Stability**: Ensuring deterministic behavior improves the stability of models when trying to replicate results across different runs.
- 📈 **Multi-GPU Support**: By setting seeds for all GPUs, this ensures that multi-GPU training sessions behave more predictably.