### PR TITLE
Allow multiple-model serving from Flask REST API

### DIFF
--- a/utils/flask_rest_api/restapi.py
+++ b/utils/flask_rest_api/restapi.py
@@ -1,6 +1,6 @@
 # YOLOv5 🚀 by Ultralytics, GPL-3.0 license
 """
-Run a Flask REST API exposing a YOLOv5s model
+Run a Flask REST API exposing one or more YOLOv5s models
 """
 
 import argparse
@@ -11,10 +11,9 @@ from flask import Flask, request
 from PIL import Image
 
 app = Flask(__name__)
+models = {}
 
 DETECTION_URL = "/v1/object-detection/<model>"
-
-models = {}
 
 
 @app.route(DETECTION_URL, methods=["POST"])

--- a/utils/flask_rest_api/restapi.py
+++ b/utils/flask_rest_api/restapi.py
@@ -49,6 +49,6 @@ if __name__ == "__main__":
     if not opt.model:
         opt.model = ['yolov5s']
     for model in opt.model:
-        models[model] = torch.hub.load("ultralytics/yolov5", model, force_reload=True)   # force_reload to recache
+        models[model] = torch.hub.load("ultralytics/yolov5", model, force_reload=True)  # force_reload to recache
 
     app.run(host="0.0.0.0", port=opt.port)  # debug=True causes Restarting with stat

--- a/utils/flask_rest_api/restapi.py
+++ b/utils/flask_rest_api/restapi.py
@@ -40,15 +40,10 @@ def predict(model):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Flask API exposing YOLOv5 model")
     parser.add_argument("--port", default=5000, type=int, help="port number")
-    parser.add_argument("--model", default=[], action='append', help="models to run (default yolov5s)")
+    parser.add_argument('--model', nargs='+', default=['yolov5s'], help='model(s) to run, i.e. --model yolov5n yolov5s')
     opt = parser.parse_args()
 
-    # Fix known issue urllib.error.HTTPError 403: rate limit exceeded https://github.com/ultralytics/yolov5/pull/7210
-    torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
-
-    if not opt.model:
-        opt.model = ['yolov5s']
-    for model in opt.model:
-        models[model] = torch.hub.load("ultralytics/yolov5", model, force_reload=True)  # force_reload to recache
+    for m in opt.model:
+        models[m] = torch.hub.load("ultralytics/yolov5", m, force_reload=True, skip_validation=True)
 
     app.run(host="0.0.0.0", port=opt.port)  # debug=True causes Restarting with stat


### PR DESCRIPTION
Hi,

This is a small modification to allow to serve multiple models with the flask rest api.

Best Regards,
Michel.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of the YOLOv5 Flask REST API to support multiple models simultaneously.

### 📊 Key Changes
- The REST API now allows specifying which model to use in the request URL.
- The server can load multiple models at startup based on command line arguments.
- The prediction route (`predict`) dynamically selects the model based on the URL.
- The hardcoded single model setup has been replaced with a flexible models dictionary.

### 🎯 Purpose & Impact
- **Flexibility:** Users can now interact with different YOLOv5 models in a single API instance, which is useful for comparing results or if different use cases require different models.
- **Convenience:** By allowing multiple models, users can avoid running separate instances for each model, saving resources and simplifying the interaction process.
- **Customizability:** The update adds the ability to specify the desired models at server startup, giving users control over which models are loaded, and adjusting for performance or resource allocation as needed.