### PR TITLE
New `smart_inference_mode()` conditional decorator

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -44,10 +44,10 @@ from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadStreams
 from utils.general import (LOGGER, check_file, check_img_size, check_imshow, check_requirements, colorstr, cv2,
                            increment_path, non_max_suppression, print_args, scale_coords, strip_optimizer, xyxy2xywh)
 from utils.plots import Annotator, colors, save_one_box
-from utils.torch_utils import select_device, time_sync
+from utils.torch_utils import select_device, smart_inference_mode, time_sync
 
 
-@torch.no_grad()
+@smart_inference_mode()
 def run(
         weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
         source=ROOT / 'data/images',  # file/dir/URL/glob, 0 for webcam

--- a/export.py
+++ b/export.py
@@ -69,7 +69,7 @@ from models.yolo import Detect
 from utils.dataloaders import LoadImages
 from utils.general import (LOGGER, check_dataset, check_img_size, check_requirements, check_version, check_yaml,
                            colorstr, file_size, print_args, url2file)
-from utils.torch_utils import select_device
+from utils.torch_utils import select_device, smart_inference_mode
 
 
 def export_formats():
@@ -455,7 +455,7 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
         LOGGER.info(f'\n{prefix} export failure: {e}')
 
 
-@torch.no_grad()
+@smart_inference_mode()
 def run(
         data=ROOT / 'data/coco128.yaml',  # 'dataset.yaml path'
         weights=ROOT / 'yolov5s.pt',  # weights path

--- a/models/common.py
+++ b/models/common.py
@@ -25,7 +25,7 @@ from utils.dataloaders import exif_transpose, letterbox
 from utils.general import (LOGGER, check_requirements, check_suffix, check_version, colorstr, increment_path,
                            make_divisible, non_max_suppression, scale_coords, xywh2xyxy, xyxy2xywh)
 from utils.plots import Annotator, colors, save_one_box
-from utils.torch_utils import copy_attr, time_sync
+from utils.torch_utils import copy_attr, smart_inference_mode, time_sync
 
 
 def autopad(k, p=None):  # kernel, padding
@@ -578,7 +578,7 @@ class AutoShape(nn.Module):
                 m.anchor_grid = list(map(fn, m.anchor_grid))
         return self
 
-    @torch.no_grad()
+    @smart_inference_mode()
     def forward(self, imgs, size=640, augment=False, profile=False):
         # Inference from various sources. For height=640, width=1280, RGB images example inputs are:
         #   file:       imgs = 'data/images/zidane.jpg'  # str or PosixPath

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -76,12 +76,12 @@ class Detect(nn.Module):
 
         return x if self.training else (torch.cat(z, 1),) if self.export else (torch.cat(z, 1), x)
 
-    def _make_grid(self, nx=20, ny=20, i=0):
+    def _make_grid(self, nx=20, ny=20, i=0, torch_1_10=check_version(torch.__version__, '1.10.0')):
         d = self.anchors[i].device
         t = self.anchors[i].dtype
         shape = 1, self.na, ny, nx, 2  # grid shape
         y, x = torch.arange(ny, device=d, dtype=t), torch.arange(nx, device=d, dtype=t)
-        if check_version(torch.__version__, '1.10.0'):  # torch>=1.10.0 meshgrid workaround for torch>=0.7 compatibility
+        if torch_1_10:  # torch>=1.10.0 meshgrid workaround for torch>=0.7 compatibility
             yv, xv = torch.meshgrid(y, x, indexing='ij')
         else:
             yv, xv = torch.meshgrid(y, x)

--- a/val.py
+++ b/val.py
@@ -42,7 +42,7 @@ from utils.general import (LOGGER, check_dataset, check_img_size, check_requirem
                            scale_coords, xywh2xyxy, xyxy2xywh)
 from utils.metrics import ConfusionMatrix, ap_per_class, box_iou
 from utils.plots import output_to_target, plot_images, plot_val_study
-from utils.torch_utils import select_device, time_sync
+from utils.torch_utils import select_device, smart_inference_mode, time_sync
 
 
 def save_one_txt(predn, save_conf, shape, file):
@@ -93,7 +93,7 @@ def process_batch(detections, labels, iouv):
     return torch.tensor(correct, dtype=torch.bool, device=iouv.device)
 
 
-@torch.no_grad()
+@smart_inference_mode()
 def run(
         data,
         weights=None,  # model.pt path(s)


### PR DESCRIPTION
Applies torch.inference_mode() decorator if torch>=1.9.0 else torch.no_grad() decorator. Material speed improvements observed in detect.py and val.py.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Integration of a new `smart_inference_mode` decorator across various Ultralytics YOLOv5 files for improved handling of inference operations.

### 📊 Key Changes
- **smart_inference_mode Decorator**: A new decorator function, `smart_inference_mode`, has been created to wrap functions that previously used the `torch.no_grad()` decorator.
- **Updates in Critical Files**: Modifications made in `detect.py`, `export.py`, `val.py`, `models/common.py`, and `models/yolo.py` to use the new decorator.
- **EMA Update Function**: The Exponential Moving Average (EMA) update function in `utils/torch_utils.py` now uses `smart_inference_mode` instead of `torch.no_grad()`.
- **Minor Refactoring**: The `_make_grid` function in `models/yolo.py` now accepts an additional parameter to handle torch version compatibility.

### 🎯 Purpose & Impact
- **Enhanced Inference Performance**: The change transitions to `torch.inference_mode` for PyTorch versions >=1.9.0, which provides a more performant context manager for inference operations, potentially speeding up the process.
- **Backward Compatibility**: The new decorator maintains compatibility with older versions of PyTorch by falling back to `torch.no_grad()` when necessary.
- **Simplified Codebase**: By replacing individual `torch.no_grad()` calls with a decorator that checks the version and decides the context, the codebase becomes cleaner and more maintainable.

These updates aim to ensure that the YOLOv5 codebase remains modern and efficient, aligning with the latest best practices for PyTorch inference, while still supporting older versions of the framework seamlessly. Users should benefit from potential performance improvements during model inference without needing to alter their own usage of the library. 🚀📈