### PR TITLE
Fix torchvision dependency for ClearML logging

### DIFF
--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -136,7 +136,8 @@ class ClearmlLogger:
             # Log every bbox_interval times and deduplicate for any intermittend extra eval runs
             if self.current_epoch % self.bbox_interval == 0 and image_path not in self.current_epoch_logged_images:
                 annotator = Annotator(im=np.ascontiguousarray(
-                    np.moveaxis(image.mul(255).clamp(0, 255).byte().cpu().numpy(), 0, 2)), pil=True)
+                    np.moveaxis(image.mul(255).clamp(0, 255).byte().cpu().numpy(), 0, 2)),
+                                      pil=True)
                 for i, (conf, class_nr, box) in enumerate(zip(boxes[:, 4], boxes[:, 5], boxes[:, :4])):
                     color = colors(i)
 

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -136,8 +136,7 @@ class ClearmlLogger:
             # Log every bbox_interval times and deduplicate for any intermittend extra eval runs
             if self.current_epoch % self.bbox_interval == 0 and image_path not in self.current_epoch_logged_images:
                 annotator = Annotator(im=np.ascontiguousarray(
-                    np.moveaxis(image.mul(255).clamp(0, 255).byte().cpu().numpy(), 0, 2)),
-                                      pil=True)
+                    np.moveaxis(image.mul(255).clamp(0, 255).byte().cpu().numpy(), 0, 2)), pil=True)
                 for i, (conf, class_nr, box) in enumerate(zip(boxes[:, 4], boxes[:, 5], boxes[:, :4])):
                     color = colors(i)
 

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -16,6 +16,8 @@ except (ImportError, AssertionError):
 
 
 def construct_dataset(clearml_info_string):
+    """Load in a clearml dataset and fill the internal data_dict with its contents.
+    """
     dataset_id = clearml_info_string.replace('clearml://', '')
     dataset = Dataset.get(dataset_id=dataset_id)
     dataset_root_path = Path(dataset.get_local_copy())
@@ -121,7 +123,7 @@ class ClearmlLogger:
 
     def log_image_with_boxes(self, image_path, boxes, class_names, image, conf_threshold=0.35):
         """
-        Draw the bounding boxes on a single image and report the result as a ClearML debug sample
+        Draw the bounding boxes on a single image and report the result as a ClearML debug sample.
 
         arguments:
         image_path (PosixPath) the path the original image file
@@ -145,8 +147,8 @@ class ClearmlLogger:
 
                     if confidence > conf_threshold:
                         annotator.rectangle(box.cpu().numpy(), outline=color)
-                        annotator.box_label(box.cpu().numpy(), label=label, color=color)                    
-                    
+                        annotator.box_label(box.cpu().numpy(), label=label, color=color)
+
                 annotated_image = annotator.result()
                 self.task.get_logger().report_image(title='Bounding Boxes',
                                                     series=image_path.name,

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -3,8 +3,9 @@ import glob
 import re
 from pathlib import Path
 
-import yaml
 import numpy as np
+import yaml
+
 from utils.plots import Annotator, colors
 
 try:
@@ -132,10 +133,9 @@ class ClearmlLogger:
         if len(self.current_epoch_logged_images) < self.max_imgs_to_log_per_epoch and self.current_epoch >= 0:
             # Log every bbox_interval times and deduplicate for any intermittend extra eval runs
             if self.current_epoch % self.bbox_interval == 0 and image_path not in self.current_epoch_logged_images:
-                annotator = Annotator(
-                    im=np.ascontiguousarray(np.moveaxis(image.mul(255).clamp(0, 255).byte().cpu().numpy(), 0, 2)),
-                    pil=True
-                )
+                annotator = Annotator(im=np.ascontiguousarray(
+                    np.moveaxis(image.mul(255).clamp(0, 255).byte().cpu().numpy(), 0, 2)),
+                                      pil=True)
                 for i, (conf, class_nr, box) in enumerate(zip(boxes[:, 4], boxes[:, 5], boxes[:, :4])):
                     color = colors(i)
 
@@ -145,8 +145,8 @@ class ClearmlLogger:
 
                     if confidence > conf_threshold:
                         annotator.rectangle(box.cpu().numpy(), outline=color)
-                        annotator.box_label(box.cpu().numpy(), label=label, color=color)                    
-                    
+                        annotator.box_label(box.cpu().numpy(), label=label, color=color)
+
                 annotated_image = annotator.result()
                 self.task.get_logger().report_image(title='Bounding Boxes',
                                                     series=image_path.name,

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -122,7 +122,7 @@ class ClearmlLogger:
                                                     local_path=str(f),
                                                     iteration=iteration)
 
-    def log_image_with_boxes(self, image_path, boxes, class_names, image, conf_threshold=0.35):
+    def log_image_with_boxes(self, image_path, boxes, class_names, image, conf_threshold=0.25):
         """
         Draw the bounding boxes on a single image and report the result as a ClearML debug sample.
 

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -135,9 +135,8 @@ class ClearmlLogger:
         if len(self.current_epoch_logged_images) < self.max_imgs_to_log_per_epoch and self.current_epoch >= 0:
             # Log every bbox_interval times and deduplicate for any intermittend extra eval runs
             if self.current_epoch % self.bbox_interval == 0 and image_path not in self.current_epoch_logged_images:
-                annotator = Annotator(im=np.ascontiguousarray(
-                    np.moveaxis(image.mul(255).clamp(0, 255).byte().cpu().numpy(), 0, 2)),
-                                      pil=True)
+                im = np.ascontiguousarray(np.moveaxis(image.mul(255).clamp(0, 255).byte().cpu().numpy(), 0, 2))
+                annotator = Annotator(im=im, pil=True)
                 for i, (conf, class_nr, box) in enumerate(zip(boxes[:, 4], boxes[:, 5], boxes[:, :4])):
                     color = colors(i)
 


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->
# ClearML bounding boxes ported to native Annotator
Fixes #8898 

Instead of using torchvision to draw the bounding boxes in the validation step, I rewrote the function to use the built-in Annotator class like @glenn-jocher suggested in the issue. This eliminates the potential dependency error.

This also includes a small rewrite of the loops in the function to make it a bit more consice and clean :)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of ClearML logging with better image annotation and configuration.

### 📊 Key Changes
- 🧩 Integrated `numpy` and custom `Annotator` from `utils.plots` for image annotation.
- 🎨 Utilized color schemes from `utils.plots.colors` for bounding box visualization.
- ✂️ Removed dependency on `torchvision.transforms.ToPILImage`.
- 🔍 Added confidence threshold parameter to `log_image_with_boxes` for filtering annotations.

### 🎯 Purpose & Impact
- 📈 **Purpose:** To improve the visual clarity of logged images with bounding boxes in ClearML and allow users to set a confidence threshold for annotations.
- 💡 **Impact:** Users will see more polished and configurable visual logs within their ClearML experiments, leading to better interpretability of their models' outputs.