### PR TITLE
Revert protobuf<=3.20.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ scipy>=1.4.1
 torch>=1.7.0
 torchvision>=0.8.1
 tqdm>=4.64.0
-protobuf<4.21.3  # https://github.com/ultralytics/yolov5/issues/8012
+protobuf<=3.20.1  # https://github.com/ultralytics/yolov5/issues/8012
 
 # Logging -------------------------------------
 tensorboard>=2.4.1


### PR DESCRIPTION
Resolve #8012 (again)



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjustment of `protobuf` version requirements for better compatibility.

### 📊 Key Changes
- Modified the required `protobuf` version in `requirements.txt` from `<4.21.3` to `<=3.20.1`.

### 🎯 Purpose & Impact
- 🛠 This change aims to address compatibility issues highlighted in issue #8012.
- 👩‍💻👨‍💻 Users can expect more stable installations and fewer conflicts with this specific dependency when setting up YOLOv5.
- 🔄 Ensuring a specific version of `protobuf` may prevent potential bugs that could arise from newer, untested versions.