### PR TITLE
Start evolution with default `anchors=3`

### DIFF
--- a/train.py
+++ b/train.py
@@ -546,7 +546,7 @@ def main(opt, callbacks=Callbacks()):
             'obj_pw': (1, 0.5, 2.0),  # obj BCELoss positive_weight
             'iou_t': (0, 0.1, 0.7),  # IoU training threshold
             'anchor_t': (1, 2.0, 8.0),  # anchor-multiple threshold
-            'anchors': (2, 2.0, 10.0),  # anchors per output grid (0 to ignore)
+            'anchors': (3, 2.0, 10.0),  # anchors per output grid (0 to ignore)
             'fl_gamma': (0, 0.0, 2.0),  # focal loss gamma (efficientDet default gamma=1.5)
             'hsv_h': (1, 0.0, 0.1),  # image HSV-Hue augmentation (fraction)
             'hsv_s': (1, 0.0, 0.9),  # image HSV-Saturation augmentation (fraction)


### PR DESCRIPTION
The default number of anchors is 3 anyways (https://github.com/ultralytics/yolov5/blob/master/train.py#L568), so better start with default settings in an evolution run.

Signed-off-by: Cyril Stoller <stocyr@users.noreply.github.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjustment to the default number of anchors per output grid in YOLOv5 training configuration.

### 📊 Key Changes
- Increased the default setting for `anchors` from 2 to 3 per output grid in the training script.

### 🎯 Purpose & Impact
- This tweak aims to improve the model's capability to detect objects by allowing it to consider more potential anchor box shapes by default.
- Users might experience a slight improvement in detection performance, especially in scenarios where objects vary in aspect ratio and size.
- This change could lead to a bit more computational overhead during training, but with the potential benefit of increased accuracy.