### PR TITLE
`--resume` training from URL weights fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -496,8 +496,8 @@ def main(opt, callbacks=Callbacks()):
             d = torch.load(last, map_location='cpu')['opt']
         opt = argparse.Namespace(**d)  # replace
         opt.cfg, opt.weights, opt.resume = '', str(last), True  # reinstate
-        if is_url(opt.data):
-            opt.data = str(opt_data)  # avoid HUB resume auth timeout
+        if is_url(opt_data):
+            opt.data = check_file(opt_data)  # avoid HUB resume auth timeout
     else:
         opt.data, opt.cfg, opt.hyp, opt.weights, opt.project = \
             check_file(opt.data), check_yaml(opt.cfg), check_yaml(opt.hyp), str(opt.weights), str(opt.project)  # checks


### PR DESCRIPTION
@kalenmike should fix data error on HUB resume

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in data path handling for resumed YOLOv5 training sessions.

### 📊 Key Changes
- Fixed the reference to the `opt_data` variable, ensuring the correct data path is used.
- Replaced a simple string conversion with the `check_file` function for validating the data path.

### 🎯 Purpose & Impact
- 🛠 Fixes a bug where the data path might not be properly set when resuming training, enhancing reliability.
- ✅ Ensures that resumed training sessions start smoothly without authentication timeout issues, improving user experience for those training models with YOLOv5 over time.