### PR TITLE
Fix Colab-update pre-commit EOF bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     rev: v4.3.0
     hooks:
       - id: end-of-file-fixer
+        stages: [commit]  # avoid Colab update EOF issues
       - id: trailing-whitespace
       - id: check-case-conflict
       - id: check-yaml


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Upgraded pre-commit hook settings to enhance code quality in repositories.

### 📊 Key Changes
- Added a new configuration line within the pre-commit hook for `end-of-file-fixer`.

### 🎯 Purpose & Impact
- 🛠 Purpose: To avoid issues when updating files in Google Colab, which can sometimes change the end-of-file (EOF) format inadvertently.
- ⚙️ Impact: Developers contributing to the codebase will experience fewer merge conflicts and cleaner commits, specifically when working with Jupyter notebooks in Colab. This change ensures a smoother workflow and maintains code hygiene without affecting the functionality for the end-users.