### PR TITLE
RUN git clone instead of COPY to `/usr/src/app`

### DIFF
--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -25,8 +25,8 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Copy contents
-COPY . /usr/src/app
-RUN git clone https://github.com/ultralytics/yolov5 /usr/src/yolov5
+# COPY . /usr/src/app  (issues as not a .git directory)
+RUN git clone https://github.com/ultralytics/yolov5 /usr/src/app
 
 # Set environment variables
 ENV OMP_NUM_THREADS=8

--- a/utils/docker/Dockerfile-arm64
+++ b/utils/docker/Dockerfile-arm64
@@ -29,8 +29,8 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Copy contents
-COPY . /usr/src/app
-RUN git clone https://github.com/ultralytics/yolov5 /usr/src/yolov5
+# COPY . /usr/src/app  (issues as not a .git directory)
+RUN git clone https://github.com/ultralytics/yolov5 /usr/src/app
 
 
 # Usage Examples -------------------------------------------------------------------------------------------------------

--- a/utils/docker/Dockerfile-cpu
+++ b/utils/docker/Dockerfile-cpu
@@ -26,8 +26,8 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Copy contents
-COPY . /usr/src/app
-RUN git clone https://github.com/ultralytics/yolov5 /usr/src/yolov5
+# COPY . /usr/src/app  (issues as not a .git directory)
+RUN git clone https://github.com/ultralytics/yolov5 /usr/src/app
 
 
 # Usage Examples -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Avoid the need for a separate /yolov5 git clone directory.

Problem with `COPY . /usr/src/app` is that directory is not a .git directory, so normal ops like git pull etc don't work in Docker currently. This should resolve this issue.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of Dockerfile configurations for YOLOv5 repository cloning.

### 📊 Key Changes
- Removed the `COPY . /usr/src/app` command in Dockerfiles across multiple architectures (default, ARM64, CPU).
- Replaced with `RUN git clone https://github.com/ultralytics/yolov5 /usr/src/app` to directly clone the YOLOv5 repo into the working directory.

### 🎯 Purpose & Impact
- 🛠 Fixes issues related to the Docker container not recognizing a `.git` directory due to the previous COPY command.
- ✅ Ensures a smoother setup and deployment process for users employing Docker, leading to a more reliable development and testing environment.
- 🚀 Potential to increase user satisfaction with the YOLOv5 Docker implementation as it alleviates past configuration issues.