### PR TITLE
Add `--save-hybrid` mAP warning

### DIFF
--- a/val.py
+++ b/val.py
@@ -366,7 +366,7 @@ def main(opt):
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466
             LOGGER.info(f'WARNING: confidence threshold {opt.conf_thres} > 0.001 produces invalid results ⚠️')
         if opt.save_hybrid:
-            LOGGER.info(f'WARNING: --save-hybrid will return mAP from hybrid labels, not from predictions alone ⚠️')
+            LOGGER.info('WARNING: --save-hybrid will return high mAP from hybrid labels, not from predictions alone ⚠️')
         run(**vars(opt))
 
     else:

--- a/val.py
+++ b/val.py
@@ -365,6 +365,8 @@ def main(opt):
     if opt.task in ('train', 'val', 'test'):  # run normally
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466
             LOGGER.info(f'WARNING: confidence threshold {opt.conf_thres} > 0.001 produces invalid results ⚠️')
+        if opt.save_hybrid:
+            LOGGER.info(f'WARNING: --save-hybrid will return mAP from hybrid labels, not from predictions alone ⚠️')
         run(**vars(opt))
 
     else:


### PR DESCRIPTION
Resolves https://github.com/ultralytics/yolov5/issues/9041

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced flexibility in validation script with new `save_hybrid` option.

### 📊 Key Changes
- Added support for a new `save_hybrid` option within the validation (`val.py`) script.

### 🎯 Purpose & Impact
- **Purpose**: This change allows users to optionally activate a new feature during model validation, which seemed to be tied to saving hybrid results based on the name `save_hybrid`.
- **Impact**: Users can now have more control over how they save their validation results, potentially enabling new workflows or result types. However, without further context, the specific nature of the 'hybrid' results is not clear, but this enhancement is directed towards users requiring this new functionality. ⚙️💾