### PR TITLE
Edge TPU add `--search_delegate` fix

### DIFF
--- a/export.py
+++ b/export.py
@@ -410,7 +410,7 @@ def export_edgetpu(file, prefix=colorstr('Edge TPU:')):
         f = str(file).replace('.pt', '-int8_edgetpu.tflite')  # Edge TPU model
         f_tfl = str(file).replace('.pt', '-int8.tflite')  # TFLite model
 
-        cmd = f"edgetpu_compiler -s -o {file.parent} {f_tfl}"
+        cmd = f"edgetpu_compiler -s -d -k 10 --out_dir {file.parent} {f_tfl}"
         subprocess.run(cmd.split(), check=True)
 
         LOGGER.info(f'{prefix} export success, saved as {f} ({file_size(f):.1f} MB)')


### PR DESCRIPTION
Resolves https://github.com/ultralytics/yolov5/issues/8842

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced Edge TPU model export with extra compiler options.

### 📊 Key Changes
- 🛠️ Modified the `edgetpu_compiler` command in `export.py`.
- 🤏 Added flags for more detailed compiler output (`-d`), keeping intermediate files (`-k 10`), and specifying an output directory (`--out_dir`).

### 🎯 Purpose & Impact
- ⚙️ Providing more transparency during the compilation by including detailed logs.
- 📁 Helping with debugging and analysis by retaining intermediate compilation files.
- 🗂️ Organizing compiled models by directing them to a specified output directory.
- ✨ These changes could improve the developer's experience with more informative feedback and better file management during Edge TPU export.