### PR TITLE
zero-mAP fix return `.detach()` to EMA

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -422,7 +422,7 @@ class ModelEMA:
         for k, v in self.ema.state_dict().items():
             if v.dtype.is_floating_point:  # true for FP16 and FP32
                 v *= d
-                v += (1 - d) * msd[k]
+                v += (1 - d) * msd[k].detach()
         assert v.dtype == msd[k].dtype == torch.float32, f'EMA {v.dtype} and model {msd[k]} must be updated in FP32'
 
     def update_attr(self, model, include=(), exclude=('process_group', 'reducer')):


### PR DESCRIPTION
Resolves https://github.com/ultralytics/hub/issues/82

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced stability in model updates during training for the YOLOv5 project.

### 📊 Key Changes
- Adjusted the Exponential Moving Average (EMA) update function by detaching the model state_dict tensors during the EMA update process.

### 🎯 Purpose & Impact
- **Purpose:** To ensure that the gradients are not calculated or tracked during the update of EMA, improving computational efficiency and reducing potential errors.
- **Impact:** Users should experience more stable training as this change will prevent inadvertent influence on gradient calculations from the EMA update step. This contributes to more reliable convergence and performance of the YOLOv5 models. 🚀