### PR TITLE
Add new `--vid-stride` inference parameter for videos

### DIFF
--- a/classify/predict.py
+++ b/classify/predict.py
@@ -66,7 +66,7 @@ def run(
         exist_ok=False,  # existing project/name ok, do not increment
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
-        skip_frame=1,  # number of video frames to skip
+        vid_stride=1,  # video frame-rate stride
 ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
@@ -89,10 +89,10 @@ def run(
     # Dataloader
     if webcam:
         view_img = check_imshow()
-        dataset = LoadStreams(source, img_size=imgsz, transforms=classify_transforms(imgsz[0]), skip_frame=skip_frame)
+        dataset = LoadStreams(source, img_size=imgsz, transforms=classify_transforms(imgsz[0]), vid_stride=vid_stride)
         bs = len(dataset)  # batch_size
     else:
-        dataset = LoadImages(source, img_size=imgsz, transforms=classify_transforms(imgsz[0]), skip_frame=skip_frame)
+        dataset = LoadImages(source, img_size=imgsz, transforms=classify_transforms(imgsz[0]), vid_stride=vid_stride)
         bs = 1  # batch_size
     vid_path, vid_writer = [None] * bs, [None] * bs
 
@@ -197,7 +197,7 @@ def parse_opt():
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
-    parser.add_argument('--skip-frame', type=int, default=1, help='number of video frames to skip')
+    parser.add_argument('--vid-stride', type=int, default=1, help='video frame-rate stride')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(vars(opt))

--- a/classify/predict.py
+++ b/classify/predict.py
@@ -66,6 +66,7 @@ def run(
         exist_ok=False,  # existing project/name ok, do not increment
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
+        skip_frame=1,  # number of frames to skip
 ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
@@ -88,10 +89,10 @@ def run(
     # Dataloader
     if webcam:
         view_img = check_imshow()
-        dataset = LoadStreams(source, img_size=imgsz, transforms=classify_transforms(imgsz[0]))
+        dataset = LoadStreams(source, img_size=imgsz, transforms=classify_transforms(imgsz[0]), skip_frame=skip_frame)
         bs = len(dataset)  # batch_size
     else:
-        dataset = LoadImages(source, img_size=imgsz, transforms=classify_transforms(imgsz[0]))
+        dataset = LoadImages(source, img_size=imgsz, transforms=classify_transforms(imgsz[0]), skip_frame=skip_frame)
         bs = 1  # batch_size
     vid_path, vid_writer = [None] * bs, [None] * bs
 
@@ -196,6 +197,7 @@ def parse_opt():
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
+    parser.add_argument('--skip-frame', type=int, default=1, help='number of frames to skip')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(vars(opt))

--- a/classify/predict.py
+++ b/classify/predict.py
@@ -66,7 +66,7 @@ def run(
         exist_ok=False,  # existing project/name ok, do not increment
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
-        skip_frame=1,  # number of frames to skip
+        skip_frame=1,  # number of video frames to skip
 ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
@@ -197,7 +197,7 @@ def parse_opt():
     parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
-    parser.add_argument('--skip-frame', type=int, default=1, help='number of frames to skip')
+    parser.add_argument('--skip-frame', type=int, default=1, help='number of video frames to skip')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(vars(opt))

--- a/detect.py
+++ b/detect.py
@@ -40,9 +40,8 @@ ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.common import DetectMultiBackend
 from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadStreams
-from utils.general import (LOGGER, Profile, check_file, check_img_size, check_imshow, check_requirements,
-                           colorstr, cv2, increment_path, non_max_suppression, print_args, scale_coords,
-                           strip_optimizer, xyxy2xywh)
+from utils.general import (LOGGER, Profile, check_file, check_img_size, check_imshow, check_requirements, colorstr, cv2,
+                           increment_path, non_max_suppression, print_args, scale_coords, strip_optimizer, xyxy2xywh)
 from utils.plots import Annotator, colors, save_one_box
 from utils.torch_utils import select_device, smart_inference_mode
 

--- a/detect.py
+++ b/detect.py
@@ -40,8 +40,9 @@ ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.common import DetectMultiBackend
 from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadStreams
-from utils.general import (LOGGER, Profile, check_file, check_img_size, check_imshow, check_requirements, colorstr, cv2,
-                           increment_path, non_max_suppression, print_args, scale_coords, strip_optimizer, xyxy2xywh)
+from utils.general import (LOGGER, Profile, check_file, check_img_size, check_imshow, check_requirements,
+                           colorstr, cv2, increment_path, non_max_suppression, print_args, scale_coords,
+                           strip_optimizer, xyxy2xywh)
 from utils.plots import Annotator, colors, save_one_box
 from utils.torch_utils import select_device, smart_inference_mode
 
@@ -74,6 +75,7 @@ def run(
         hide_conf=False,  # hide confidences
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
+        skip_frame=1,  # number of frames to skip
 ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
@@ -99,7 +101,7 @@ def run(
         dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt)
         bs = len(dataset)  # batch_size
     else:
-        dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt)
+        dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt, skip_frame=skip_frame)
         bs = 1  # batch_size
     vid_path, vid_writer = [None] * bs, [None] * bs
 
@@ -236,6 +238,7 @@ def parse_opt():
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
+    parser.add_argument('--skip-frame', type=int, default=1, help='number of frames to skip')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(vars(opt))

--- a/detect.py
+++ b/detect.py
@@ -97,7 +97,7 @@ def run(
     # Dataloader
     if webcam:
         view_img = check_imshow()
-        dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt)
+        dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt, skip_frame=skip_frame)
         bs = len(dataset)  # batch_size
     else:
         dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt, skip_frame=skip_frame)

--- a/detect.py
+++ b/detect.py
@@ -74,7 +74,7 @@ def run(
         hide_conf=False,  # hide confidences
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
-        skip_frame=1,  # number of video frames to skip
+        vid_stride=1,  # video frame-rate stride
 ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
@@ -97,10 +97,10 @@ def run(
     # Dataloader
     if webcam:
         view_img = check_imshow()
-        dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt, skip_frame=skip_frame)
+        dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt, vid_stride=vid_stride)
         bs = len(dataset)  # batch_size
     else:
-        dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt, skip_frame=skip_frame)
+        dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt, vid_stride=vid_stride)
         bs = 1  # batch_size
     vid_path, vid_writer = [None] * bs, [None] * bs
 
@@ -237,7 +237,7 @@ def parse_opt():
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
-    parser.add_argument('--skip-frame', type=int, default=1, help='number of video frames to skip')
+    parser.add_argument('--vid-stride', type=int, default=1, help='video frame-rate stride')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(vars(opt))

--- a/detect.py
+++ b/detect.py
@@ -74,7 +74,7 @@ def run(
         hide_conf=False,  # hide confidences
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
-        skip_frame=1,  # number of frames to skip
+        skip_frame=1,  # number of video frames to skip
 ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
@@ -237,7 +237,7 @@ def parse_opt():
     parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
-    parser.add_argument('--skip-frame', type=int, default=1, help='number of frames to skip')
+    parser.add_argument('--skip-frame', type=int, default=1, help='number of video frames to skip')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(vars(opt))

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -202,7 +202,6 @@ class LoadImages:
 
         images = [x for x in files if x.split('.')[-1].lower() in IMG_FORMATS]
         videos = [x for x in files if x.split('.')[-1].lower() in VID_FORMATS]
-
         ni, nv = len(images), len(videos)
 
         self.img_size = img_size
@@ -214,7 +213,6 @@ class LoadImages:
         self.auto = auto
         self.transforms = transforms  # optional
         self.skip_frame = skip_frame
-
         if any(videos):
             self._new_video(videos[0])  # new video
         else:

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -292,7 +292,7 @@ class LoadImages:
 
 class LoadStreams:
     # YOLOv5 streamloader, i.e. `python detect.py --source 'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP streams`
-    def __init__(self, sources='streams.txt', img_size=640, stride=32, auto=True, transforms=None,  skip_frame=1):
+    def __init__(self, sources='streams.txt', img_size=640, stride=32, auto=True, transforms=None, skip_frame=1):
         torch.backends.cudnn.benchmark = True  # faster for fixed-size inference
         self.mode = 'stream'
         self.img_size = img_size

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -233,8 +233,7 @@ class LoadImages:
             # Read video
             self.mode = 'video'
             ret_val, im0 = self.cap.read()
-            self.cap.set(cv2.CAP_PROP_POS_FRAMES,
-                         self.skip_frame * (self.frame + 1))  # read_frame/inference every self.skip_frame frames
+            self.cap.set(cv2.CAP_PROP_POS_FRAMES, self.skip_frame * (self.frame + 1))  # load every self.skip_frame frames
             while not ret_val:
                 self.count += 1
                 self.cap.release()

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -268,7 +268,6 @@ class LoadImages:
         # Create a new video capture object
         self.frame = 0
         self.cap = cv2.VideoCapture(path)
-        self.video_fps = self.cap.get(cv2.CAP_PROP_FPS)
         self.frames = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT) / self.skip_frame)
         self.orientation = int(self.cap.get(cv2.CAP_PROP_ORIENTATION_META))  # rotation degrees
         # self.cap.set(cv2.CAP_PROP_ORIENTATION_AUTO, 0)  # disable https://github.com/ultralytics/yolov5/issues/8493

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -212,7 +212,7 @@ class LoadImages:
         self.mode = 'image'
         self.auto = auto
         self.transforms = transforms  # optional
-        self.skip_frame = skip_frame
+        self.skip_frame = skip_frame  # number of video frames to skip
         if any(videos):
             self._new_video(videos[0])  # new video
         else:
@@ -293,7 +293,7 @@ class LoadStreams:
         self.mode = 'stream'
         self.img_size = img_size
         self.stride = stride
-        self.skip_frame = skip_frame
+        self.skip_frame = skip_frame  # number of video frames to skip
         sources = Path(sources).read_text().rsplit() if Path(sources).is_file() else [sources]
         n = len(sources)
         self.sources = [clean_str(x) for x in sources]  # clean source names for later

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -233,8 +233,7 @@ class LoadImages:
             # Read video
             self.mode = 'video'
             ret_val, im0 = self.cap.read()
-            self.cap.set(cv2.CAP_PROP_POS_FRAMES,
-                         self.vid_stride * (self.frame + 1))  # load every self.vid_stride frames
+            self.cap.set(cv2.CAP_PROP_POS_FRAMES, self.vid_stride * (self.frame + 1))  # read at vid_stride
             while not ret_val:
                 self.count += 1
                 self.cap.release()

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -233,7 +233,8 @@ class LoadImages:
             # Read video
             self.mode = 'video'
             ret_val, im0 = self.cap.read()
-            self.cap.set(cv2.CAP_PROP_POS_FRAMES, self.skip_frame * (self.frame + 1))  # load every self.skip_frame frames
+            self.cap.set(cv2.CAP_PROP_POS_FRAMES,
+                         self.skip_frame * (self.frame + 1))  # load every self.skip_frame frames
             while not ret_val:
                 self.count += 1
                 self.cap.release()

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -244,7 +244,7 @@ class LoadImages:
                 ret_val, im0 = self.cap.read()
 
             self.frame += 1
-            # im0 = self._cv2_rotate(im0)  # for use if cv2 auto rotation is False
+            # im0 = self._cv2_rotate(im0)  # for use if cv2 autorotation is False
             s = f'video {self.count + 1}/{self.nf} ({self.frame}/{self.frames}) {path}: '
 
         else:

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -38,7 +38,6 @@ from utils.torch_utils import torch_distributed_zero_first
 HELP_URL = 'See https://github.com/ultralytics/yolov5/wiki/Train-Custom-Data'
 IMG_FORMATS = 'bmp', 'dng', 'jpeg', 'jpg', 'mpo', 'png', 'tif', 'tiff', 'webp', 'pfm'  # include image suffixes
 VID_FORMATS = 'asf', 'avi', 'gif', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'ts', 'wmv'  # include video suffixes
-VID_FRAME_RATE_UNITS = 'fps', 'fpm', 'fph'
 BAR_FORMAT = '{l_bar}{bar:10}{r_bar}{bar:-10b}'  # tqdm bar format
 LOCAL_RANK = int(os.getenv('LOCAL_RANK', -1))  # https://pytorch.org/docs/stable/elastic/run.html
 PIN_MEMORY = str(os.getenv('PIN_MEMORY', True)).lower() == 'true'  # global pin_memory for dataloaders


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

@glenn-jocher as seen in the issue https://github.com/ultralytics/yolov5/issues/8079#issue-12581169989 there's the need sometimes to skip frames while performing inference on a video.
One of the useful use cases could be batch processing of very long archive videos where high frame rates are not needed.


I added two parameters to detect.py
- --inf-rate --> number of inference given a frame rate unit
- --fr-unit --> frame rate unit ('fps', 'fpm', 'fph')

Where :
- fps = frames per second
- fpm = frames per minute
- fph = frames per hour


example use:
`python detect.py --device 0 --weights yolov5s.pt --inf-rate 1 --fr-unit fps --source vid.mp4`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement to video frame processing with the introduction of frame-rate stride control.

### 📊 Key Changes
- 🖼️ Added a `vid_stride` parameter to control the stride of video frame processing (skipping frames).
- 🛠️ `vid_stride` is implemented in `LoadImages` and `LoadStreams` classes, affecting how videos are loaded and processed.
- 🎛️ The `vid_stride` option is added as a command-line argument in both `predict.py` and `detect.py` scripts, permitting customization from the command-line interface.

### 🎯 Purpose & Impact
- 🚀 The purpose is to allow users to speed up video processing by analyzing fewer frames (skipping over frames based on stride value).
- ✨ This can significantly reduce processing time and resource usage when high frame-rate precision is not required.
- 🌐 It can also be beneficial for streaming scenarios where live feedback is more important than processing every single frame.