### PR TITLE
zero-mAP fix 3

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -412,7 +412,6 @@ class ModelEMA:
         for p in self.ema.parameters():
             p.requires_grad_(False)
 
-    @smart_inference_mode()
     def update(self, model):
         # Update EMA parameters
         self.updates += 1

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -422,7 +422,7 @@ class ModelEMA:
             if v.dtype.is_floating_point:  # true for FP16 and FP32
                 v *= d
                 v += (1 - d) * msd[k].detach()
-        assert v.dtype == msd[k].dtype == torch.float32, f'EMA {v.dtype} and model {msd[k]} must be updated in FP32'
+        assert v.dtype == msd[k].detach().dtype == torch.float32, f'EMA {v.dtype} and model {msd[k]} must be updated in FP32'
 
     def update_attr(self, model, include=(), exclude=('process_group', 'reducer')):
         # Update EMA attributes

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -422,8 +422,7 @@ class ModelEMA:
             if v.dtype.is_floating_point:  # true for FP16 and FP32
                 v *= d
                 v += (1 - d) * msd[k].detach()
-        assert v.dtype == msd[k].detach(
-        ).dtype == torch.float32, f'EMA {v.dtype} and model {msd[k]} must be updated in FP32'
+        assert v.dtype == msd[k].detach().dtype == torch.float32, f'EMA {v.dtype} and model {msd[k]} must both be FP32'
 
     def update_attr(self, model, include=(), exclude=('process_group', 'reducer')):
         # Update EMA attributes

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -422,7 +422,8 @@ class ModelEMA:
             if v.dtype.is_floating_point:  # true for FP16 and FP32
                 v *= d
                 v += (1 - d) * msd[k].detach()
-        assert v.dtype == msd[k].detach().dtype == torch.float32, f'EMA {v.dtype} and model {msd[k]} must be updated in FP32'
+        assert v.dtype == msd[k].detach(
+        ).dtype == torch.float32, f'EMA {v.dtype} and model {msd[k]} must be updated in FP32'
 
     def update_attr(self, model, include=(), exclude=('process_group', 'reducer')):
         # Update EMA attributes


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in EMA update mechanism within the YOLOv5 model utility functions.

### 📊 Key Changes
- Removed the `@smart_inference_mode()` decorator from the EMA update function.
- Modified the assert statement in EMA update to ensure the data types of the model and EMA weights are both in FP32 after detaching the model state dict.

### 🎯 Purpose & Impact
- 🛠️ The removal of `@smart_inference_mode()` likely aims to improve code simplicity and reduce potential issues with context management that might have occurred.
- 🧐 Adjusting the assertion for FP32 consistency helps to enforce that EMA updates are processed in a standard floating-point format, ensuring compatibility and consistency in calculations.
- ✅ These changes can lead to a more robust EMA update process, potentially improving the model's performance and reliability for the end-users.
  
Note: EMA stands for Exponential Moving Average, which is a technique to update model weights to stabilize training. FP32 refers to 32-bit floating-point data type.