### PR TITLE
Update dataloaders.py remove `float64` shapes

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -478,7 +478,7 @@ class LoadImagesAndLabels(Dataset):
         [cache.pop(k) for k in ('hash', 'version', 'msgs')]  # remove items
         labels, shapes, self.segments = zip(*cache.values())
         self.labels = list(labels)
-        self.shapes = np.array(shapes, dtype=np.float64)
+        self.shapes = np.array(shapes)
         self.im_files = list(cache.keys())  # update
         self.label_files = img2label_paths(cache.keys())  # update
         n = len(shapes)  # number of images


### PR DESCRIPTION
May help https://github.com/ultralytics/yolov5/issues/8862

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced data loader efficiency by simplifying shape arrays.

### 📊 Key Changes
- Removed explicit `dtype=np.float64` specification from `np.array(shapes)` assignment.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: The change is intended to simplify the data loading process by not explicitly defining the data type of the shape array. This could potentially lead to using a default data type that's more memory-efficient.
- ✅ **Impact**: Users might experience improved memory usage and possibly faster data loading times when training their models, especially if the default data type is smaller than float64.