### PR TITLE
Remove DDP `destroy_process_group()` on train end

### DIFF
--- a/train.py
+++ b/train.py
@@ -527,9 +527,6 @@ def main(opt, callbacks=Callbacks()):
     # Train
     if not opt.evolve:
         train(opt.hyp, opt, device, callbacks)
-        if WORLD_SIZE > 1 and RANK == 0:
-            LOGGER.info('Destroying process group... ')
-            dist.destroy_process_group()
 
     # Evolve hyperparameters (optional)
     else:


### PR DESCRIPTION
May resolve https://github.com/ultralytics/yolov5/issues/7307


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimized distributed training cleanup process in YOLOv5.

### 📊 Key Changes
- Removed redundant code that manually destroyed the process group after training.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: Streamlines the distributed training process to be more efficient.
- ✨ **Impact**: Can lead to smoother shutdown of training processes, possibly reducing errors on exit for users utilizing distributed training environments. This change primarily affects users working with multiple GPUs or across multiple nodes.