### PR TITLE
Remove usage of `pathlib.Path.unlink(missing_ok=...)`

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -917,7 +917,9 @@ def autosplit(path=DATASETS_DIR / 'coco128/images', weights=(0.9, 0.1, 0.0), ann
     indices = random.choices([0, 1, 2], weights=weights, k=n)  # assign each image to a split
 
     txt = ['autosplit_train.txt', 'autosplit_val.txt', 'autosplit_test.txt']  # 3 txt files
-    [(path.parent / x).unlink(missing_ok=True) for x in txt]  # remove existing
+    for x in txt:
+        if (path.parent / x).exists():
+            (path.parent / x).unlink()  # remove existing
 
     print(f'Autosplitting images from {path}' + ', using *.txt labeled images only' * annotated_only)
     for i, img in tqdm(zip(indices, files), total=n):


### PR DESCRIPTION
Argument `missing_ok` in `pathlib.Path.unlink()` has only been introduced since Python 3.8, leading to errors when using Python 3.7.



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved file existence checks before deletion in various utility functions.

### 📊 Key Changes
- Modified `autosplit` function to explicitly check for file existence before attempting to delete auto-generated .txt files.
- Updated `safe_download` function to verify file presence before deletion to prevent possible file-not-found errors.
- Changed `gdrive_download` function to incorporate file presence verification ahead of file and cookie deletions.

### 🎯 Purpose & Impact
- The updates prevent potential errors that could arise when attempting to delete files that do not exist.
- Users will experience smoother operation without encountering exceptions related to file deletion, especially in environments that may not support the `missing_ok` parameter.
- Overall reliability of the download and autosplit processes within the repository is enhanced, leading to more robust data preparation and file handling operations.