### PR TITLE
De-thread TensorBoard graph logging

### DIFF
--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -11,7 +11,7 @@ import pkg_resources as pkg
 import torch
 from torch.utils.tensorboard import SummaryWriter
 
-from utils.general import colorstr, cv2, threaded
+from utils.general import colorstr, cv2
 from utils.loggers.clearml.clearml_utils import ClearmlLogger
 from utils.loggers.wandb.wandb_utils import WandbLogger
 from utils.plots import plot_images, plot_labels, plot_results

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -292,7 +292,6 @@ class GenericLogger:
             wandb.log_artifact(art)
 
 
-@threaded
 def log_tensorboard_graph(tb, model, imgsz=(640, 640)):
     # Log model graph to TensorBoard
     try:


### PR DESCRIPTION
Issues with Classification models

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging functionalities in Ultralytics YOLOv5.

### 📊 Key Changes
- Removed the `threaded` decorator from the TensorFlow graph logging function.
- Simplified import statements by removing unnecessary references.

### 🎯 Purpose & Impact
- This PR aims to streamline the logging process by removing the `threaded` decorator, which may improve the stability and predictability of the TensorFlow graph logging.
- Users may experience more reliable logging performance without the complexity of multi-threading, potentially leading to better debugging and visualization experiences in TensorBoard. 🌐🔍