### PR TITLE
Remove `assert not is_docker()` from GitHub checks

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -316,7 +316,6 @@ def check_git_status(repo='ultralytics/yolov5'):
     msg = f', for updates see {url}'
     s = colorstr('github: ')  # string
     assert Path('.git').exists(), s + 'skipping check (not a git repository)' + msg
-    # assert not is_docker(), s + 'skipping check (Docker image)' + msg
     assert check_online(), s + 'skipping check (offline)' + msg
 
     splits = re.split(pattern=r'\s', string=check_output('git remote -v', shell=True).decode())

--- a/utils/general.py
+++ b/utils/general.py
@@ -316,7 +316,7 @@ def check_git_status(repo='ultralytics/yolov5'):
     msg = f', for updates see {url}'
     s = colorstr('github: ')  # string
     assert Path('.git').exists(), s + 'skipping check (not a git repository)' + msg
-    assert not is_docker(), s + 'skipping check (Docker image)' + msg
+    # assert not is_docker(), s + 'skipping check (Docker image)' + msg
     assert check_online(), s + 'skipping check (offline)' + msg
 
     splits = re.split(pattern=r'\s', string=check_output('git remote -v', shell=True).decode())


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved GitHub checks in non-Docker environments 🛠️.

### 📊 Key Changes
- Removed the line that skips GitHub status checks if the code is running within a Docker image.

### 🎯 Purpose & Impact
- Enables the GitHub status check feature within Docker containers, ensuring that users are alerted about updates even when operating in these environments.
- Potentially affects users who rely on the Docker setup for YOLOv5, as they will now receive prompts for updates or changes to the repository, enhancing their awareness of new features or important fixes. 🚀