### PR TITLE
Fix RGB Albumentations order

### DIFF
--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -48,7 +48,7 @@ def augment_hsv(im, hgain=0.5, sgain=0.5, vgain=0.5):
     # HSV color-space augmentation
     if hgain or sgain or vgain:
         r = np.random.uniform(-1, 1, 3) * [hgain, sgain, vgain] + 1  # random gains
-        hue, sat, val = cv2.split(cv2.cvtColor(im, cv2.COLOR_BGR2HSV))
+        hue, sat, val = cv2.split(cv2.cvtColor(im, cv2.COLOR_RGB2HSV))
         dtype = im.dtype  # uint8
 
         x = np.arange(0, 256, dtype=r.dtype)
@@ -57,7 +57,7 @@ def augment_hsv(im, hgain=0.5, sgain=0.5, vgain=0.5):
         lut_val = np.clip(x * r[2], 0, 255).astype(dtype)
 
         im_hsv = cv2.merge((cv2.LUT(hue, lut_hue), cv2.LUT(sat, lut_sat), cv2.LUT(val, lut_val)))
-        cv2.cvtColor(im_hsv, cv2.COLOR_HSV2BGR, dst=im)  # no return needed
+        cv2.cvtColor(im_hsv, cv2.COLOR_HSV2RGB, dst=im)  # no return needed
 
 
 def hist_equalize(im, clahe=True, bgr=False):

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -660,7 +660,7 @@ class LoadImagesAndLabels(Dataset):
             labels_out[:, 1:] = torch.from_numpy(labels)
 
         # Convert
-        img = img.transpose((2, 0, 1))[::-1]  # HWC to CHW, BGR to RGB
+        img = img.transpose((2, 0, 1))  # HWC to CHW
         img = np.ascontiguousarray(img)
 
         return torch.from_numpy(img), labels_out, self.im_files[index], shapes
@@ -670,7 +670,7 @@ class LoadImagesAndLabels(Dataset):
         im, f, fn = self.ims[i], self.im_files[i], self.npy_files[i],
         if im is None:  # not cached in RAM
             if fn.exists():  # load npy
-                im = np.load(fn)
+                im = np.load(fn)  # BGR
             else:  # read image
                 im = cv2.imread(f)  # BGR
                 assert im is not None, f'Image Not Found {f}'
@@ -679,8 +679,8 @@ class LoadImagesAndLabels(Dataset):
             if r != 1:  # if sizes are not equal
                 interp = cv2.INTER_LINEAR if (self.augment or r > 1) else cv2.INTER_AREA
                 im = cv2.resize(im, (int(w0 * r), int(h0 * r)), interpolation=interp)
-            return im, (h0, w0), im.shape[:2]  # im, hw_original, hw_resized
-        return self.ims[i], self.im_hw0[i], self.im_hw[i]  # im, hw_original, hw_resized
+            return im[..., ::-1], (h0, w0), im.shape[:2]  # im RGB, hw_original, hw_resized
+        return self.ims[i], self.im_hw0[i], self.im_hw[i]  # im RGB, hw_original, hw_resized
 
     def cache_images_to_disk(self, i):
         # Saves an image as an *.npy file for faster loading


### PR DESCRIPTION
Second attempt at resolving RGB Albmentations order issue https://github.com/ultralytics/yolov5/pull/8695. 

First PR fix #8695 failed and reverted.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved color handling in image augmentations and loading by ensuring consistent RGB color space usage.

### 📊 Key Changes
- Changed `cv2.COLOR_BGR2HSV` to `cv2.COLOR_RGB2HSV` in `augment_hsv()` to start with RGB images for HSV conversion.
- Updated `cv2.COLOR_HSV2BGR` to `cv2.COLOR_HSV2RGB` after HSV operations to maintain images in RGB format.
- Removed reverse channel ordering (BGR to RGB conversion) from `transpose` operation in `__getitem__()` in `dataloaders.py`.
- Added explicit RGB format notation in `load_image()` and `cache_images_to_disk` to indicate that images are kept in RGB.

### 🎯 Purpose & Impact
- Ensures image data is consistently in RGB format throughout processing, which aligns with commonly used image formats in machine learning and reduces confusion.
- These changes should make the codebase more intuitive and reduce potential errors related to color space mismanagement, resulting in a smoother development and training experience for users working with the YOLOv5 code. 🏗️🌈