### PR TITLE
Revert "Fix BGR->RGB Bug in albumentations #8641"

### DIFF
--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -39,9 +39,8 @@ class Albumentations:
 
     def __call__(self, im, labels, p=1.0):
         if self.transform and random.random() < p:
-            new = self.transform(image=im[..., ::-1], bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
-            im = new['image'][..., ::-1]  # RGB to BGR
-            labels = np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
+            new = self.transform(image=im, bboxes=labels[:, 1:], class_labels=labels[:, 0])  # transformed
+            im, labels = new['image'], np.array([[c, *b] for c, b in zip(new['class_labels'], new['bboxes'])])
         return im, labels
 
 


### PR DESCRIPTION
Reverts ultralytics/yolov5#8695Reverts https://github.com/ultralytics/yolov5/pull/8695 to resolve bug https://github.com/ultralytics/yolov5/issues/8641

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplification of image augmentation in YOLOv5 by removing unnecessary color space conversion.

### 📊 Key Changes
- Removed the code flipping image channels from RGB to BGR and back during augmentations.
- Updated the augmentation process to work directly with the original image format.

### 🎯 Purpose & Impact
- 📈 **Increased Efficiency**: Skipping the color space conversion step should reduce computation time during augmentation.
- 🔍 **Streamlined Code**: The change simplifies the codebase, making it cleaner and easier to maintain.
- 🖼 **Consistency in Image Processing**: Ensures image data remains consistent in its original format throughout processing.