### PR TITLE
Scope `torchvision.utils.draw_bounding_boxes` import

### DIFF
--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -9,7 +9,7 @@ from torchvision.transforms import ToPILImage
 try:
     import clearml
     from clearml import Dataset, Task
-    from torchvision.utils import draw_bounding_boxes
+    from torchvision.utils import draw_bounding_boxes  # WARNING: requires torchvision>=0.9.0
 
     assert hasattr(clearml, '__version__')  # verify package import not local dir
 except (ImportError, AssertionError):

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 import yaml
 from torchvision.transforms import ToPILImage
-from torchvision.utils import draw_bounding_boxes
 
 try:
     import clearml
     from clearml import Dataset, Task
+    from torchvision.utils import draw_bounding_boxes
 
     assert hasattr(clearml, '__version__')  # verify package import not local dir
 except (ImportError, AssertionError):


### PR DESCRIPTION
Quick fix for https://github.com/ultralytics/yolov5/issues/8898#issuecomment-1208851874 until a more permanent fix is implemented

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to ClearML logger dependency in YOLOv5 for bounding box visualization.

### 📊 Key Changes
- Moved the import statement for `draw_bounding_boxes` from `torchvision.utils` inside the try-except block.

### 🎯 Purpose & Impact
- 🔁 The change ensures compatibility with specific versions of the torchvision package (enforcing a minimum version of 0.9.0).
- ✅ Users will benefit from more reliable bounding box visualizations when using ClearML with YOLOv5 as this prevents import errors related to version mismatches.
- ⏩ Developers can ensure that the necessary prerequisites are met for proper logger functionality, reducing potential issues with dependencies.