### PR TITLE
Faster pre-processing for gray image input

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -615,7 +615,7 @@ class AutoShape(nn.Module):
             files.append(Path(f).with_suffix('.jpg').name)
             if im.shape[0] < 5:  # image in CHW
                 im = im.transpose((1, 2, 0))  # reverse dataloader .transpose(2, 0, 1)
-            im = im[..., :3] if im.ndim == 3 else np.tile(im[..., None], 3)  # enforce 3ch input
+            im = im[..., :3] if im.ndim == 3 else cv2.cvtColor(im,cv2.COLOR_GRAY2BGR)  # enforce 3ch input
             s = im.shape[:2]  # HWC
             shape0.append(s)  # image shape
             g = (size / max(s))  # gain

--- a/models/common.py
+++ b/models/common.py
@@ -615,7 +615,7 @@ class AutoShape(nn.Module):
             files.append(Path(f).with_suffix('.jpg').name)
             if im.shape[0] < 5:  # image in CHW
                 im = im.transpose((1, 2, 0))  # reverse dataloader .transpose(2, 0, 1)
-            im = im[..., :3] if im.ndim == 3 else cv2.cvtColor(im,cv2.COLOR_GRAY2BGR)  # enforce 3ch input
+            im = im[..., :3] if im.ndim == 3 else cv2.cvtColor(im, cv2.COLOR_GRAY2BGR)  # enforce 3ch input
             s = im.shape[:2]  # HWC
             shape0.append(s)  # image shape
             g = (size / max(s))  # gain


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

Using opencv cvtColor function is significantly faster than np.tile method to enforce 3 channel input


```
%%timeit -r 7 -n 100
im_cv_3ch=cv.cvtColor(im,cv.COLOR_GRAY2BGR)
13.2 ms ± 250 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

%%timeit -r 7 -n 100
im_np_3ch=np.tile(im[..., None], 3)
119 ms ± 2.62 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

(Test done on Windows machine with Intel i5 CPU)


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image preprocessing for grayscale images in YOLOv5.

### 📊 Key Changes
- Modified the method to enforce 3-channel input for grayscale images.
- Replaced `np.tile()` with OpenCV's `cv2.cvtColor()` for converting single-channel images to 3-channel BGR format.

### 🎯 Purpose & Impact
- The change ensures better handling of grayscale images during preprocessing, leading to potentially improved model training and inference performance with such data.
- Users working with grayscale datasets can expect their images to be correctly processed without manual intervention.
- The use of OpenCV's function may result in more efficient and standardized conversion compared to NumPy's tiling method. 🚀