### PR TITLE
Revert "Fix BGR->RGB Bug in albumentations #8641"

### DIFF
--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -39,9 +39,8 @@ class Albumentations:
 
     def __call__(self, im, labels, p=1.0):
         if self.transform and random.random() < p:
-            new = self.transform(image=im[..., ::-1], bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
-            im = new['image'][..., ::-1]  # RGB to BGR
-            labels = np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
+            new = self.transform(image=im, bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
+            im, labels = new['image'], np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
         return im, labels
 
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -39,7 +39,7 @@ class Albumentations:
 
     def __call__(self, im, labels, p=1.0):
         if self.transform and random.random() < p:
-            new = self.transform(image=im, bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
+            new = self.transform(image=im[..., ::-1], bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
             im, labels = new['image'], np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
         return im, labels
 
@@ -48,7 +48,7 @@ def augment_hsv(im, hgain=0.5, sgain=0.5, vgain=0.5):
     # HSV color-space augmentation
     if hgain or sgain or vgain:
         r = np.random.uniform(-1, 1, 3) * [hgain, sgain, vgain] + 1  # random gains
-        hue, sat, val = cv2.split(cv2.cvtColor(im, cv2.COLOR_BGR2HSV))
+        hue, sat, val = cv2.split(cv2.cvtColor(im, cv2.COLOR_RGB2HSV))
         dtype = im.dtype  # uint8
 
         x = np.arange(0, 256, dtype=r.dtype)
@@ -57,7 +57,7 @@ def augment_hsv(im, hgain=0.5, sgain=0.5, vgain=0.5):
         lut_val = np.clip(x * r[2], 0, 255).astype(dtype)
 
         im_hsv = cv2.merge((cv2.LUT(hue, lut_hue), cv2.LUT(sat, lut_sat), cv2.LUT(val, lut_val)))
-        cv2.cvtColor(im_hsv, cv2.COLOR_HSV2BGR, dst=im)  # no return needed
+        cv2.cvtColor(im_hsv, cv2.COLOR_HSV2RGB, dst=im)  # no return needed
 
 
 def hist_equalize(im, clahe=True, bgr=False):

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -45,7 +45,7 @@ class Albumentations:
 
 
 def augment_hsv(im, hgain=0.5, sgain=0.5, vgain=0.5):
-    # HSV color-space augmentation
+    # HSV color-space augmentation, im is RGB
     if hgain or sgain or vgain:
         r = np.random.uniform(-1, 1, 3) * [hgain, sgain, vgain] + 1  # random gains
         hue, sat, val = cv2.split(cv2.cvtColor(im, cv2.COLOR_RGB2HSV))

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -633,7 +633,7 @@ class LoadImagesAndLabels(Dataset):
 
         if self.augment:
             # Albumentations
-            img, labels = self.albumentations(img, labels)
+            img, labels = self.albumentations(img[..., ::-1], labels)
             nl = len(labels)  # update after albumentations
 
             # HSV color-space
@@ -660,7 +660,7 @@ class LoadImagesAndLabels(Dataset):
             labels_out[:, 1:] = torch.from_numpy(labels)
 
         # Convert
-        img = img.transpose((2, 0, 1))[::-1]  # HWC to CHW, BGR to RGB
+        img = img.transpose((2, 0, 1))  # HWC to CHW, BGR to RGB
         img = np.ascontiguousarray(img)
 
         return torch.from_numpy(img), labels_out, self.im_files[index], shapes


### PR DESCRIPTION
Reverts ultralytics/yolov5#8695 to resolve bug #8641

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refactoring Image Augmentation and Color-Space Conversion

### 📊 Key Changes
- Simplified code by combining two lines into a single line when applying image transformations and relabeling.
- Corrected color-space conversions, enforcing RGB usage over BGR to maintain consistency in the augmentation process.
- Updated dataloader to apply augmentations directly to images in RGB, instead of the previously used BGR format.

### 🎯 Purpose & Impact
- Improves code efficiency and readability, reducing the potential for errors.
- Ensures that image manipulations are performed consistently in the RGB color space, which aligns with common image processing standards.
- The changes may lead to subtle differences in training data presentation, possibly affecting model training outcomes. Users can expect more standardized image handling throughout the augmentation pipeline. 🌈