### PR TITLE
Remove hook `torch.nan_to_num(x)`

### DIFF
--- a/train.py
+++ b/train.py
@@ -131,7 +131,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     freeze = [f'model.{x}.' for x in (freeze if len(freeze) > 1 else range(freeze[0]))]  # layers to freeze
     for k, v in model.named_parameters():
         v.requires_grad = True  # train all layers
-        v.register_hook(lambda x: torch.nan_to_num(x))  # NaN to 0.0
+        # v.register_hook(lambda x: torch.nan_to_num(x))  # NaN to 0.0
         if any(x in k for x in freeze):
             LOGGER.info(f'freezing {k}')
             v.requires_grad = False

--- a/train.py
+++ b/train.py
@@ -131,7 +131,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     freeze = [f'model.{x}.' for x in (freeze if len(freeze) > 1 else range(freeze[0]))]  # layers to freeze
     for k, v in model.named_parameters():
         v.requires_grad = True  # train all layers
-        # v.register_hook(lambda x: torch.nan_to_num(x))  # NaN to 0.0
+        # v.register_hook(lambda x: torch.nan_to_num(x))  # NaN to 0 (commented for erratic training results)
         if any(x in k for x in freeze):
             LOGGER.info(f'freezing {k}')
             v.requires_grad = False


### PR DESCRIPTION
Observed erratic training behavior (green line) with the nan_to_num hook (introduced in #8598) in classifier branch. I'm going to remove it from master.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to the training stability by adjusting layer freeze behavior in the YOLOv5 model.

### 📊 Key Changes
- The hook that converts NaN (not a number) values to zero during training has been commented out.

### 🎯 Purpose & Impact
- **Purpose:** To address and possibly resolve erratic training results that may be caused by the previous method of handling NaN values.
- **Impact:** Users should experience more stable and reliable training, although they might need to monitor the training process for NaN values which are no longer being automatically converted to zeros.