### PR TITLE
About "os.R_OK" in general.py

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -69,7 +69,7 @@ def is_kaggle():
 def is_writeable(dir, test=False):
     # Return True if directory has write permissions, test opening a file with write permissions if test=True
     if not test:
-        return os.access(dir, os.R_OK)  # possible issues on Windows
+        return os.access(dir, os.W_OK)  # possible issues on Windows
     file = Path(dir) / 'tmp.txt'
     try:
         with open(file, 'w'):  # open file with write permissions


### PR DESCRIPTION
# The notes says "Return True if directory has write permissions", however, the code below is "os.R_OK", I think "os.W_OK" is preferred.

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
- Enhanced file write permission check in utility functions.

### 📊 Key Changes
- Corrected the `is_writeable` function to check for write permissions (`os.W_OK`) instead of read permissions (`os.R_OK`).

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To ensure the `is_writeable` function accurately verifies if a directory is writeable, which is crucial for operations involving file creation or modification.
- 💥 **Impact**: This fix prevents potential bugs where the system incorrectly assumes it cannot write to a directory due to a permissions check error, improving overall reliability. Users can expect more consistent behavior when the application interacts with the filesystem, especially on platforms like Windows where permission issues are more common.