### PR TITLE
Fix BGR->RGB Bug in albumentations #8641

### DIFF
--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -40,7 +40,8 @@ class Albumentations:
     def __call__(self, im, labels, p=1.0):
         if self.transform and random.random() < p:
             new = self.transform(image=im[..., ::-1], bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
-            im, labels = new['image'][..., ::-1], np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
+            im, labels = new['image'][..., ::-1], np.array([[c, *b]
+                                                            for c, b in zip(new['class_labels'], new['bboxes'])])
         return im, labels
 
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -39,8 +39,10 @@ class Albumentations:
 
     def __call__(self, im, labels, p=1.0):
         if self.transform and random.random() < p:
+            im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)
             new = self.transform(image=im, bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
             im, labels = new['image'], np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
+            im = cv2.cvtColor(im, cv2.COLOR_RGB2BGR)
         return im, labels
 
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -39,10 +39,10 @@ class Albumentations:
 
     def __call__(self, im, labels, p=1.0):
         if self.transform and random.random() < p:
-            im = im[:,:,::-1] #BGR -> RGB
+            im = im[:, :, ::-1]  #BGR -> RGB
             new = self.transform(image=im, bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
             im, labels = new['image'], np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
-            im = im[:,:,::-1] #RGB -> BGR
+            im = im[:, :, ::-1]  #RGB -> BGR
         return im, labels
 
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -39,10 +39,8 @@ class Albumentations:
 
     def __call__(self, im, labels, p=1.0):
         if self.transform and random.random() < p:
-            im = im[:, :, ::-1]  #BGR -> RGB
-            new = self.transform(image=im, bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
-            im, labels = new['image'], np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
-            im = im[:, :, ::-1]  #RGB -> BGR
+            new = self.transform(image=im[..., ::-1], bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
+            im, labels = new['image'][..., ::-1], np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
         return im, labels
 
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -40,8 +40,8 @@ class Albumentations:
     def __call__(self, im, labels, p=1.0):
         if self.transform and random.random() < p:
             new = self.transform(image=im[..., ::-1], bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
-            im, labels = new['image'][..., ::-1], np.array([[c, *b]
-                                                            for c, b in zip(new['class_labels'], new['bboxes'])])
+            im = new['image'][..., ::-1]  # RGB to BGR
+            labels = np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
         return im, labels
 
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -39,10 +39,10 @@ class Albumentations:
 
     def __call__(self, im, labels, p=1.0):
         if self.transform and random.random() < p:
-            im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)
+            im = im[:,:,::-1] #BGR -> RGB
             new = self.transform(image=im, bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
             im, labels = new['image'], np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
-            im = cv2.cvtColor(im, cv2.COLOR_RGB2BGR)
+            im = im[:,:,::-1] #RGB -> BGR
         return im, labels
 
 


### PR DESCRIPTION
@glenn-jocher First idea. Easy, but maybe not the fastest one...

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image augmentation compatibility for BGR image inputs.

### 📊 Key Changes
- Augmentation now converts images from BGR to RGB before applying transformations.
- After transformations, images are converted back from RGB to BGR.

### 🎯 Purpose & Impact
- **Purpose:** Ensures image augmentations are applied correctly when the input images are in BGR format, which is common in OpenCV.
- **Impact:** Users can now expect consistent augmentation results even if their images start in BGR format, leading to potentially more accurate models when training with images processed by OpenCV. This change also streamlines preprocessing steps for users working with BGR images.