### PR TITLE
Refactor Loggers : Move code outside train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -91,16 +91,15 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     data_dict = None
     if RANK in {-1, 0}:
         loggers = Loggers(save_dir, weights, opt, hyp, LOGGER)  # loggers instance
-        if loggers.clearml:
-            data_dict = loggers.clearml.data_dict  # None if no ClearML dataset or filled in by ClearML
-        if loggers.wandb:
-            data_dict = loggers.wandb.data_dict
-            if resume:
-                weights, epochs, hyp, batch_size = opt.weights, opt.epochs, opt.hyp, opt.batch_size
-
+        
         # Register actions
         for k in methods(loggers):
             callbacks.register_action(k, callback=getattr(loggers, k))
+        
+        # Process custom dataset artifact link
+        data_dict = loggers.remote_dataset
+        if resume: # If resuming runs from remote artifact
+            weights, epochs, hyp, batch_size = opt.weights, opt.epochs, opt.hyp, opt.batch_size
 
     # Config
     plots = not evolve and not opt.noplots  # create plots

--- a/train.py
+++ b/train.py
@@ -91,14 +91,14 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     data_dict = None
     if RANK in {-1, 0}:
         loggers = Loggers(save_dir, weights, opt, hyp, LOGGER)  # loggers instance
-        
+
         # Register actions
         for k in methods(loggers):
             callbacks.register_action(k, callback=getattr(loggers, k))
-        
+
         # Process custom dataset artifact link
         data_dict = loggers.remote_dataset
-        if resume: # If resuming runs from remote artifact
+        if resume:  # If resuming runs from remote artifact
             weights, epochs, hyp, batch_size = opt.weights, opt.epochs, opt.hyp, opt.batch_size
 
     # Config

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -106,7 +106,7 @@ class Loggers():
             self.clearml = ClearmlLogger(self.opt, self.hyp)
         else:
             self.clearml = None
-            
+
     @property
     def remote_dataset(self):
         # Get data_dict if custom dataset artifact link is provided

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -106,12 +106,13 @@ class Loggers():
             self.clearml = ClearmlLogger(self.opt, self.hyp)
         else:
             self.clearml = None
+            
     @property
     def remote_dataset(self):
         # Get data_dict if custom dataset artifact link is provided
         data_dict = None
         if self.clearml:
-            data_dict = self.clearml.data_dict  # None if no ClearML dataset or filled in by ClearML
+            data_dict = self.clearml.data_dict
         if self.wandb:
             data_dict = self.wandb.data_dict
         

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -106,6 +106,16 @@ class Loggers():
             self.clearml = ClearmlLogger(self.opt, self.hyp)
         else:
             self.clearml = None
+    @property
+    def remote_dataset(self):
+        # Get data_dict if custom dataset artifact link is provided
+        data_dict = None
+        if self.clearml:
+            data_dict = self.clearml.data_dict  # None if no ClearML dataset or filled in by ClearML
+        if self.wandb:
+            data_dict = self.wandb.data_dict
+        
+        return data_dict
 
     def on_train_start(self):
         # Callback runs on train start

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -106,6 +106,7 @@ class Loggers():
             self.clearml = ClearmlLogger(self.opt, self.hyp)
         else:
             self.clearml = None
+
     @property
     def remote_dataset(self):
         # Get data_dict if custom dataset artifact link is provided
@@ -114,7 +115,7 @@ class Loggers():
             data_dict = self.clearml.data_dict  # None if no ClearML dataset or filled in by ClearML
         if self.wandb:
             data_dict = self.wandb.data_dict
-        
+
         return data_dict
 
     def on_train_start(self):

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -106,6 +106,7 @@ class Loggers():
             self.clearml = ClearmlLogger(self.opt, self.hyp)
         else:
             self.clearml = None
+            
     @property
     def remote_dataset(self):
         # Get data_dict if custom dataset artifact link is provided


### PR DESCRIPTION
@glenn-jocher most loggers will/are pushing for dataset/model artifact registry service. They already want to use custom dataset links. This interface attempts to provide a cleaner interface for that.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved dataset artifact management for remote runs in YOLOv5.

### 📊 Key Changes
- Consolidated data_dict retrieval from remote sources to a single location.
- Enabled dataset reference update during resumption of training.

### 🎯 Purpose & Impact
- Enhances code maintainability by centralizing logic related to remote dataset handling.
- 🔄 Ensures consistent dataset usage when training is resumed, potentially improving user experience and model performance.