### PR TITLE
Fix `--source 'path/*.jpg'` glob example

### DIFF
--- a/.github/README_cn.md
+++ b/.github/README_cn.md
@@ -102,7 +102,7 @@ python detect.py --source 0  # 网络摄像头
                           img.jpg  # 图像
                           vid.mp4  # 视频
                           path/  # 文件夹
-                          path/*.jpg  # glob
+                          'path/*.jpg'  # glob
                           'https://youtu.be/Zgi9g1ksQHc'  # YouTube
                           'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP 流
 ```

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ python detect.py --source 0  # webcam
                           img.jpg  # image
                           vid.mp4  # video
                           path/  # directory
-                          path/*.jpg  # glob
+                          'path/*.jpg'  # glob
                           'https://youtu.be/Zgi9g1ksQHc'  # YouTube
                           'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP stream
 ```

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -448,7 +448,7 @@
         "                          img.jpg  # image \n",
         "                          vid.mp4  # video\n",
         "                          path/  # directory\n",
-        "                          path/*.jpg  # glob\n",
+        "                          'path/*.jpg'  # glob\n",
         "                          'https://youtu.be/Zgi9g1ksQHc'  # YouTube\n",
         "                          'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP stream\n",
         "```"


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved documentation for path specifications in `yolov5`.

### 📊 Key Changes
- Enclosed the path pattern `*.jpg` with single quotes in README files and notebook tutorial.
- Ensured there is a newline at the end of the `tutorial.ipynb` file.

### 🎯 Purpose & Impact
- 📝 Enhances clarity in documentation, making it explicit that glob patterns should be quoted to prevent shell interpretation issues.
- 🐞 Fixes potentially unintended behaviors when users input file paths, leading to a smoother user experience.
- 🧹 Minor file formatting improvement for code consistency and standards compliance.