### PR TITLE
Train.py line 486 typo fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -483,7 +483,7 @@ def main(opt, callbacks=Callbacks()):
         check_requirements()
 
     # Resume (from specified or most recent last.pt)
-    if opt.resume and not check_wandb_resume(opt) and not check_comet_resume(opt) or opt.evolve:
+    if opt.resume and not check_wandb_resume(opt) and not check_comet_resume(opt) and not opt.evolve:
         last = Path(check_file(opt.resume) if isinstance(opt.resume, str) else get_latest_run())
         opt_yaml = last.parent.parent / 'opt.yaml'  # train options yaml
         opt_data = opt.data  # original dataset


### PR DESCRIPTION
Fix for bug described in [issue 9329](https://github.com/ultralytics/yolov5/issues/9329)
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved conditional logic for resuming training or evolutionary search in the YOLOv5 training script.

### 📊 Key Changes
- Adjusted the conditional statement that determines when to resume a training session or an evolutionary search for hyperparameters.

### 🎯 Purpose & Impact
- **Purpose:** The change ensures that the conditions for resuming training and for starting or resuming an evolutionary search are mutually exclusive. This prevents potential conflicts when both options are specified.
- **Impact:** Provides a clearer, more predictable behavior for users looking to resume training sessions or perform hyperparameter evolution without unexpected interference between the two processes. 🔄