### PR TITLE
`Detect.inplace=False` for multithread-safe inference

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -55,6 +55,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
                 if len(ckpt['model'].names) == classes:
                     model.names = ckpt['model'].names  # set class names attribute
         if autoshape:
+            model.model.model[-1].inplace = False  # Detect.inplace=False for safe multithread inference
             model = AutoShape(model)  # for file/URI/PIL/cv2/np inputs and NMS
         if not verbose:
             LOGGER.setLevel(logging.INFO)  # reset to default

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -50,7 +50,7 @@ class Detect(nn.Module):
         self.anchor_grid = [torch.zeros(1)] * self.nl  # init anchor grid
         self.register_buffer('anchors', torch.tensor(anchors).float().view(self.nl, -1, 2))  # shape(nl,na,2)
         self.m = nn.ModuleList(nn.Conv2d(x, self.no * self.na, 1) for x in ch)  # output conv
-        self.inplace = inplace  # use in-place ops (e.g. slice assignment)
+        self.inplace = inplace  # use inplace ops (e.g. slice assignment)
 
     def forward(self, x):
         z = []  # inference output


### PR DESCRIPTION
`Detect.inplace=False` for safe multithread inference when loading YOLOv5 AutoShape models with PyTorch Hub.

May resolve https://github.com/ultralytics/yolov5/issues/8565

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved thread safety for multi-threaded inference in the YOLOv5 model.

### 📊 Key Changes
- Set `Detect.inplace` attribute to `False` during model creation for safer multithreading.
- Tidy-up in the `yolo.py` comments without changing functionality (changed 'in-place' to 'inplace').

### 🎯 Purpose & Impact
- 🧵 The modification ensures thread safety, reducing the risk of issues when the YOLOv5 model is used in environments with multiple threads making inferences simultaneously.
- 🚀 Potential impact includes more robust performance in multi-threaded applications, improving the model's reliability and usability in production environments.