### PR TITLE
Temporarily remove `macos-latest` from CI

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]  # macos-latest
+        os: [ ubuntu-latest, windows-latest ]  # macos-latest bug https://github.com/ultralytics/yolov5/pull/9049
         python-version: [ '3.10' ]
         model: [ yolov5n ]
         include:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest ]  # macos-latest
         python-version: [ '3.10' ]
         model: [ yolov5n ]
         include:


### PR DESCRIPTION
macos-latest causing many failed CI runs that resolve after manually re-running 2 or 3 times. I don't know what the cause is. Will replace at a later date.

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of CI Testing by excluding macOS due to a known issue.

### 📊 Key Changes
- Removed `macos-latest` from the CI testing matrix.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: Prevent false positives in continuous integration (CI) tests caused by a bug with the macOS environment.
- 🛠️ **Impact**: Ensures CI results are reliable and representative of the true state of the code, but temporarily reduces the diversity of OS environments tested, which might delay the discovery of macOS-specific issues until the bug is resolved.