### PR TITLE
Comment `protobuf` in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ scipy>=1.4.1
 torch>=1.7.0
 torchvision>=0.8.1
 tqdm>=4.64.0
-protobuf<=3.20.1  # https://github.com/ultralytics/yolov5/issues/8012
+# protobuf<=3.20.1  # https://github.com/ultralytics/yolov5/issues/8012
 
 # Logging -------------------------------------
 tensorboard>=2.4.1


### PR DESCRIPTION
The low package version is causing conflicts among other dependencies, commenting it causes no ill effects in CI so this should be fine.

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improving compatibility by adjusting protobuf requirement.

### 📊 Key Changes
- The specific version restriction for `protobuf` has been removed from the `requirements.txt` file.

### 🎯 Purpose & Impact
- 🎈 The purpose is to avoid potential conflicts with other packages that require different `protobuf` versions, enhancing the flexibility of the YOLOv5 installation.
- 🔗 This change could impact users by making it easier to integrate YOLOv5 with other software stacks that might need a newer version of `protobuf`.
- 👍 Users no longer need to downgrade `protobuf` manually for compatibility with YOLOv5, which streamlines the setup process.