### PR TITLE
Add PaddlePaddle export and inference

### DIFF
--- a/export.py
+++ b/export.py
@@ -184,7 +184,7 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
 def export_paddle(file, metadata, prefix=colorstr('PaddlePaddle:')):
     # YOLOv5 Paddle export
     os.environ["CUDA_VISIBLE_DEVICES"] = '0'
-    check_requirements(('x2paddle',))
+    check_requirements(('paddlepaddle', x2paddle'))
     import x2paddle
 
     LOGGER.info(f'\n{prefix} starting export with X2Paddle {x2paddle.__version__}...')

--- a/export.py
+++ b/export.py
@@ -74,13 +74,19 @@ from utils.torch_utils import select_device, smart_inference_mode
 
 def export_formats():
     # YOLOv5 export formats
-    x = [['PyTorch', '-', '.pt', True, True], ['TorchScript', 'torchscript', '.torchscript', True, True],
-         ['ONNX', 'onnx', '.onnx', True, True], ['OpenVINO', 'openvino', '_openvino_model', True, False],
-         ['TensorRT', 'engine', '.engine', False, True], ['CoreML', 'coreml', '.mlmodel', True, False],
-         ['TensorFlow SavedModel', 'saved_model', '_saved_model', True, True],
-         ['TensorFlow GraphDef', 'pb', '.pb', True, True], ['TensorFlow Lite', 'tflite', '.tflite', True, False],
-         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
-         ['TensorFlow.js', 'tfjs', '_web_model', False, False], ['PaddlePaddle', 'paddle', '_paddle_model', True, True]]
+    x = [
+        ['PyTorch', '-', '.pt', True, True],
+        ['TorchScript', 'torchscript', '.torchscript', True, True],
+        ['ONNX', 'onnx', '.onnx', True, True],
+        ['OpenVINO', 'openvino', '_openvino_model', True, False],
+        ['TensorRT', 'engine', '.engine', False, True],
+        ['CoreML', 'coreml', '.mlmodel', True, False],
+        ['TensorFlow SavedModel', 'saved_model', '_saved_model', True, True],
+        ['TensorFlow GraphDef', 'pb', '.pb', True, True],
+        ['TensorFlow Lite', 'tflite', '.tflite', True, False],
+        ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
+        ['TensorFlow.js', 'tfjs', '_web_model', False, False],
+        ['PaddlePaddle', 'paddle', '_paddle_model', True, True],]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'CPU', 'GPU'])
 
 
@@ -438,9 +444,9 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}}}', r'{"outputs": {"Identity": {"name": "Identity"}, '
-            r'"Identity_1": {"name": "Identity_1"}, '
-            r'"Identity_2": {"name": "Identity_2"}, '
-            r'"Identity_3": {"name": "Identity_3"}}}', json)
+                                                           r'"Identity_1": {"name": "Identity_1"}, '
+                                                           r'"Identity_2": {"name": "Identity_2"}, '
+                                                           r'"Identity_3": {"name": "Identity_3"}}}', json)
         j.write(subst)
     return f, None
 
@@ -513,7 +519,7 @@ def run(
     LOGGER.info(f"\n{colorstr('PyTorch:')} starting from {file} with output shape {shape} ({file_size(file):.1f} MB)")
 
     # Exports
-    f = [''] * 10  # exported filenames
+    f = [''] * (len(fmts) - 1)  # exported filenames
     warnings.filterwarnings(action='ignore', category=torch.jit.TracerWarning)  # suppress TracerWarning
     if jit:  # TorchScript
         f[0], _ = export_torchscript(model, im, file, optimize)

--- a/export.py
+++ b/export.py
@@ -75,20 +75,13 @@ from utils.torch_utils import select_device, smart_inference_mode
 
 def export_formats():
     # YOLOv5 export formats
-    x = [
-        ['PyTorch', '-', '.pt', True, True],
-        ['TorchScript', 'torchscript', '.torchscript', True, True],
-        ['ONNX', 'onnx', '.onnx', True, True],
-        ['OpenVINO', 'openvino', '_openvino_model', True, False],
-        ['TensorRT', 'engine', '.engine', False, True],
-        ['CoreML', 'coreml', '.mlmodel', True, False],
-        ['TensorFlow SavedModel', 'saved_model', '_saved_model', True, True],
-        ['TensorFlow GraphDef', 'pb', '.pb', True, True],
-        ['TensorFlow Lite', 'tflite', '.tflite', True, False],
-        ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
-        ['TensorFlow.js', 'tfjs', '_web_model', False, False],
-        ['Paddle', 'pd', '_pd_model', True, True]
-    ]
+    x = [['PyTorch', '-', '.pt', True, True], ['TorchScript', 'torchscript', '.torchscript', True, True],
+         ['ONNX', 'onnx', '.onnx', True, True], ['OpenVINO', 'openvino', '_openvino_model', True, False],
+         ['TensorRT', 'engine', '.engine', False, True], ['CoreML', 'coreml', '.mlmodel', True, False],
+         ['TensorFlow SavedModel', 'saved_model', '_saved_model', True, True],
+         ['TensorFlow GraphDef', 'pb', '.pb', True, True], ['TensorFlow Lite', 'tflite', '.tflite', True, False],
+         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
+         ['TensorFlow.js', 'tfjs', '_web_model', False, False], ['Paddle', 'pd', '_pd_model', True, True]]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'CPU', 'GPU'])
 
 
@@ -192,7 +185,11 @@ def export_paddle(model, file, prefix=colorstr('Paddle:')):
 
     LOGGER.info(f'\n{prefix} starting export with X2Paddle {x2paddle.__version__}...')
     f = str(file).replace('.pt', f'_pd_model{os.sep}')
-    x2paddle.convert.onnx2paddle(file.with_suffix('.onnx'), f, convert_to_lite=False, lite_valid_places="arm", lite_model_type="naive_buffer")
+    x2paddle.convert.onnx2paddle(file.with_suffix('.onnx'),
+                                 f,
+                                 convert_to_lite=False,
+                                 lite_valid_places="arm",
+                                 lite_model_type="naive_buffer")
     with open(Path(f) / file.with_suffix('.yaml').name, 'w') as g:
         yaml.dump({'stride': int(max(model.stride)), 'names': model.names}, g)  # add metadata.yaml
     return f, None
@@ -208,7 +205,7 @@ def export_openvino(model, file, half, prefix=colorstr('OpenVINO:')):
     f = str(file).replace('.pt', f'_openvino_model{os.sep}')
 
     cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f} --data_type {'FP16' if half else 'FP32'}"
-    subprocess.run(cmd.split(),check=True,env=os.environ)  # export
+    subprocess.run(cmd.split(), check=True, env=os.environ)  # export
     with open(Path(f) / file.with_suffix('.yaml').name, 'w') as g:
         yaml.dump({'stride': int(max(model.stride)), 'names': model.names}, g)  # add metadata.yaml
     return f, None
@@ -483,7 +480,7 @@ def run(
     fmts = tuple(export_formats()['Argument'][1:])  # --include arguments
     flags = [x in include for x in fmts]
     assert sum(flags) == len(include), f'ERROR: Invalid --include {include}, valid --include arguments are {fmts}'
-    jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs,paddle = flags  # export booleans
+    jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle = flags  # export booleans
     file = Path(url2file(weights) if str(weights).startswith(('http:/', 'https:/')) else weights)  # PyTorch weights
 
     # Load PyTorch model
@@ -532,7 +529,7 @@ def run(
     if coreml:
         f[4], _ = export_coreml(model, im, file, int8, half)
     if paddle:
-        f[5],_ =export_paddle(model, file)
+        f[5], _ = export_paddle(model, file)
 
     # TensorFlow Exports
     if any((saved_model, pb, tflite, edgetpu, tfjs)):

--- a/export.py
+++ b/export.py
@@ -519,7 +519,7 @@ def run(
     LOGGER.info(f"\n{colorstr('PyTorch:')} starting from {file} with output shape {shape} ({file_size(file):.1f} MB)")
 
     # Exports
-    f = [''] * (len(fmts) - 1)  # exported filenames
+    f = [''] * len(fmts)  # exported filenames
     warnings.filterwarnings(action='ignore', category=torch.jit.TracerWarning)  # suppress TracerWarning
     if jit:  # TorchScript
         f[0], _ = export_torchscript(model, im, file, optimize)

--- a/export.py
+++ b/export.py
@@ -523,7 +523,7 @@ def run(
         f[0], _ = export_torchscript(model, im, file, optimize)
     if engine:  # TensorRT required before ONNX
         f[1], _ = export_engine(model, im, file, half, dynamic, simplify, workspace, verbose)
-    if onnx or xml or paddle:  # OpenVINO and Paddle require ONNX
+    if onnx or xml:  # OpenVINO requires ONNX
         f[2], _ = export_onnx(model, im, file, opset, train, dynamic, simplify)
     if xml:  # OpenVINO
         f[3], _ = export_openvino(file, metadata, half)

--- a/export.py
+++ b/export.py
@@ -181,22 +181,6 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
 
 
 @try_export
-def export_paddle(model, im, file, metadata, prefix=colorstr('PaddlePaddle:')):
-    # YOLOv5 Paddle export
-    os.environ["CUDA_VISIBLE_DEVICES"] = '0'
-    check_requirements(('paddlepaddle', 'x2paddle'))
-    import x2paddle
-    from x2paddle.convert import pytorch2paddle
-
-    LOGGER.info(f'\n{prefix} starting export with X2Paddle {x2paddle.__version__}...')
-    f = str(file).replace('.pt', f'_paddle_model{os.sep}')
-    pytorch2paddle(module=model, save_dir=f, jit_type='trace', input_examples=[im])  # export
-
-    yaml_save(Path(f) / file.with_suffix('.yaml').name, metadata)  # add metadata.yaml
-    return f, None
-
-
-@try_export
 def export_openvino(file, metadata, half, prefix=colorstr('OpenVINO:')):
     # YOLOv5 OpenVINO export
     check_requirements(('openvino-dev',))  # requires openvino-dev: https://pypi.org/project/openvino-dev/
@@ -207,6 +191,21 @@ def export_openvino(file, metadata, half, prefix=colorstr('OpenVINO:')):
 
     cmd = f"mo --input_model {file.with_suffix('.onnx')} --output_dir {f} --data_type {'FP16' if half else 'FP32'}"
     subprocess.run(cmd.split(), check=True, env=os.environ)  # export
+    yaml_save(Path(f) / file.with_suffix('.yaml').name, metadata)  # add metadata.yaml
+    return f, None
+
+
+@try_export
+def export_paddle(model, im, file, metadata, prefix=colorstr('PaddlePaddle:')):
+    # YOLOv5 Paddle export
+    check_requirements(('paddlepaddle', 'x2paddle'))
+    import x2paddle
+    from x2paddle.convert import pytorch2paddle
+
+    LOGGER.info(f'\n{prefix} starting export with X2Paddle {x2paddle.__version__}...')
+    f = str(file).replace('.pt', f'_paddle_model{os.sep}')
+    
+    pytorch2paddle(module=model, save_dir=f, jit_type='trace', input_examples=[im])  # export
     yaml_save(Path(f) / file.with_suffix('.yaml').name, metadata)  # add metadata.yaml
     return f, None
 

--- a/export.py
+++ b/export.py
@@ -86,7 +86,7 @@ def export_formats():
         ['TensorFlow Lite', 'tflite', '.tflite', True, False],
         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
         ['TensorFlow.js', 'tfjs', '_web_model', False, False],
-        ['PaddlePaddle', 'paddle', '_paddle_model', True, True], ]
+        ['PaddlePaddle', 'paddle', '_paddle_model', True, True],]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'CPU', 'GPU'])
 
 
@@ -190,10 +190,7 @@ def export_paddle(model, im, file, metadata, prefix=colorstr('PaddlePaddle:')):
 
     LOGGER.info(f'\n{prefix} starting export with X2Paddle {x2paddle.__version__}...')
     f = str(file).replace('.pt', f'_paddle_model{os.sep}')
-    pytorch2paddle(module=model,
-                   save_dir=f,
-                   jit_type="trace",
-                   input_examples=[im])  # export
+    pytorch2paddle(module=model, save_dir=f, jit_type="trace", input_examples=[im])  # export
 
     yaml_save(Path(f) / file.with_suffix('.yaml').name, metadata)  # add metadata.yaml
     return f, None
@@ -445,9 +442,9 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}}}', r'{"outputs": {"Identity": {"name": "Identity"}, '
-                                                           r'"Identity_1": {"name": "Identity_1"}, '
-                                                           r'"Identity_2": {"name": "Identity_2"}, '
-                                                           r'"Identity_3": {"name": "Identity_3"}}}', json)
+            r'"Identity_1": {"name": "Identity_1"}, '
+            r'"Identity_2": {"name": "Identity_2"}, '
+            r'"Identity_3": {"name": "Identity_3"}}}', json)
         j.write(subst)
     return f, None
 

--- a/export.py
+++ b/export.py
@@ -74,19 +74,13 @@ from utils.torch_utils import select_device, smart_inference_mode
 
 def export_formats():
     # YOLOv5 export formats
-    x = [
-        ['PyTorch', '-', '.pt', True, True],
-        ['TorchScript', 'torchscript', '.torchscript', True, True],
-        ['ONNX', 'onnx', '.onnx', True, True],
-        ['OpenVINO', 'openvino', '_openvino_model', True, False],
-        ['TensorRT', 'engine', '.engine', False, True],
-        ['CoreML', 'coreml', '.mlmodel', True, False],
-        ['TensorFlow SavedModel', 'saved_model', '_saved_model', True, True],
-        ['TensorFlow GraphDef', 'pb', '.pb', True, True],
-        ['TensorFlow Lite', 'tflite', '.tflite', True, False],
-        ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
-        ['TensorFlow.js', 'tfjs', '_web_model', False, False],
-        ['PaddlePaddle', 'paddle', '_paddle_model', True, True]]
+    x = [['PyTorch', '-', '.pt', True, True], ['TorchScript', 'torchscript', '.torchscript', True, True],
+         ['ONNX', 'onnx', '.onnx', True, True], ['OpenVINO', 'openvino', '_openvino_model', True, False],
+         ['TensorRT', 'engine', '.engine', False, True], ['CoreML', 'coreml', '.mlmodel', True, False],
+         ['TensorFlow SavedModel', 'saved_model', '_saved_model', True, True],
+         ['TensorFlow GraphDef', 'pb', '.pb', True, True], ['TensorFlow Lite', 'tflite', '.tflite', True, False],
+         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
+         ['TensorFlow.js', 'tfjs', '_web_model', False, False], ['PaddlePaddle', 'paddle', '_paddle_model', True, True]]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'CPU', 'GPU'])
 
 
@@ -444,9 +438,9 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}}}', r'{"outputs": {"Identity": {"name": "Identity"}, '
-                                                           r'"Identity_1": {"name": "Identity_1"}, '
-                                                           r'"Identity_2": {"name": "Identity_2"}, '
-                                                           r'"Identity_3": {"name": "Identity_3"}}}', json)
+            r'"Identity_1": {"name": "Identity_1"}, '
+            r'"Identity_2": {"name": "Identity_2"}, '
+            r'"Identity_3": {"name": "Identity_3"}}}', json)
         j.write(subst)
     return f, None
 

--- a/export.py
+++ b/export.py
@@ -183,17 +183,18 @@ def export_onnx(model, im, file, opset, train, dynamic, simplify, prefix=colorst
 @try_export
 def export_paddle(file, metadata, prefix=colorstr('PaddlePaddle:')):
     # YOLOv5 Paddle export
-    os.environ["CUDA_VISIBLE_DEVICES"] = '0'
-    check_requirements(('paddlepaddle', x2paddle'))
+    check_requirements(('paddlepaddle', 'x2paddle'))
     import x2paddle
+    from x2paddle.convert import onnx2paddle
 
     LOGGER.info(f'\n{prefix} starting export with X2Paddle {x2paddle.__version__}...')
     f = str(file).replace('.pt', f'_paddle_model{os.sep}')
-    x2paddle.convert.onnx2paddle(file.with_suffix('.onnx'),
-                                 f,
-                                 convert_to_lite=False,
-                                 lite_valid_places="arm",
-                                 lite_model_type="naive_buffer")  # export
+    onnx2paddle(file.with_suffix('.onnx'),
+                f,
+                convert_to_lite=False,
+                lite_valid_places="arm",
+                lite_model_type="naive_buffer")  # export
+
     yaml_save(Path(f) / file.with_suffix('.yaml').name, metadata)  # add metadata.yaml
     return f, None
 

--- a/export.py
+++ b/export.py
@@ -190,7 +190,7 @@ def export_paddle(model, im, file, metadata, prefix=colorstr('PaddlePaddle:')):
 
     LOGGER.info(f'\n{prefix} starting export with X2Paddle {x2paddle.__version__}...')
     f = str(file).replace('.pt', f'_paddle_model{os.sep}')
-    pytorch2paddle(module=model, save_dir=f, jit_type="trace", input_examples=[im])  # export
+    pytorch2paddle(module=model, save_dir=f, jit_type='trace', input_examples=[im])  # export
 
     yaml_save(Path(f) / file.with_suffix('.yaml').name, metadata)  # add metadata.yaml
     return f, None

--- a/export.py
+++ b/export.py
@@ -204,7 +204,7 @@ def export_paddle(model, im, file, metadata, prefix=colorstr('PaddlePaddle:')):
 
     LOGGER.info(f'\n{prefix} starting export with X2Paddle {x2paddle.__version__}...')
     f = str(file).replace('.pt', f'_paddle_model{os.sep}')
-    
+
     pytorch2paddle(module=model, save_dir=f, jit_type='trace', input_examples=[im])  # export
     yaml_save(Path(f) / file.with_suffix('.yaml').name, metadata)  # add metadata.yaml
     return f, None

--- a/export.py
+++ b/export.py
@@ -444,9 +444,9 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}}}', r'{"outputs": {"Identity": {"name": "Identity"}, '
-                                                           r'"Identity_1": {"name": "Identity_1"}, '
-                                                           r'"Identity_2": {"name": "Identity_2"}, '
-                                                           r'"Identity_3": {"name": "Identity_3"}}}', json)
+            r'"Identity_1": {"name": "Identity_1"}, '
+            r'"Identity_2": {"name": "Identity_2"}, '
+            r'"Identity_3": {"name": "Identity_3"}}}', json)
         j.write(subst)
     return f, None
 

--- a/models/common.py
+++ b/models/common.py
@@ -450,12 +450,11 @@ class DetectMultiBackend(nn.Module):
             raise NotImplementedError('ERROR: YOLOv5 TF.js inference is not supported')
         elif paddle:  # PaddlePaddle
             LOGGER.info(f'Loading {w} for PaddlePaddle inference...')
-            check_requirements(('paddlepaddle-gpu' if cuda else 'paddlepaddle'),)
+            check_requirements('paddlepaddle-gpu' if cuda else 'paddlepaddle')
             import paddle.inference as pdi
             if not Path(w).is_file():  # if not *.pdmodel
                 w = next(Path(w).rglob('*.pdmodel'))  # get *.xml file from *_openvino_model dir
             weights = Path(w).with_suffix('.pdiparams')
-            cuda = torch.cuda.is_available() and device.type != 'cpu'
             config = pdi.Config(str(w), str(weights))
             if cuda:
                 config.enable_use_gpu(memory_pool_init_size_mb=2048, device_id=0)

--- a/models/common.py
+++ b/models/common.py
@@ -448,7 +448,7 @@ class DetectMultiBackend(nn.Module):
             raise NotImplementedError('ERROR: YOLOv5 TF.js inference is not supported')
         elif paddle:  # PaddlePaddle
             LOGGER.info(f'Loading {w} for PaddlePaddle inference...')
-            check_requirements('paddlepaddle-gpu' if cuda else 'paddlepaddle',)
+            check_requirements(('paddlepaddle-gpu' if cuda else 'paddlepaddle'),)
             import paddle.inference as pdi
             if not Path(w).is_file():  # if not *.pdmodel
                 w = next(Path(w).rglob('*.pdmodel'))  # get *.xml file from *_openvino_model dir

--- a/models/common.py
+++ b/models/common.py
@@ -448,15 +448,13 @@ class DetectMultiBackend(nn.Module):
             raise NotImplementedError('ERROR: YOLOv5 TF.js inference is not supported')
         elif paddle:  # PaddlePaddle
             LOGGER.info(f'Loading {w} for PaddlePaddle inference...')
-            check_requirements("paddlepaddle")
+            check_requirements(('paddlepaddle',))
             import paddle.inference as pdi
-            w = Path(w) / "inference_model"
-            if not Path(w).is_file():  # if not *.xml
-                w = next(Path(w).glob('*.pdmodel'))  # get *.xml file from *_openvino_model dir
-            model = w
+            if not Path(w).is_file():  # if not *.pdmodel
+                w = next(Path(w).rglob('*.pdmodel'))  # get *.xml file from *_openvino_model dir
             weights = Path(w).with_suffix('.pdiparams')
             cuda = torch.cuda.is_available() and device.type != 'cpu'
-            config = pdi.Config(str(model), str(weights))
+            config = pdi.Config(str(w), str(weights))
             if cuda:
                 config.enable_use_gpu(memory_pool_init_size_mb=2048, device_id=0)
             predictor = pdi.create_predictor(config)

--- a/models/common.py
+++ b/models/common.py
@@ -318,11 +318,12 @@ class DetectMultiBackend(nn.Module):
         #   TensorFlow GraphDef:            *.pb
         #   TensorFlow Lite:                *.tflite
         #   TensorFlow Edge TPU:            *_edgetpu.tflite
+        #   PaddlePaddle:                   *_paddle_model
         from models.experimental import attempt_download, attempt_load  # scoped to avoid circular import
 
         super().__init__()
         w = str(weights[0] if isinstance(weights, list) else weights)
-        pt, jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs = self._model_type(w)  # get backend
+        pt, jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle = self._model_type(w)  # type
         w = attempt_download(w)  # download if not local
         fp16 &= pt or jit or onnx or engine  # FP16
         stride = 32  # default stride
@@ -407,48 +408,49 @@ class DetectMultiBackend(nn.Module):
             LOGGER.info(f'Loading {w} for CoreML inference...')
             import coremltools as ct
             model = ct.models.MLModel(w)
-        else:  # TensorFlow (SavedModel, GraphDef, Lite, Edge TPU)
-            if saved_model:  # SavedModel
-                LOGGER.info(f'Loading {w} for TensorFlow SavedModel inference...')
-                import tensorflow as tf
-                keras = False  # assume TF1 saved_model
-                model = tf.keras.models.load_model(w) if keras else tf.saved_model.load(w)
-            elif pb:  # GraphDef https://www.tensorflow.org/guide/migrate#a_graphpb_or_graphpbtxt
-                LOGGER.info(f'Loading {w} for TensorFlow GraphDef inference...')
-                import tensorflow as tf
+        elif saved_model:  # TF SavedModel
+            LOGGER.info(f'Loading {w} for TensorFlow SavedModel inference...')
+            import tensorflow as tf
+            keras = False  # assume TF1 saved_model
+            model = tf.keras.models.load_model(w) if keras else tf.saved_model.load(w)
+        elif pb:  # GraphDef https://www.tensorflow.org/guide/migrate#a_graphpb_or_graphpbtxt
+            LOGGER.info(f'Loading {w} for TensorFlow GraphDef inference...')
+            import tensorflow as tf
 
-                def wrap_frozen_graph(gd, inputs, outputs):
-                    x = tf.compat.v1.wrap_function(lambda: tf.compat.v1.import_graph_def(gd, name=""), [])  # wrapped
-                    ge = x.graph.as_graph_element
-                    return x.prune(tf.nest.map_structure(ge, inputs), tf.nest.map_structure(ge, outputs))
+            def wrap_frozen_graph(gd, inputs, outputs):
+                x = tf.compat.v1.wrap_function(lambda: tf.compat.v1.import_graph_def(gd, name=""), [])  # wrapped
+                ge = x.graph.as_graph_element
+                return x.prune(tf.nest.map_structure(ge, inputs), tf.nest.map_structure(ge, outputs))
 
-                gd = tf.Graph().as_graph_def()  # graph_def
-                with open(w, 'rb') as f:
-                    gd.ParseFromString(f.read())
-                frozen_func = wrap_frozen_graph(gd, inputs="x:0", outputs="Identity:0")
-            elif tflite or edgetpu:  # https://www.tensorflow.org/lite/guide/python#install_tensorflow_lite_for_python
-                try:  # https://coral.ai/docs/edgetpu/tflite-python/#update-existing-tf-lite-code-for-the-edge-tpu
-                    from tflite_runtime.interpreter import Interpreter, load_delegate
-                except ImportError:
-                    import tensorflow as tf
-                    Interpreter, load_delegate = tf.lite.Interpreter, tf.lite.experimental.load_delegate,
-                if edgetpu:  # Edge TPU https://coral.ai/software/#edgetpu-runtime
-                    LOGGER.info(f'Loading {w} for TensorFlow Lite Edge TPU inference...')
-                    delegate = {
-                        'Linux': 'libedgetpu.so.1',
-                        'Darwin': 'libedgetpu.1.dylib',
-                        'Windows': 'edgetpu.dll'}[platform.system()]
-                    interpreter = Interpreter(model_path=w, experimental_delegates=[load_delegate(delegate)])
-                else:  # Lite
-                    LOGGER.info(f'Loading {w} for TensorFlow Lite inference...')
-                    interpreter = Interpreter(model_path=w)  # load TFLite model
-                interpreter.allocate_tensors()  # allocate
-                input_details = interpreter.get_input_details()  # inputs
-                output_details = interpreter.get_output_details()  # outputs
-            elif tfjs:
-                raise NotImplementedError('ERROR: YOLOv5 TF.js inference is not supported')
-            else:
-                raise NotImplementedError(f'ERROR: {w} is not a supported format')
+            gd = tf.Graph().as_graph_def()  # TF GraphDef
+            with open(w, 'rb') as f:
+                gd.ParseFromString(f.read())
+            frozen_func = wrap_frozen_graph(gd, inputs="x:0", outputs="Identity:0")
+        elif tflite or edgetpu:  # https://www.tensorflow.org/lite/guide/python#install_tensorflow_lite_for_python
+            try:  # https://coral.ai/docs/edgetpu/tflite-python/#update-existing-tf-lite-code-for-the-edge-tpu
+                from tflite_runtime.interpreter import Interpreter, load_delegate
+            except ImportError:
+                import tensorflow as tf
+                Interpreter, load_delegate = tf.lite.Interpreter, tf.lite.experimental.load_delegate,
+            if edgetpu:  # TF Edge TPU https://coral.ai/software/#edgetpu-runtime
+                LOGGER.info(f'Loading {w} for TensorFlow Lite Edge TPU inference...')
+                delegate = {
+                    'Linux': 'libedgetpu.so.1',
+                    'Darwin': 'libedgetpu.1.dylib',
+                    'Windows': 'edgetpu.dll'}[platform.system()]
+                interpreter = Interpreter(model_path=w, experimental_delegates=[load_delegate(delegate)])
+            else:  # TFLite
+                LOGGER.info(f'Loading {w} for TensorFlow Lite inference...')
+                interpreter = Interpreter(model_path=w)  # load TFLite model
+            interpreter.allocate_tensors()  # allocate
+            input_details = interpreter.get_input_details()  # inputs
+            output_details = interpreter.get_output_details()  # outputs
+        elif tfjs:  # TF.js
+            raise NotImplementedError('ERROR: YOLOv5 TF.js inference is not supported')
+        elif paddle:  # PaddlePaddle
+            raise NotImplementedError('ERROR: YOLOv5 PaddlePaddle inference is not yet supported')
+        else:
+            raise NotImplementedError(f'ERROR: {w} is not a supported format')
 
         # class names
         if 'names' not in locals():
@@ -503,6 +505,8 @@ class DetectMultiBackend(nn.Module):
             else:
                 k = 'var_' + str(sorted(int(k.replace('var_', '')) for k in y)[-1])  # output key
                 y = y[k]  # output
+        elif self.paddle:  # PaddlePaddle
+            raise NotImplementedError('ERROR: YOLOv5 PaddlePaddle inference is not yet supported')
         else:  # TensorFlow (SavedModel, GraphDef, Lite, Edge TPU)
             im = im.permute(0, 2, 3, 1).cpu().numpy()  # torch BCHW to numpy BHWC shape(1,320,192,3)
             if self.saved_model:  # SavedModel
@@ -539,13 +543,13 @@ class DetectMultiBackend(nn.Module):
     def _model_type(p='path/to/model.pt'):
         # Return model type from model path, i.e. path='path/to/model.onnx' -> type=onnx
         from export import export_formats
-        suffixes = list(export_formats().Suffix) + ['.xml']  # export suffixes
-        check_suffix(p, suffixes)  # checks
+        sf = list(export_formats().Suffix) + ['.xml']  # export suffixes
+        check_suffix(p, sf)  # checks
         p = Path(p).name  # eliminate trailing separators
-        pt, jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, xml2 = (s in p for s in suffixes)
+        pt, jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle, xml2 = (s in p for s in sf)
         xml |= xml2  # *_openvino_model or *.xml
         tflite &= not edgetpu  # *.tflite
-        return pt, jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs
+        return pt, jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle
 
     @staticmethod
     def _load_metadata(f='path/to/meta.yaml'):

--- a/models/common.py
+++ b/models/common.py
@@ -448,7 +448,7 @@ class DetectMultiBackend(nn.Module):
             raise NotImplementedError('ERROR: YOLOv5 TF.js inference is not supported')
         elif paddle:  # PaddlePaddle
             LOGGER.info(f'Loading {w} for PaddlePaddle inference...')
-            check_requirements('paddlepaddle-gpu' if cuda else 'paddlepaddle')
+            check_requirements('paddlepaddle-gpu' if cuda else 'paddlepaddle',)
             import paddle.inference as pdi
             if not Path(w).is_file():  # if not *.pdmodel
                 w = next(Path(w).rglob('*.pdmodel'))  # get *.xml file from *_openvino_model dir

--- a/models/common.py
+++ b/models/common.py
@@ -447,7 +447,7 @@ class DetectMultiBackend(nn.Module):
         elif tfjs:  # TF.js
             raise NotImplementedError('ERROR: YOLOv5 TF.js inference is not supported')
         elif paddle:  # PaddlePaddle
-            LOGGER.info(f'Loading {w} for OpenVINO inference...')
+            LOGGER.info(f'Loading {w} for PaddlePaddle inference...')
             check_requirements("paddlepaddle")
             import paddle.inference as pdi
             w = Path(w) / "inference_model"

--- a/models/common.py
+++ b/models/common.py
@@ -448,7 +448,7 @@ class DetectMultiBackend(nn.Module):
             raise NotImplementedError('ERROR: YOLOv5 TF.js inference is not supported')
         elif paddle:  # PaddlePaddle
             LOGGER.info(f'Loading {w} for PaddlePaddle inference...')
-            check_requirements(('paddlepaddle-gpu' if cuda else 'paddlepaddle'))
+            check_requirements('paddlepaddle-gpu' if cuda else 'paddlepaddle')
             import paddle.inference as pdi
             if not Path(w).is_file():  # if not *.pdmodel
                 w = next(Path(w).rglob('*.pdmodel'))  # get *.xml file from *_openvino_model dir

--- a/models/common.py
+++ b/models/common.py
@@ -450,11 +450,11 @@ class DetectMultiBackend(nn.Module):
             LOGGER.info(f'Loading {w} for OpenVINO inference...')
             check_requirements("paddlepaddle")
             import paddle.inference as pdi
-            w=Path(w)/"inference_model"
+            w = Path(w) / "inference_model"
             if not Path(w).is_file():  # if not *.xml
                 w = next(Path(w).glob('*.pdmodel'))  # get *.xml file from *_openvino_model dir
-            model=w
-            weights=Path(w).with_suffix('.pdiparams')
+            model = w
+            weights = Path(w).with_suffix('.pdiparams')
             cuda = torch.cuda.is_available() and device.type != 'cpu'
             config = pdi.Config(str(model), str(weights))
             if cuda:

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -61,7 +61,7 @@ def run(
     device = select_device(device)
     for i, (name, f, suffix, cpu, gpu) in export.export_formats().iterrows():  # index, (name, file, suffix, CPU, GPU)
         try:
-            assert i not in (9, 10), 'inference not supported'  # Edge TPU and TF.js are unsupported
+            assert i not in (9, 10, 11), 'inference not supported'  # Edge TPU, TF.js and Paddle are unsupported
             assert i != 5 or platform.system() == 'Darwin', 'inference only supported on macOS>=10.13'  # CoreML
             if 'cpu' in device.type:
                 assert cpu, 'inference not supported on CPU'


### PR DESCRIPTION
Test on Yolov5 DockerEnviroment with paddlepaddle-gpu v2.2

Signed-off-by: Katteria <39751846+kisaragychihaya@users.noreply.github.com>

### Usage

```python
Export:          python export.py --weights yolov5s.pt --include paddle

Detect:          python detect.py --weights yolov5s_paddle_model/ 
Validate:        python val.py --weights yolov5s_paddle_model/ 
PyTorch Hub:     model = torch.hub.load('ultralytics/yolov5', 'custom', 'yolov5s_paddle_model/')
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Support for PaddlePaddle export added to YOLOv5.

### 📊 Key Changes
- 🚀 PaddlePaddle export option included in allowed export formats.
- 🧹 Removed unused `yaml` import.
- 🛠 Fixed OpenVINO export and added `metadata` parameter for consistency.
- 💾 New `export_paddle` function defined to enable PaddlePaddle exporting.
- 📦 Updates in `common.py` to allow loading and running models exported in PaddlePaddle format.
- 📈 Modifying `benchmarks.py` to include PaddlePaddle as a new, currently unsupported format for inference benchmarking.

### 🎯 Purpose & Impact
- 🎨 Allows YOLOv5 models to be exported to PaddlePaddle, expanding the range of supported platforms and potential users.
- 🛠 Improves code modularity and maintenance by removing unnecessary code and enhancing function signatures for consistency.
- 🌍 Provides support for one of the popular machine learning frameworks from China, potentially increasing usability for developers in the Asian market.
- ⚖️ While PaddlePaddle export is now possible, inference benchmarking does not support it yet, indicating future work to fully integrate this feature.