### PR TITLE
Skip AMP check on MPS

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -535,8 +535,8 @@ def check_amp(model):
 
     prefix = colorstr('AMP: ')
     device = next(model.parameters()).device  # get model device
-    if device.type == 'cpu':
-        return False  # AMP disabled on CPU
+    if device.type in ('cpu', 'mps'):
+        return False  # AMP only used on CUDA devices
     f = ROOT / 'data' / 'images' / 'bus.jpg'  # image to check
     im = f if f.exists() else 'https://ultralytics.com/images/bus.jpg' if check_online() else np.ones((640, 640, 3))
     try:


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved device compatibility for Automatic Mixed Precision (AMP) in YOLOv5.

### 📊 Key Changes
- AMP is now explicitly disabled on both CPU and Metal Performance Shaders (MPS) devices.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To prevent users from attempting to use AMP on devices that don't support it, which are now specified as CPU and MPS, enhancing code robustness.
- 💥 **Impact**: Ensures better stability and clarity for users working on different hardware, as attempting to use AMP on unsupported devices would likely result in errors or suboptimal performance.