### PR TITLE
Fix anchor incorrectly initialized

### DIFF
--- a/train.py
+++ b/train.py
@@ -569,6 +569,8 @@ def main(opt, callbacks=Callbacks()):
             hyp = yaml.safe_load(f)  # load hyps dict
             if 'anchors' not in hyp:  # anchors commented in hyp.yaml
                 hyp['anchors'] = 3
+        if opt.noautoanchor:
+            del hyp['anchors']
         opt.noval, opt.nosave, save_dir = True, True, Path(opt.save_dir)  # only val/save final epoch
         # ei = [isinstance(x, (int, float)) for x in hyp.values()]  # evolvable indices
         evolve_yaml, evolve_csv = save_dir / 'hyp_evolve.yaml', save_dir / 'evolve.csv'

--- a/train.py
+++ b/train.py
@@ -571,6 +571,7 @@ def main(opt, callbacks=Callbacks()):
                 hyp['anchors'] = 3
         if opt.noautoanchor:
             del hyp['anchors']
+            del meta['anchors']
         opt.noval, opt.nosave, save_dir = True, True, Path(opt.save_dir)  # only val/save final epoch
         # ei = [isinstance(x, (int, float)) for x in hyp.values()]  # evolvable indices
         evolve_yaml, evolve_csv = save_dir / 'hyp_evolve.yaml', save_dir / 'evolve.csv'

--- a/train.py
+++ b/train.py
@@ -570,8 +570,7 @@ def main(opt, callbacks=Callbacks()):
             if 'anchors' not in hyp:  # anchors commented in hyp.yaml
                 hyp['anchors'] = 3
         if opt.noautoanchor:
-            del hyp['anchors']
-            del meta['anchors']
+            del hyp['anchors'], meta['anchors']
         opt.noval, opt.nosave, save_dir = True, True, Path(opt.save_dir)  # only val/save final epoch
         # ei = [isinstance(x, (int, float)) for x in hyp.values()]  # evolvable indices
         evolve_yaml, evolve_csv = save_dir / 'hyp_evolve.yaml', save_dir / 'evolve.csv'


### PR DESCRIPTION
Using --noautoanchor and --evolve simultaneously leads to anchor incorrectly initialized. --noautoanchor denotes anchors don't need to evolve, thus removing anchors from hyp will fix it.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved YOLOv5 model customization with auto-anchor disable option.

### 📊 Key Changes
- Added support to disable automatic anchor adjustment during training when specified by a new command-line option.

### 🎯 Purpose & Impact
- **Purpose:** Allows users more control over anchor settings during training by introducing the option to turn off the automatic adjustment of anchors, a key part of the YOLOv5 detection algorithm.
- **Impact:** Users who are experienced with the YOLO architecture or those wanting to experiment with fixed anchor sizes can potentially achieve better performance on custom datasets. This change enhances the flexibility of the model training process.