### PR TITLE
Add weight `decay` to argparser

### DIFF
--- a/classify/train.py
+++ b/classify/train.py
@@ -136,7 +136,7 @@ def train(opt, device):
         logger.log_graph(model, imgsz)  # log model
 
     # Optimizer
-    optimizer = smart_optimizer(model, opt.optimizer, opt.lr0, momentum=0.9, decay=5e-5)
+    optimizer = smart_optimizer(model, opt.optimizer, opt.lr0, momentum=0.9, decay=opt.decay)
 
     # Scheduler
     lrf = 0.01  # final lr (fraction of lr0)
@@ -280,6 +280,7 @@ def parse_opt(known=False):
     parser.add_argument('--pretrained', nargs='?', const=True, default=True, help='start from i.e. --pretrained False')
     parser.add_argument('--optimizer', choices=['SGD', 'Adam', 'AdamW', 'RMSProp'], default='Adam', help='optimizer')
     parser.add_argument('--lr0', type=float, default=0.001, help='initial learning rate')
+    parser.add_argument('--decay', type=float, default=5e-5, help='weight decay')
     parser.add_argument('--label-smoothing', type=float, default=0.1, help='Label smoothing epsilon')
     parser.add_argument('--cutoff', type=int, default=None, help='Model layer cutoff index for Classify() head')
     parser.add_argument('--dropout', type=float, default=None, help='Dropout (fraction)')


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved configurability of the weight decay parameter for training in the YOLOv5 classification module.

### 📊 Key Changes
- The optimizer now uses a customizable `decay` parameter from the command line options.
- Added a `--decay` command line argument to specify weight decay.

### 🎯 Purpose & Impact
- **Purpose:** To allow users greater flexibility when setting up the weight decay during model training, which can help in preventing overfitting and improving generalization.
- **Impact:** Users can now fine-tune the weight decay according to their dataset and training regimen, potentially leading to better model performance. 🚀