### PR TITLE
Comment dataloader `generator`

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -137,8 +137,8 @@ def create_dataloader(path,
     nw = min([os.cpu_count() // max(nd, 1), batch_size if batch_size > 1 else 0, workers])  # number of workers
     sampler = None if rank == -1 else distributed.DistributedSampler(dataset, shuffle=shuffle)
     loader = DataLoader if image_weights else InfiniteDataLoader  # only DataLoader allows for attribute updates
-    generator = torch.Generator()
-    generator.manual_seed(0)
+    # generator = torch.Generator()
+    # generator.manual_seed(0)
     return loader(dataset,
                   batch_size=batch_size,
                   shuffle=shuffle and sampler is None,
@@ -146,9 +146,8 @@ def create_dataloader(path,
                   sampler=sampler,
                   pin_memory=True,
                   collate_fn=LoadImagesAndLabels.collate_fn4 if quad else LoadImagesAndLabels.collate_fn,
-                  worker_init_fn=seed_worker,
-                  generator=generator), dataset
-
+                  # generator=generator,
+                  worker_init_fn=seed_worker), dataset
 
 class InfiniteDataLoader(dataloader.DataLoader):
     """ Dataloader that reuses workers

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -139,15 +139,17 @@ def create_dataloader(path,
     loader = DataLoader if image_weights else InfiniteDataLoader  # only DataLoader allows for attribute updates
     # generator = torch.Generator()
     # generator.manual_seed(0)
-    return loader(dataset,
-                  batch_size=batch_size,
-                  shuffle=shuffle and sampler is None,
-                  num_workers=nw,
-                  sampler=sampler,
-                  pin_memory=True,
-                  collate_fn=LoadImagesAndLabels.collate_fn4 if quad else LoadImagesAndLabels.collate_fn,
-                  # generator=generator,
-                  worker_init_fn=seed_worker), dataset
+    return loader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=shuffle and sampler is None,
+        num_workers=nw,
+        sampler=sampler,
+        pin_memory=True,
+        collate_fn=LoadImagesAndLabels.collate_fn4 if quad else LoadImagesAndLabels.collate_fn,
+        # generator=generator,
+        worker_init_fn=seed_worker), dataset
+
 
 class InfiniteDataLoader(dataloader.DataLoader):
     """ Dataloader that reuses workers


### PR DESCRIPTION
@AyushExel @Laughing-q detection training experiment tracked in https://wandb.ai/glenn-jocher/test-generator

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of data loader initialization for better efficiency and training stability.

### 📊 Key Changes
- Removed initialization of a separate `torch.Generator` for the data loader.
- Commented out `manual_seed(0)` setting, which was previously used to seed the generator.

### 🎯 Purpose & Impact
- 🔨 **Improves Efficiency**: By not initializing an unnecessary `torch.Generator`, the creation of the data loader becomes slightly more efficient.
- 🛠️ **Training Reproducibility**: Previously, every data loader was being seeded with the same seed (zero), now the behavior aligns with PyTorch's default, introducing potential variability in data loading for different runs. This could impact the reproducibility of training results unless managed externally.
- 🚀 **Potential Impact**: Users might notice subtle differences in how data is loaded during training, which could affect the overall training performance and results. It's a small change, but one that aligns the data loading process more closely with typical PyTorch practices.