### PR TITLE
Add LoadImages._cv2_rotate()

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -212,7 +212,7 @@ class LoadImages:
         self.auto = auto
         self.transforms = transforms  # optional
         if any(videos):
-            self.new_video(videos[0])  # new video
+            self._new_video(videos[0])  # new video
         else:
             self.cap = None
         assert self.nf > 0, f'No images or videos found in {p}. ' \
@@ -237,10 +237,11 @@ class LoadImages:
                 if self.count == self.nf:  # last video
                     raise StopIteration
                 path = self.files[self.count]
-                self.new_video(path)
+                self._new_video(path)
                 ret_val, im0 = self.cap.read()
 
             self.frame += 1
+            # im0 = self._cv2_rotate(im0)  # for use if cv2 auto rotation is False
             s = f'video {self.count + 1}/{self.nf} ({self.frame}/{self.frames}) {path}: '
 
         else:
@@ -259,10 +260,23 @@ class LoadImages:
 
         return path, im, im0, self.cap, s
 
-    def new_video(self, path):
+    def _new_video(self, path):
+        # Create a new video capture object
         self.frame = 0
         self.cap = cv2.VideoCapture(path)
         self.frames = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        self.orientation = int(self.cap.get(cv2.CAP_PROP_ORIENTATION_META))  # rotation degrees
+        # self.cap.set(cv2.CAP_PROP_ORIENTATION_AUTO, 0)  # disable https://github.com/ultralytics/yolov5/issues/8493
+
+    def _cv2_rotate(self, im):
+        # Rotate a cv2 video manually
+        if self.orientation == 0:
+            return cv2.rotate(im, cv2.ROTATE_90_CLOCKWISE)
+        elif self.orientation == 180:
+            return cv2.rotate(im, cv2.ROTATE_90_COUNTERCLOCKWISE)
+        elif self.orientation == 90:
+            return cv2.rotate(im, cv2.ROTATE_180)
+        return im
 
     def __len__(self):
         return self.nf  # number of files


### PR DESCRIPTION
Optional manual rotation code per iPhone rotation issue in https://github.com/ultralytics/yolov5/issues/8493

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved video loading orientations in YOLOv5 data loader.

### 📊 Key Changes
- Renamed `new_video` method to `_new_video` to indicate it's for internal use.
- Added `_cv2_rotate` method for rotating videos based on their orientation metadata.
- Integrated video orientation metadata retrieval in `_new_video`.

### 🎯 Purpose & Impact
- 🔄 Ensures correct video orientation during processing, which may prevent model training/testing errors.
- 🛠 Offers a manual video rotation option for instances where cv2 auto rotation is disabled.
- 🔒 Internal use designation for video loading method to clarify its intended scope and use within the codebase. 

The changes will result in better user experience by handling videos that have different orientations, thus facilitating smoother model training and evaluation with fewer manual adjustments.