### PR TITLE
HUBDatasetStats() preview images to 50 quality

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -1034,7 +1034,7 @@ class HUBDatasetStats():
             r = max_dim / max(im.height, im.width)  # ratio
             if r < 1.0:  # image too large
                 im = im.resize((int(im.width * r), int(im.height * r)))
-            im.save(f_new, 'JPEG', quality=75, optimize=True)  # save
+            im.save(f_new, 'JPEG', quality=50, optimize=True)  # save
         except Exception as e:  # use OpenCV
             print(f'WARNING: HUB ops PIL failure {f}: {e}')
             im = cv2.imread(f)


### PR DESCRIPTION
@kalenmike should represent a 30% filesize reduction vs 75 quality

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimized image processing in data loading by changing JPEG save quality.

### 📊 Key Changes
- Reduced the JPEG save quality setting from 75 to 50 during image resizing operations.

### 🎯 Purpose & Impact
- **Purpose**: To improve the efficiency of data loading by decreasing the file size of images, which may speed up the training process.
- **Impact**: Users might experience faster data loading and training times, at the potential cost of reduced image quality, which could affect model accuracy. This balance between efficiency and quality might not be noticeable in all applications but could be significant in some cases. ⚖️🚀