### PR TITLE
Add `torch==1.7.0` to CI tests

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -65,7 +65,7 @@ jobs:
             model: yolov5n
             torch: latest
           - os: ubuntu-latest
-            python-version: '3.9'
+            python-version: '3.8'  # torch 1.7.0 requires python >=3.6, <=3.8
             model: yolov5n
             torch: '1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
     steps:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip wheel
-          if [ "${{ matrix.model }}" == "latest" ]; then
+          if [ "${{ matrix.torch }}" == "latest" ]; then
             pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
           else
             pip install -r requirements.txt torch==1.7.0 torchvision==0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -83,16 +83,15 @@ jobs:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('requirements.txt') }}
           restore-keys: ${{ runner.os }}-${{ matrix.python-version }}-pip-
-      - name: Install torch==1.7.0 requirements
-        if: matrix.torch == '1.7.0'
-        run: |
-          python -m pip install --upgrade pip wheel
-          pip install -r requirements.txt torch==1.7.0 torchvision==0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Install requirements
-        if: matrix.torch == 'latest'
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+          if [ "${{ matrix.torch }}" == "1.7.0" ]; then
+              pip install -r requirements.txt torch==1.7.0 torchvision==0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu
+          else
+              pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+          fi
+        shell: bash  # required for Windows compatibility
       - name: Check environment
         run: |
           python -c "import utils; utils.notebook_init()"

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -64,10 +64,10 @@ jobs:
             python-version: '3.9'
             model: yolov5n
             torch: latest
-          - os: ubuntu-latest
-            python-version: '3.10'
+          - os: ubuntu-latest  # min torch version CI https://pypi.org/project/torchvision/
+            python-version: '3.8'
             model: yolov5n
-            torch: 1.7.0
+            torch: '1.7.0'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -3,6 +3,8 @@
 
 name: YOLOv5 CI
 
+env:
+  TORCH_LATEST: 1.12.1
 on:
   push:
     branches: [master]
@@ -48,18 +50,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        torch: ["$TORCH_LATEST"]
         python-version: ['3.10']
         model: [yolov5n]
-        torch: [latest]
         include:
           - os: ubuntu-latest
+            torch: torch-latest
             python-version: '3.7'  # '3.6.8' min
             model: yolov5n
-            torch: latest
           - os: ubuntu-latest
+            torch: torch-latest
             python-version: '3.8'
             model: yolov5n
-            torch: latest
           - os: ubuntu-latest
             python-version: '3.9'
             model: yolov5n

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        torch: [env.TORCH_LATEST]
+        torch: ${{ env.TORCH_LATEST }}
         python-version: ['3.10']
         model: [yolov5n]
         include:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip wheel
-          if [ ${{ matrix.model }} == "latest" ]; then
+          if [ "${{ matrix.model }}" == "latest" ]; then
             pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
           else
             pip install -r requirements.txt torch==1.7.0 torchvision==0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -3,8 +3,6 @@
 
 name: YOLOv5 CI
 
-env:
-  TORCH_LATEST: '1.12.1'
 on:
   push:
     branches: [master]
@@ -50,26 +48,23 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        torch: [eval('env.TORCH_LATEST')]
+        torch: [torch-latest]
         python-version: ['3.10']
         model: [yolov5n]
         include:
           - os: ubuntu-latest
-            torch: torch-latest
             python-version: '3.7'  # '3.6.8' min
             model: yolov5n
           - os: ubuntu-latest
-            torch: torch-latest
             python-version: '3.8'
             model: yolov5n
           - os: ubuntu-latest
             python-version: '3.9'
             model: yolov5n
-            torch: latest
           - os: ubuntu-latest
+            torch: '1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
             python-version: '3.8'  # torch 1.7.0 requires python >=3.6, <=3.8
             model: yolov5n
-            torch: '1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        torch: ["$TORCH_LATEST"]
+        torch: [$TORCH_LATEST]
         python-version: ['3.10']
         model: [yolov5n]
         include:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -48,7 +48,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        torch: [torch-latest]
         python-version: ['3.10']
         model: [yolov5n]
         include:
@@ -62,9 +61,9 @@ jobs:
             python-version: '3.9'
             model: yolov5n
           - os: ubuntu-latest
-            torch: '1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
             python-version: '3.8'  # torch 1.7.0 requires python >=3.6, <=3.8
             model: yolov5n
+            torch: '1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -90,7 +90,7 @@ jobs:
           then
             pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
           else
-            pip install -r requirements.txt torch==1.7.0 torchvision=0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu
+            pip install -r requirements.txt torch==1.7.0 torchvision==0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu
           fi
           python --version
           pip --version

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -63,7 +63,7 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.8'  # torch 1.7.0 requires python >=3.6, <=3.8
             model: yolov5n
-            torch: 'torch==1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
+            torch: '1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -82,7 +82,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip wheel
-          if [ "${{ matrix.torch }}" == "torch==1.7.0" ]; then
+          if [ "${{ matrix.torch }}" == "1.7.0" ]; then
               pip install -r requirements.txt torch==1.7.0 torchvision==0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu
           else
               pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -63,7 +63,7 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.8'  # torch 1.7.0 requires python >=3.6, <=3.8
             model: yolov5n
-            torch: 'torch-1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
+            torch: 'torch==1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -82,7 +82,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip wheel
-          if [ "${{ matrix.torch }}" == "torch-1.7.0" ]; then
+          if [ "${{ matrix.torch }}" == "torch==1.7.0" ]; then
               pip install -r requirements.txt torch==1.7.0 torchvision==0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu
           else
               pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -86,8 +86,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip wheel
-          if [ ${{ matrix.torch }} == "latest" ]
-          then
+          if [ ${{ matrix.model }} == "latest" ]; then
             pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
           else
             pip install -r requirements.txt torch==1.7.0 torchvision==0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -63,7 +63,7 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.8'  # torch 1.7.0 requires python >=3.6, <=3.8
             model: yolov5n
-            torch: '1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
+            torch: 'torch-1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -82,7 +82,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip wheel
-          if [ "${{ matrix.torch }}" == "1.7.0" ]; then
+          if [ "${{ matrix.torch }}" == "torch-1.7.0" ]; then
               pip install -r requirements.txt torch==1.7.0 torchvision==0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu
           else
               pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        torch: [${{ env.TORCH_LATEST }}]
+        torch: [eval('env.TORCH_LATEST')]
         python-version: ['3.10']
         model: [yolov5n]
         include:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -64,10 +64,10 @@ jobs:
             python-version: '3.9'
             model: yolov5n
             torch: latest
-          - os: ubuntu-latest  # min torch version CI https://pypi.org/project/torchvision/
-            python-version: '3.8'
+          - os: ubuntu-latest
+            python-version: '3.10'
             model: yolov5n
-            torch: '1.7.0'
+            torch: '1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -83,17 +83,16 @@ jobs:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('requirements.txt') }}
           restore-keys: ${{ runner.os }}-${{ matrix.python-version }}-pip-
-      - name: Install requirements
+      - name: Install torch==1.7.0 requirements
+        if: matrix.torch == '1.7.0'
         run: |
           python -m pip install --upgrade pip wheel
-          if [ "${{ matrix.torch }}" == "latest" ]; then
-            pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
-          else
-            pip install -r requirements.txt torch==1.7.0 torchvision==0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu
-          fi
-          python --version
-          pip --version
-          pip list
+          pip install -r requirements.txt torch==1.7.0 torchvision==0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu
+      - name: Install requirements
+        if: matrix.torch == 'latest'
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
       - name: Check environment
         run: |
           python -c "import utils; utils.notebook_init()"
@@ -103,6 +102,9 @@ jobs:
           echo "GITHUB_ACTOR is ${{ github.actor }}"
           echo "GITHUB_REPOSITORY is ${{ github.repository }}"
           echo "GITHUB_REPOSITORY_OWNER is ${{ github.repository_owner }}"
+          python --version
+          pip --version
+          pip list
       - name: Run tests
         shell: bash
         run: |

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -50,16 +50,24 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.10']
         model: [yolov5n]
+        torch: [latest]
         include:
           - os: ubuntu-latest
             python-version: '3.7'  # '3.6.8' min
             model: yolov5n
+            torch: latest
           - os: ubuntu-latest
             python-version: '3.8'
             model: yolov5n
+            torch: latest
           - os: ubuntu-latest
             python-version: '3.9'
             model: yolov5n
+            torch: latest
+          - os: ubuntu-latest
+            python-version: '3.10'
+            model: yolov5n
+            torch: 1.7.0
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -78,7 +86,12 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+          if [ ${{ matrix.torch }} == "latest" ]
+          then
+            pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cpu
+          else
+            pip install -r requirements.txt torch==1.7.0 torchvision=0.8.1 --extra-index-url https://download.pytorch.org/whl/cpu
+          fi
           python --version
           pip --version
           pip list

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        torch: [$TORCH_LATEST]
+        torch: [env.TORCH_LATEST]
         python-version: ['3.10']
         model: [yolov5n]
         include:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -4,7 +4,7 @@
 name: YOLOv5 CI
 
 env:
-  TORCH_LATEST: 1.12.1
+  TORCH_LATEST: '1.12.1'
 on:
   push:
     branches: [master]
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        torch: ${{ env.TORCH_LATEST }}
+        torch: [${{ env.TORCH_LATEST }}]
         python-version: ['3.10']
         model: [yolov5n]
         include:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -65,7 +65,7 @@ jobs:
             model: yolov5n
             torch: latest
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.9'
             model: yolov5n
             torch: '1.7.0'  # min torch version CI https://pypi.org/project/torchvision/
     steps:

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 import yaml
 from torchvision.transforms import ToPILImage
-from torchvision.utils import draw_bounding_boxes  # WARNING: requires torchvision>=0.9.0
 
 try:
     import clearml
     from clearml import Dataset, Task
+    from torchvision.utils import draw_bounding_boxes  # WARNING: requires torchvision>=0.9.0
 
     assert hasattr(clearml, '__version__')  # verify package import not local dir
 except (ImportError, AssertionError):

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 import yaml
 from torchvision.transforms import ToPILImage
+from torchvision.utils import draw_bounding_boxes  # WARNING: requires torchvision>=0.9.0
 
 try:
     import clearml
     from clearml import Dataset, Task
-    from torchvision.utils import draw_bounding_boxes  # WARNING: requires torchvision>=0.9.0
 
     assert hasattr(clearml, '__version__')  # verify package import not local dir
 except (ImportError, AssertionError):


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of CI testing to ensure compatibility with older Python and PyTorch versions.

### 📊 Key Changes
- Added a CI test case for Ubuntu with Python 3.8 and PyTorch 1.7.0.
- Conditional requirements installation based on the specified PyTorch version.
- Moved `python --version`, `pip --version`, and `pip list` commands to a later step in the workflow.

### 🎯 Purpose & Impact
- **Ensures backward compatibility:** By testing against older Python and PyTorch versions, Ultralytics ensures that YOLOv5 remains compatible with environments that have not upgraded to the latest versions.
- **Reduces potential issues for users:** Users on legacy systems will appreciate continued support, minimizing disruption and the need for upgrades.
- **Maintains robust testing:** By adjusting CI workflows, the project continues to maintain high-quality standards through automated testing.