### PR TITLE
Comet changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ python train.py --data coco.yaml --cfg yolov5n.yaml --weights '' --batch-size 12
 - [Roboflow for Datasets, Labeling, and Active Learning](https://github.com/ultralytics/yolov5/issues/4975)  🌟 NEW
 - [ClearML Logging](https://github.com/ultralytics/yolov5/tree/master/utils/loggers/clearml) 🌟 NEW
 - [Deci Platform](https://github.com/ultralytics/yolov5/wiki/Deci-Platform) 🌟 NEW
+- [Comet Logging](https://github.com/ultralytics/yolov5/tree/master/utils/loggers/comet) 🌟 NEW
 
 </details>
 

--- a/utils/loggers/comet/__init__.py
+++ b/utils/loggers/comet/__init__.py
@@ -133,7 +133,7 @@ class CometLogger:
 
         self.comet_log_predictions = COMET_LOG_PREDICTIONS
         if self.opt.bbox_interval == -1:
-            self.comet_log_prediction_interval = self.opt.epochs // 10 if self.opt.epochs < 10 else 1
+            self.comet_log_prediction_interval = 1 if self.opt.epochs < 10 else self.opt.epochs // 10
         else:
             self.comet_log_prediction_interval = self.opt.bbox_interval
 


### PR DESCRIPTION
This PR:

1. Adds a link to the Comet Tutorial from the main README
2. Fixes a bug in the `bbox_interval` calculation resulting in division by zero error in the Comet Logger when logging predictions. 

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging intervals for Comet.ml in Ultralytics YOLOv5.

### 📊 Key Changes
- Adjusted the logging frequency of predictions to Comet.ml when using YOLOv5.

### 🎯 Purpose & Impact
- 🛠 Fixes an issue with setting the interval for logging predictions to Comet.ml to ensure more consistent behavior.
- 🚀 Users with shorter training runs (less than 10 epochs) will now get prediction logs every epoch, enhancing the monitoring and evaluation experience.
- 📈 This leads to better insight and tracking for small-scale experiments, potentially improving model development and debugging processes.