### PR TITLE
Make sure best.pt model file is preserved ClearML

### DIFF
--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -233,7 +233,11 @@ class Loggers():
             self.wandb.finish_run()
 
         if self.clearml and not self.opt.evolve:
-            self.clearml.task.update_output_model(model_path=str(best if best.exists() else last), name='Best Model')
+            self.clearml.task.update_output_model(
+                model_path=str(best if best.exists() else last),
+                name='Best Model',
+                auto_delete_file=False
+            )
 
     def on_params_update(self, params: dict):
         # Update hyperparams or configs of the experiment

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -233,11 +233,9 @@ class Loggers():
             self.wandb.finish_run()
 
         if self.clearml and not self.opt.evolve:
-            self.clearml.task.update_output_model(
-                model_path=str(best if best.exists() else last),
-                name='Best Model',
-                auto_delete_file=False
-            )
+            self.clearml.task.update_output_model(model_path=str(best if best.exists() else last),
+                                                  name='Best Model',
+                                                  auto_delete_file=False)
 
     def on_params_update(self, params: dict):
         # Update hyperparams or configs of the experiment


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

Adresses #9251 
There are 2 model upload point in the code. One of them did not have the necessary argument to preserve the model file.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced ClearML logging behavior in YOLOv5 training callbacks.

### 📊 Key Changes
- Modified the `on_train_end` method within the logging utilities.
- Added an `auto_delete_file=False` parameter to the ClearML `update_output_model` call to prevent automatic deletion of model files.

### 🎯 Purpose & Impact
- 🎯 **Purpose:** To ensure that the model files are retained and not automatically deleted when the ClearML task concludes, providing more consistent model management within the YOLOv5 training process.
- 🎯 **Impact:** Users integrating YOLOv5 with ClearML will have a more reliable and explicit handling of their output models, reducing the risk of unintentional data loss.