### PR TITLE
AutoBatch protect from extreme batch sizes

### DIFF
--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -60,8 +60,8 @@ def autobatch(model, imgsz=640, fraction=0.9, batch_size=16):
         i = results.index(None)  # first fail index
         if b >= batch_sizes[i]:  # y intercept above failure point
             b = batch_sizes[max(i - 1, 0)]  # select prior safe point
-    if b < 1:  # zero or negative batch size
-        b = 16
+    if b < 1 or b > 1024:  # b outside of safe range
+        b = batch_size
         LOGGER.warning(f'{prefix}WARNING: ⚠️ CUDA anomaly detected, recommend restart environment and retry command.')
 
     fraction = np.polyval(p, b) / t  # actual fraction predicted


### PR DESCRIPTION
If < 1 or > 1024 set output to default batch size 16.

May partially address https://github.com/ultralytics/yolov5/issues/9156

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved range checking for auto-batching to ensure optimal batch size within safe limits.

### 📊 Key Changes 
- Added an upper limit check to prevent the batch size from exceeding 1024.
- The batch size now defaults to the user-defined `batch_size` if the calculated batch size falls outside the acceptable range (below 1 or above 1024).

### 🎯 Purpose & Impact 
- Prevents unrealistic batch sizes that could cause memory issues or degrade performance.
- Offers more stable and reliable auto-batching by adhering to a reasonable pre-set or user-defined default batch size.
- Ensures the auto-batching feature provides a balance between speed and resource usage, leading to potentially improved user experience. 🔄