### PR TITLE
Check git status on upstream `ultralytics` or `origin` dynamically

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -326,8 +326,7 @@ def check_git_status(repo='ultralytics/yolov5'):
     else:
         remote = 'ultralytics'
         check_output(f'git remote add {remote} {url}', shell=True)
-    cmd = f'git fetch {remote} && git config --get remote.{remote}.url'
-    url = check_output(cmd, shell=True, timeout=5).decode().strip().rstrip('.git')  # git fetch
+    check_output(f'git fetch {remote}', shell=True, timeout=5)  # git fetch
     branch = check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode().strip()  # checked out
     n = int(check_output(f'git rev-list {branch}..{remote}/master --count', shell=True))  # commits behind
     if n > 0:

--- a/utils/general.py
+++ b/utils/general.py
@@ -310,30 +310,29 @@ def git_describe(path=ROOT):  # path must be a directory
 
 @try_except
 @WorkingDirectory(ROOT)
-def check_git_status(repo='https://github.com/ultralytics/yolov5'):
-    # Recommend 'git pull' if code is out of date
-    msg = f', for updates see {repo}'
+def check_git_status(repo='ultralytics/yolov5'):
+    # YOLOv5 status check, recommend 'git pull' if code is out of date
+    url = f'https://github.com/{repo}'
+    msg = f', for updates see {url}'
     s = colorstr('github: ')  # string
     assert Path('.git').exists(), s + 'skipping check (not a git repository)' + msg
     assert not is_docker(), s + 'skipping check (Docker image)' + msg
     assert check_online(), s + 'skipping check (offline)' + msg
 
-    result = check_output('git remote -v', shell=True).decode()
-    remote_name = 'ultralytics'
-    for line in result.split('\n'):
-        if repo in line:
-            remote_name, _ = line.split('\t')
-            break
+    s = re.split(pattern=r'\s', string=check_output('git remote -v', shell=True).decode())
+    matches = [repo in x for x in s]
+    if any(matches):
+        remote = s[matches.index(True) - 1]
     else:
-        check_output(f'git remote add {remote_name} {repo}', shell=True)
-        check_output(f'git fetch {remote_name}', shell=True)
-
-    cmd = f'git fetch && git config --get remote.{remote_name}.url'
+        remote = 'ultralytics'
+        check_output(f'git remote add {remote} {url}', shell=True)
+    cmd = f'git fetch {remote} && git config --get remote.{remote}.url'
     url = check_output(cmd, shell=True, timeout=5).decode().strip().rstrip('.git')  # git fetch
     branch = check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode().strip()  # checked out
-    n = int(check_output(f'git rev-list {branch}..{remote_name}/master --count', shell=True))  # commits behind
+    n = int(check_output(f'git rev-list {branch}..{remote}/master --count', shell=True))  # commits behind
     if n > 0:
-        s += f"⚠️ YOLOv5 is out of date by {n} commit{'s' * (n > 1)}. Use `git pull` or `git clone {url}` to update."
+        pull = 'git pull' if remote == 'origin' else f'git pull {remote} master'
+        s += f"⚠️ YOLOv5 is out of date by {n} commit{'s' * (n > 1)}. Use `{pull}` or `git clone {url}` to update."
     else:
         s += f'up to date with {url} ✅'
     LOGGER.info(emojis(s))  # emoji-safe

--- a/utils/general.py
+++ b/utils/general.py
@@ -310,23 +310,22 @@ def git_describe(path=ROOT):  # path must be a directory
 
 @try_except
 @WorkingDirectory(ROOT)
-def check_git_status():
+def check_git_status(repo='https://github.com/ultralytics/yolov5'):
     # Recommend 'git pull' if code is out of date
-    msg = ', for updates see https://github.com/ultralytics/yolov5'
+    msg = f', for updates see {repo}'
     s = colorstr('github: ')  # string
     assert Path('.git').exists(), s + 'skipping check (not a git repository)' + msg
     assert not is_docker(), s + 'skipping check (Docker image)' + msg
     assert check_online(), s + 'skipping check (offline)' + msg
 
     result = check_output('git remote -v', shell=True).decode()
-    ultralytics_repo = 'https://github.com/ultralytics/yolov5'
     remote_name = 'ultralytics'
     for line in result.split('\n'):
-        if ultralytics_repo in line:
+        if repo in line:
             remote_name, _ = line.split('\t')
             break
     else:
-        check_output(f'git remote add {remote_name} {ultralytics_repo}', shell=True)
+        check_output(f'git remote add {remote_name} {repo}', shell=True)
         check_output(f'git fetch {remote_name}', shell=True)
 
     cmd = f'git fetch && git config --get remote.{remote_name}.url'

--- a/utils/general.py
+++ b/utils/general.py
@@ -319,10 +319,10 @@ def check_git_status(repo='ultralytics/yolov5'):
     assert not is_docker(), s + 'skipping check (Docker image)' + msg
     assert check_online(), s + 'skipping check (offline)' + msg
 
-    s = re.split(pattern=r'\s', string=check_output('git remote -v', shell=True).decode())
-    matches = [repo in x for x in s]
+    splits = re.split(pattern=r'\s', string=check_output('git remote -v', shell=True).decode())
+    matches = [repo in s for s in splits]
     if any(matches):
-        remote = s[matches.index(True) - 1]
+        remote = splits[matches.index(True) - 1]
     else:
         remote = 'ultralytics'
         check_output(f'git remote add {remote} {url}', shell=True)


### PR DESCRIPTION
This repo has 10k forks. Mosts of them would never update their repos and use outdated versions. We should warn them since this has great cost. Currently, It just compares it to `master`. This approach doesn't work for forked repos! 

```bash
git remote -v
```
```bash
origin	https://github.com/pourmand1376/yolov5 (fetch)
origin	https://github.com/pourmand1376/yolov5 (push)
ultralytics	https://github.com/ultralytics/yolov5.git (fetch)
ultralytics	https://github.com/ultralytics/yolov5.git (push)
```
Then, I separate them by '\n' character and find the name of the remote which has the address of main repo. For normal repos, this is origin, but for forked repos, this doesn't exist! We should create it for the first time and use it afterwards. 

This is because I have wasted two days of my time debugging and finding errors in the code that has been already fixed. I think we should really warn users for outdated repos. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced git status checks in YOLOv5 with more robust handling of git remotes.

### 📊 Key Changes
- 🔄 The `check_git_status` function can now specify a repository.
- 🔍 Improved detection of the repository's remote URL.
- 🔄 If the necessary remote does not exist, it is added dynamically.
- 🗂️ The git fetch command now uses the correct remote.
- 🆕 Added a more dynamic way to determine the number of commits behind the upstream.

### 🎯 Purpose & Impact
- 🤝 This update makes the codebase more flexible by allowing status checks against different repositories.
- 🔗 By automatically adding missing remotes, users are eased from manual git configuration steps.
- 🛠 The dynamic commit comparison reduces the likelihood of errors when checking if the local repository is up to date.
- 🔄 Potential impact: Easier maintenance for users with forks or customized setups of the YOLOv5 repository.