### PR TITLE
Update CI to default Python 3.10

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: ['3.10']
         model: [yolov5n]
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.10]
+        python-version: ['3.10']
         model: [yolov5n]
         include:
           - os: ubuntu-latest

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9]
+        python-version: [3.10]
         model: [yolov5n]
         include:
           - os: ubuntu-latest
@@ -58,7 +58,7 @@ jobs:
             python-version: '3.8'
             model: yolov5n
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.9'
             model: yolov5n
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.9']  # requires python<=3.9
         model: [yolov5n]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements in CI testing configurations for better compatibility checks.

### 📊 Key Changes
- Defined Python `3.9` version as a string and added a comment to specify a maximum compatible version limitation.
- Updated the CI test matrix to include Python `3.10` for all operating systems.
- Set Python `3.9` specifically for tests running on Ubuntu.

### 🎯 Purpose & Impact
- Clarifies the Python versions requirements, preventing potential confusion regarding supported Python versions.
- Expands testing to ensure compatibility with the newer Python `3.10`, ensuring users on the latest Python version have a smooth experience.
- Maintains broad compatibility testing across multiple operating systems and Python versions to catch potential issues early, leading to more stable software for all users.