### PR TITLE
Fix confidence threshold for ClearML debug images

### DIFF
--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -141,10 +141,10 @@ class ClearmlLogger:
                     color = colors(i)
 
                     class_name = class_names[int(class_nr)]
-                    confidence = round(float(conf) * 100, 2)
-                    label = f"{class_name}: {confidence}%"
+                    confidence_percentage = round(float(conf) * 100, 2)
+                    label = f"{class_name}: {confidence_percentage}%"
 
-                    if confidence > conf_threshold:
+                    if conf > conf_threshold:
                         annotator.rectangle(box.cpu().numpy(), outline=color)
                         annotator.box_label(box.cpu().numpy(), label=label, color=color)
 

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -122,7 +122,7 @@ class ClearmlLogger:
                                                     local_path=str(f),
                                                     iteration=iteration)
 
-    def log_image_with_boxes(self, image_path, boxes, class_names, image, conf_threshold=0.25):
+    def log_image_with_boxes(self, image_path, boxes, class_names, image, conf_threshold=25):
         """
         Draw the bounding boxes on a single image and report the result as a ClearML debug sample.
 

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -122,7 +122,7 @@ class ClearmlLogger:
                                                     local_path=str(f),
                                                     iteration=iteration)
 
-    def log_image_with_boxes(self, image_path, boxes, class_names, image, conf_threshold=25):
+    def log_image_with_boxes(self, image_path, boxes, class_names, image, conf_threshold=0.25):
         """
         Draw the bounding boxes on a single image and report the result as a ClearML debug sample.
 


### PR DESCRIPTION
The confidence is converted to a percentage on line 144, but it is being compared to a default conf_threshold value of a decimal value instead of percent value.

Signed-off-by: HighMans <42877729+HighMans@users.noreply.github.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved variable naming and fixed confidence threshold logic in ClearML image logging.

### 📊 Key Changes
- Renamed the `confidence` variable to `confidence_percentage` for better clarity.
- Corrected the threshold comparison to use the raw confidence value (`conf`) instead of the percentage.

### 🎯 Purpose & Impact
- 👍 Enhances code readability by making variable names more descriptive.
- 🐞 Fixes an issue where the confidence percentage was incorrectly used in the threshold comparison, ensuring only relevant detections are logged. This can lead to more accurate debugging and visualization in ClearML.