### PR TITLE
Update README.md with contributors.png

### DIFF
--- a/.github/README_cn.md
+++ b/.github/README_cn.md
@@ -249,7 +249,9 @@ We are super excited about our first-ever Ultralytics YOLOv5 🚀 EXPORT Competi
 ## <div align="center">贡献</div>
 
 我们重视您的意见! 我们希望给大家提供尽可能的简单和透明的方式对 YOLOv5 做出贡献。开始之前请先点击并查看我们的 [贡献指南](CONTRIBUTING.md)，填写[YOLOv5调查问卷](https://ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey) 来向我们发送您的经验反馈。真诚感谢我们所有的贡献者!
-<a href="https://github.com/ultralytics/yolov5/graphs/contributors"><img src="https://opencollective.com/ultralytics/contributors.svg?width=990" /></a>
+
+<!-- SVG image from https://opencollective.com/ultralytics/contributors.svg?width=990 -->
+<a href="https://github.com/ultralytics/yolov5/graphs/contributors"><img src="https://github.com/ultralytics/yolov5/releases/download/v1.0/image-contributors-1280.png" /></a>   
 
 ## <div align="center">联系</div>
 

--- a/.github/README_cn.md
+++ b/.github/README_cn.md
@@ -251,7 +251,7 @@ We are super excited about our first-ever Ultralytics YOLOv5 🚀 EXPORT Competi
 我们重视您的意见! 我们希望给大家提供尽可能的简单和透明的方式对 YOLOv5 做出贡献。开始之前请先点击并查看我们的 [贡献指南](CONTRIBUTING.md)，填写[YOLOv5调查问卷](https://ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey) 来向我们发送您的经验反馈。真诚感谢我们所有的贡献者!
 
 <!-- SVG image from https://opencollective.com/ultralytics/contributors.svg?width=990 -->
-<a href="https://github.com/ultralytics/yolov5/graphs/contributors"><img src="https://github.com/ultralytics/yolov5/releases/download/v1.0/image-contributors-1280.png" /></a>   
+<a href="https://github.com/ultralytics/yolov5/graphs/contributors"><img src="https://github.com/ultralytics/yolov5/releases/download/v1.0/image-contributors-1280.png" /></a>
 
 ## <div align="center">联系</div>
 

--- a/README.md
+++ b/README.md
@@ -259,8 +259,7 @@ We are super excited about our first-ever Ultralytics YOLOv5 🚀 EXPORT Competi
 
 We love your input! We want to make contributing to YOLOv5 as easy and transparent as possible. Please see our [Contributing Guide](CONTRIBUTING.md) to get started, and fill out the [YOLOv5 Survey](https://ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey) to send us feedback on your experiences. Thank you to all our contributors!
 
-<!-- create image from https://opencollective.com/ultralytics/contributors.svg?width=990 -->
-<a href="https://github.com/ultralytics/yolov5/graphs/contributors"><img src="https://opencollective.com/ultralytics/contributors.svg?width=990" /></a>
+<!-- SVG image from https://opencollective.com/ultralytics/contributors.svg?width=990 -->
 <a href="https://github.com/ultralytics/yolov5/graphs/contributors"><img src="https://github.com/ultralytics/yolov5/releases/download/v1.0/image-contributors-1280.png" /></a>
 
 ## <div align="center">Contact</div>

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ We love your input! We want to make contributing to YOLOv5 as easy and transpare
 
 <!-- create image from https://opencollective.com/ultralytics/contributors.svg?width=990 -->
 <a href="https://github.com/ultralytics/yolov5/graphs/contributors"><img src="https://opencollective.com/ultralytics/contributors.svg?width=990" /></a>
-<a href="https://github.com/ultralytics/yolov5/graphs/contributors"><img src="https://github.com/ultralytics/yolov5/releases/download/v1.0/image-contributors.png" /></a>
+<a href="https://github.com/ultralytics/yolov5/graphs/contributors"><img src="https://github.com/ultralytics/yolov5/releases/download/v1.0/image-contributors-1280.png" /></a>
 
 ## <div align="center">Contact</div>
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,9 @@ We are super excited about our first-ever Ultralytics YOLOv5 🚀 EXPORT Competi
 
 We love your input! We want to make contributing to YOLOv5 as easy and transparent as possible. Please see our [Contributing Guide](CONTRIBUTING.md) to get started, and fill out the [YOLOv5 Survey](https://ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey) to send us feedback on your experiences. Thank you to all our contributors!
 
+<!-- create image from https://opencollective.com/ultralytics/contributors.svg?width=990 -->
 <a href="https://github.com/ultralytics/yolov5/graphs/contributors"><img src="https://opencollective.com/ultralytics/contributors.svg?width=990" /></a>
+<a href="https://github.com/ultralytics/yolov5/graphs/contributors"><img src="https://github.com/ultralytics/yolov5/releases/download/v1.0/image-contributors.png" /></a>
 
 ## <div align="center">Contact</div>
 


### PR DESCRIPTION
Replace dynamic svg from opencollective with static png for improved stability and lighter size (700kB vs 2MB).

May resolve https://github.com/ultralytics/yolov5/issues/8817 by @AyushExel 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated contributor images for better visibility and style.

### 📊 Key Changes
- Replaced dynamic SVG contributor images from Open Collective with a static PNG image in both English and Chinese README files.
- The static PNG image is now hosted in the project's own Releases.

### 🎯 Purpose & Impact
- **Enhanced Readability**: The new static image may improve page load times and is less prone to rendering issues.
- **Visual Consistency**: Hosting the image within GitHub ensures consistent availability and style, aligning with the project's aesthetic.
- **User Experience**: By maintaining clear, accessible documentation, the project remains inviting to current and potential contributors, bolstering community engagement. 🌐✨