### PR TITLE
Default AutoBatch 0.8 fraction

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -47,7 +47,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
                 model = DetectMultiBackend(path, device=device, fuse=autoshape)  # detection model
                 if autoshape:
                     if model.pt and isinstance(model.model, ClassificationModel):
-                        LOGGER.warning('WARNING: YOLOv5 v6.2 ClassificationModel is not yet AutoShape compatible. '
+                        LOGGER.warning('WARNING: ⚠️ YOLOv5 v6.2 ClassificationModel is not yet AutoShape compatible. '
                                        'You must pass torch tensors in BCHW to this model, i.e. shape(1,3,224,224).')
                     else:
                         model = AutoShape(model)  # for file/URI/PIL/cv2/np inputs and NMS

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -18,7 +18,7 @@ def check_train_batch_size(model, imgsz=640, amp=True):
         return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
 
 
-def autobatch(model, imgsz=640, fraction=0.9, batch_size=16):
+def autobatch(model, imgsz=640, fraction=0.8, batch_size=16):
     # Automatically estimate best batch size to use `fraction` of available CUDA memory
     # Usage:
     #     import torch


### PR DESCRIPTION
Should be more stable, ran into CUDA OOM on validation when train utilization is too high.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced compatibility and optimization of batch size for memory usage in YOLOv5 models.

### 📊 Key Changes
- Adjusted warning for YOLOv5 v6.2 ClassificationModel to clarify its non-compatibility with AutoShape.
- Modified the default memory fraction used in the `autobatch` function from 0.9 to 0.8.

### 🎯 Purpose & Impact
- The update provides clearer guidance to users attempting to use AutoShape with the ClassificationModel, preventing confusion and potential errors. 🛑
- Reducing the default memory fraction allows for larger models or datasets by lowering the risk of running out of CUDA memory, leading to fewer crashes and enhanced performance on systems with limited resources. 📈🖥️