### PR TITLE
Move `cudnn.benchmarks(True)` to LoadStreams

### DIFF
--- a/classify/predict.py
+++ b/classify/predict.py
@@ -31,7 +31,6 @@ import sys
 from pathlib import Path
 
 import torch
-import torch.backends.cudnn as cudnn
 import torch.nn.functional as F
 
 FILE = Path(__file__).resolve()
@@ -89,7 +88,6 @@ def run(
     # Dataloader
     if webcam:
         view_img = check_imshow()
-        cudnn.benchmark = True  # set True to speed up constant image size inference
         dataset = LoadStreams(source, img_size=imgsz, transforms=classify_transforms(imgsz[0]))
         bs = len(dataset)  # batch_size
     else:

--- a/detect.py
+++ b/detect.py
@@ -31,7 +31,6 @@ import sys
 from pathlib import Path
 
 import torch
-import torch.backends.cudnn as cudnn
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory
@@ -97,7 +96,6 @@ def run(
     # Dataloader
     if webcam:
         view_img = check_imshow()
-        cudnn.benchmark = True  # set True to speed up constant image size inference
         dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt)
         bs = len(dataset)  # batch_size
     else:

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -283,62 +283,18 @@ class LoadImages:
         return self.nf  # number of files
 
 
-class LoadWebcam:  # for inference
-    # YOLOv5 local webcam dataloader, i.e. `python detect.py --source 0`
-    def __init__(self, pipe='0', img_size=640, stride=32):
-        self.img_size = img_size
-        self.stride = stride
-        self.pipe = eval(pipe) if pipe.isnumeric() else pipe
-        self.cap = cv2.VideoCapture(self.pipe)  # video capture object
-        self.cap.set(cv2.CAP_PROP_BUFFERSIZE, 3)  # set buffer size
-
-    def __iter__(self):
-        self.count = -1
-        return self
-
-    def __next__(self):
-        self.count += 1
-        if cv2.waitKey(1) == ord('q'):  # q to quit
-            self.cap.release()
-            cv2.destroyAllWindows()
-            raise StopIteration
-
-        # Read frame
-        ret_val, im0 = self.cap.read()
-        im0 = cv2.flip(im0, 1)  # flip left-right
-
-        # Print
-        assert ret_val, f'Camera Error {self.pipe}'
-        img_path = 'webcam.jpg'
-        s = f'webcam {self.count}: '
-
-        # Process
-        im = letterbox(im0, self.img_size, stride=self.stride)[0]  # resize
-        im = im.transpose((2, 0, 1))[::-1]  # HWC to CHW, BGR to RGB
-        im = np.ascontiguousarray(im)  # contiguous
-
-        return img_path, im, im0, None, s
-
-    def __len__(self):
-        return 0
-
-
 class LoadStreams:
     # YOLOv5 streamloader, i.e. `python detect.py --source 'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP streams`
     def __init__(self, sources='streams.txt', img_size=640, stride=32, auto=True, transforms=None):
+        torch.backends.cudnn.benchmark(True)  # faster for fixed-size inference
         self.mode = 'stream'
         self.img_size = img_size
         self.stride = stride
+        sources = Path(sources).read_text() if Path(sources).is_file() else [sources]
+        self.sources = [clean_str(x).strip() for x in sources if len(x.strip())]  # clean source names for later
 
-        if os.path.isfile(sources):
-            with open(sources) as f:
-                sources = [x.strip() for x in f.read().strip().splitlines() if len(x.strip())]
-        else:
-            sources = [sources]
-
-        n = len(sources)
+        n = len(self.sources)
         self.imgs, self.fps, self.frames, self.threads = [None] * n, [0] * n, [0] * n, [None] * n
-        self.sources = [clean_str(x) for x in sources]  # clean source names for later
         for i, s in enumerate(sources):  # index, source
             # Start thread to read frames from video stream
             st = f'{i + 1}/{n}: {s}... '

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -333,8 +333,7 @@ class LoadStreams:
         n, f, read = 0, self.frames[i], 1  # frame number, frame array, inference every 'read' frame
         while cap.isOpened() and n < f:
             n += 1
-            # _, self.imgs[index] = cap.read()
-            cap.grab()
+            cap.grab()  # .read() = .grab() followed by .retrieve()
             if n % read == 0:
                 success, im = cap.retrieve()
                 if success:

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -286,14 +286,13 @@ class LoadImages:
 class LoadStreams:
     # YOLOv5 streamloader, i.e. `python detect.py --source 'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP streams`
     def __init__(self, sources='streams.txt', img_size=640, stride=32, auto=True, transforms=None):
-        torch.backends.cudnn.benchmark(True)  # faster for fixed-size inference
+        torch.backends.cudnn.benchmark = True  # faster for fixed-size inference
         self.mode = 'stream'
         self.img_size = img_size
         self.stride = stride
-        sources = Path(sources).read_text() if Path(sources).is_file() else [sources]
-        self.sources = [clean_str(x).strip() for x in sources if len(x.strip())]  # clean source names for later
-
-        n = len(self.sources)
+        sources = Path(sources).read_text().rsplit() if Path(sources).is_file() else [sources]
+        n = len(sources)
+        self.sources = [clean_str(x) for x in sources]  # clean source names for later
         self.imgs, self.fps, self.frames, self.threads = [None] * n, [0] * n, [0] * n, [None] * n
         for i, s in enumerate(sources):  # index, source
             # Start thread to read frames from video stream


### PR DESCRIPTION
Also remove unused LoadWebcam class.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements in webcam and stream data loading for YOLOv5 inference.

### 📊 Key Changes
- Removed usage of `torch.backends.cudnn` from `predict.py` and `detect.py`, moved it to `dataloaders.py`.
- Deleted the `LoadWebcam` class, as webcam functionality is now unified with other streams in the `LoadStreams` class.
- Simplified stream source validation by utilizing `Path` reading instead of manual file checks.
- Optimized the stream update method by using `cap.grab()` solely rather than a read-grab combination.

### 🎯 Purpose & Impact
- 🚀 **Performance:** Centralizing `cudnn.benchmark = True` for consistent inference speed-up across different scripts.
- 📹 **Simplicity:** By removing the `LoadWebcam` class and consolidating webcam handling into `LoadStreams`, code maintenance and future updates are simplified.
- 🧼 **Cleaner Code:** Streamlining the method to obtain stream sources and updating frames provides cleaner and more efficient code, potentially leading to fewer bugs and easier troubleshooting.
- 🛠️ **User Experience:** These changes should result in a smoother and potentially faster experience for users performing detections via webcam or streamed inputs.