### PR TITLE
Update benchmarks CI with `--hard-fail` min metric floor

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -39,7 +39,7 @@ jobs:
           pip list
       - name: Run benchmarks
         run: |
-          python utils/benchmarks.py --weights ${{ matrix.model }}.pt --img 320 --hard-fail
+          python utils/benchmarks.py --weights ${{ matrix.model }}.pt --img 320 --hard-fail 0.29
 
   Tests:
     timeout-minutes: 60

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -92,10 +92,14 @@ def run(
     LOGGER.info('\n')
     parse_opt()
     notebook_init()  # print system info
-    c = ['Format', 'Size (MB)', 'mAP@0.5:0.95', 'Inference time (ms)'] if map else ['Format', 'Export', '', '']
+    c = ['Format', 'Size (MB)', 'mAP50-95', 'Inference time (ms)'] if map else ['Format', 'Export', '', '']
     py = pd.DataFrame(y, columns=c)
     LOGGER.info(f'\nBenchmarks complete ({time.time() - t:.2f}s)')
     LOGGER.info(str(py if map else py.iloc[:, :2]))
+    if hard_fail and isinstance(hard_fail, str):
+        metrics = py['mAP50-95']  # values to compare to floor
+        floor = eval(hard_fail)  # minimum metric floor to pass, i.e. = 0.29 mAP for YOLOv5n
+        assert all(x > floor for x in metrics if x is not None), f'Metrics {metrics} < floor {floor} detected'
     return py
 
 
@@ -141,7 +145,7 @@ def parse_opt():
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--test', action='store_true', help='test exports only')
     parser.add_argument('--pt-only', action='store_true', help='test PyTorch only')
-    parser.add_argument('--hard-fail', action='store_true', help='throw error on benchmark failure')
+    parser.add_argument('--hard-fail', nargs='?', const=True, default=False, help='Exception of failure or min metric')
     opt = parser.parse_args()
     opt.data = check_yaml(opt.data)  # check YAML
     print_args(vars(opt))

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -145,7 +145,7 @@ def parse_opt():
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--test', action='store_true', help='test exports only')
     parser.add_argument('--pt-only', action='store_true', help='test PyTorch only')
-    parser.add_argument('--hard-fail', nargs='?', const=True, default=False, help='Exception of failure or min metric')
+    parser.add_argument('--hard-fail', nargs='?', const=True, default=False, help='Exception on error or < min metric')
     opt = parser.parse_args()
     opt.data = check_yaml(opt.data)  # check YAML
     print_args(vars(opt))

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -97,9 +97,9 @@ def run(
     LOGGER.info(f'\nBenchmarks complete ({time.time() - t:.2f}s)')
     LOGGER.info(str(py if map else py.iloc[:, :2]))
     if hard_fail and isinstance(hard_fail, str):
-        metrics = py['mAP50-95'].values  # values to compare to floor
+        metrics = py['mAP50-95'].array  # values to compare to floor
         floor = eval(hard_fail)  # minimum metric floor to pass, i.e. = 0.29 mAP for YOLOv5n
-        assert all(x > floor for x in metrics if x is not None), f'Metrics {metrics} < floor {floor} detected'
+        assert all(x > floor for x in metrics if pd.notna(x)), f'Metrics {metrics} < floor {floor} detected'
     return py
 
 

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -97,7 +97,7 @@ def run(
     LOGGER.info(f'\nBenchmarks complete ({time.time() - t:.2f}s)')
     LOGGER.info(str(py if map else py.iloc[:, :2]))
     if hard_fail and isinstance(hard_fail, str):
-        metrics = py['mAP50-95']  # values to compare to floor
+        metrics = py['mAP50-95'].values  # values to compare to floor
         floor = eval(hard_fail)  # minimum metric floor to pass, i.e. = 0.29 mAP for YOLOv5n
         assert all(x > floor for x in metrics if x is not None), f'Metrics {metrics} < floor {floor} detected'
     return py

--- a/utils/benchmarks.py
+++ b/utils/benchmarks.py
@@ -99,7 +99,7 @@ def run(
     if hard_fail and isinstance(hard_fail, str):
         metrics = py['mAP50-95'].array  # values to compare to floor
         floor = eval(hard_fail)  # minimum metric floor to pass, i.e. = 0.29 mAP for YOLOv5n
-        assert all(x > floor for x in metrics if pd.notna(x)), f'Metrics {metrics} < floor {floor} detected'
+        assert all(x > floor for x in metrics if pd.notna(x)), f'HARD FAIL: mAP50-95 < floor {floor}'
     return py
 
 


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved benchmark testing with adjustable performance floors.

### 📊 Key Changes
- 🔄 Revised the output labels in benchmark results from 'mAP@0.5:0.95' to 'mAP50-95'.
- ✨ Added a conditional check to apply a minimum performance floor (default 0.29) in benchmarks.
- 🛠️ Updated `--hard-fail` CLI argument to accept an optional performance floor value.

### 🎯 Purpose & Impact
- 📏 Ensures maintainability of performance standards by allowing custom minimum metrics for passing tests.
- 🚀 Facilitates detection of performance regressions that could lead to better model quality over time.
- ⚙️ Provides more granular control over testing processes, aiding developers in quality assurance tasks.