### PR TITLE
ClearML's set_report_period's time is defined in minutes not seconds.

### DIFF
--- a/utils/loggers/clearml/hpo.py
+++ b/utils/loggers/clearml/hpo.py
@@ -69,7 +69,7 @@ optimizer = HyperParameterOptimizer(
 )
 
 # report every 10 seconds, this is way too often, but we are testing here
-optimizer.set_report_period(10/60)
+optimizer.set_report_period(10 / 60)
 # You can also use the line below instead to run all the optimizer tasks locally, without using queues or agent
 # an_optimizer.start_locally(job_complete_callback=job_complete_callback)
 # set the time limit for the optimization process (2 hours)

--- a/utils/loggers/clearml/hpo.py
+++ b/utils/loggers/clearml/hpo.py
@@ -69,7 +69,7 @@ optimizer = HyperParameterOptimizer(
 )
 
 # report every 10 seconds, this is way too often, but we are testing here
-optimizer.set_report_period(10)
+optimizer.set_report_period(10/60)
 # You can also use the line below instead to run all the optimizer tasks locally, without using queues or agent
 # an_optimizer.start_locally(job_complete_callback=job_complete_callback)
 # set the time limit for the optimization process (2 hours)


### PR DESCRIPTION
https://clear.ml/docs/latest/docs/references/sdk/hpo_optimization_hyperparameteroptimizer/#set_report_period

set_report_period function takes in time in terms of minutes, not seconds.

Signed-off-by: HighMans <42877729+HighMans@users.noreply.github.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization reporting frequency adjustment for ClearML Hyperparameter Optimization (HPO)

### 📊 Key Changes
- Changed the report period in ClearML's hyperparameter optimization from 10 seconds to every 10/60 minutes (10 seconds).

### 🎯 Purpose & Impact
- The update reduces the reporting frequency to a more reasonable interval for real-world applications.
- This can lead to less network traffic and reduced logging overhead, potentially improving the performance and usability of the HPO process for users.