### PR TITLE
New arg parser utilitarian

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -75,6 +75,7 @@ def run(
         hide_conf=False,  # hide confidences
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
+        abs_path = False, # saves all exports on the path provided by --project, without creating --name folder and labels subfolders
 ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
@@ -85,8 +86,15 @@ def run(
         source = check_file(source)  # download
 
     # Directories
-    save_dir = increment_path(Path(project) / name, exist_ok=exist_ok)  # increment run
-    (save_dir / 'labels' if save_txt else save_dir).mkdir(parents=True, exist_ok=True)  # make dir
+    if abs_path:
+        if os.path.isdir(Path(project)):
+            save_dir = Path(project)
+        else:
+            os.mkdir(Path(project))
+            save_dir = Path(project)
+    else:
+        save_dir = increment_path(Path(project) / name, exist_ok=exist_ok)  # increment run
+        (save_dir / 'labels' if save_txt else save_dir).mkdir(parents=True, exist_ok=True)  # make dir
 
     # Load model
     device = select_device(device)
@@ -142,7 +150,10 @@ def run(
 
             p = Path(p)  # to Path
             save_path = str(save_dir / p.name)  # im.jpg
-            txt_path = str(save_dir / 'labels' / p.stem) + ('' if dataset.mode == 'image' else f'_{frame}')  # im.txt
+            if abs_path:
+                txt_path = str(save_dir / p.stem) + ('' if dataset.mode == 'image' else f'_{frame}') # im.txt
+            else:
+                txt_path = str(save_dir / 'labels' / p.stem) + ('' if dataset.mode == 'image' else f'_{frame}')  # im.txt
             s += '%gx%g ' % im.shape[2:]  # print string
             gn = torch.tensor(im0.shape)[[1, 0, 1, 0]]  # normalization gain whwh
             imc = im0.copy() if save_crop else im0  # for save_crop
@@ -207,7 +218,10 @@ def run(
     t = tuple(x / seen * 1E3 for x in dt)  # speeds per image
     LOGGER.info(f'Speed: %.1fms pre-process, %.1fms inference, %.1fms NMS per image at shape {(1, 3, *imgsz)}' % t)
     if save_txt or save_img:
-        s = f"\n{len(list(save_dir.glob('labels/*.txt')))} labels saved to {save_dir / 'labels'}" if save_txt else ''
+        if abs_path:
+            s = f"\n{len(list(save_dir.glob('*.txt')))} labels saved to {save_dir}" if save_txt else ''
+        else:
+            s = f"\n{len(list(save_dir.glob('labels/*.txt')))} labels saved to {save_dir / 'labels'}" if save_txt else ''
         LOGGER.info(f"Results saved to {colorstr('bold', save_dir)}{s}")
     if update:
         strip_optimizer(weights[0])  # update model (to fix SourceChangeWarning)
@@ -241,6 +255,7 @@ def parse_opt():
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
+    parser.add_argument('--abs-path', action='store_true', help='saves all exports on the path provided by --project, without creating --name folder and labels/ subfolders')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(vars(opt))

--- a/detect.py
+++ b/detect.py
@@ -75,7 +75,7 @@ def run(
         hide_conf=False,  # hide confidences
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
-        abs_path = False, # saves all exports on the path provided by --project, without creating --name folder and labels subfolders
+        abs_path=False,  # saves all exports on the path provided by --project, without creating --name folder and labels subfolders
 ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
@@ -151,9 +151,10 @@ def run(
             p = Path(p)  # to Path
             save_path = str(save_dir / p.name)  # im.jpg
             if abs_path:
-                txt_path = str(save_dir / p.stem) + ('' if dataset.mode == 'image' else f'_{frame}') # im.txt
+                txt_path = str(save_dir / p.stem) + ('' if dataset.mode == 'image' else f'_{frame}')  # im.txt
             else:
-                txt_path = str(save_dir / 'labels' / p.stem) + ('' if dataset.mode == 'image' else f'_{frame}')  # im.txt
+                txt_path = str(save_dir / 'labels' / p.stem) + ('' if dataset.mode == 'image' else f'_{frame}'
+                                                                )  # im.txt
             s += '%gx%g ' % im.shape[2:]  # print string
             gn = torch.tensor(im0.shape)[[1, 0, 1, 0]]  # normalization gain whwh
             imc = im0.copy() if save_crop else im0  # for save_crop
@@ -255,7 +256,11 @@ def parse_opt():
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
-    parser.add_argument('--abs-path', action='store_true', help='saves all exports on the path provided by --project, without creating --name folder and labels/ subfolders')
+    parser.add_argument(
+        '--abs-path',
+        action='store_true',
+        help='saves all exports on the path provided by --project, without creating --name folder and labels/ subfolders'
+    )
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(vars(opt))


### PR DESCRIPTION
Hello I've been using Yolov5 for a year and I started to do some tweaks on utilitarians that helped on my projects, I am making them less hard coded and generic so I can do the PR's this is my first time doing PR so I'm not sure if I'm following all the protocols, but anyway here it goes.

On this PR I added the parser argument  --abs-path that saves all exports on the path provided by --project, without creating --name folder and labels subfolders. Useful when you need the output txt and jpg to be on the same folder and without creating sublfolders on the path provided on --project.

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing the `--abs-path` option to control output directory structure during detection.

### 📊 Key Changes
- Added `abs_path` argument to the `detect.py` script.
- With `abs_path` set to True, outputs are saved directly in the `--project` directory.
- Removed the automatic creation of a subfolder named `--name` and `labels/` subdirectories when `abs_path` is True.

### 🎯 Purpose & Impact
- 🎨 Provides users with more control over the directory structure where the detection results are saved.
- 🛠️ Simplifies the output path for users who don't need hierarchical directories.
- ☑️ Offers a more straightforward saving option that could be useful for integrating YOLOv5 into existing workflows or systems where directory structure is tightly controlled.