### PR TITLE
Add dilated conv support

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -38,8 +38,8 @@ def autopad(k, p=None, d=1):  # kernel, padding, dilation
 
 
 class Conv(nn.Module):
-    # Standard convolution
-    def __init__(self, c1, c2, k=1, s=1, p=None, g=1, d=1, act=True):  # ch_in, ch_out, kernel, stride, padding, groups
+    # Standard convolution with args(ch_in, ch_out, kernel, stride, padding, groups, dilation, activation)
+    def __init__(self, c1, c2, k=1, s=1, p=None, g=1, d=1, act=True):
         super().__init__()
         self.conv = nn.Conv2d(c1, c2, k, s, autopad(k, p, d), groups=g, dilation=d, bias=False)
         self.bn = nn.BatchNorm2d(c2)
@@ -53,13 +53,13 @@ class Conv(nn.Module):
 
 
 class DWConv(Conv):
-    # Depth-wise convolution class
+    # Depth-wise convolution
     def __init__(self, c1, c2, k=1, s=1, act=True):  # ch_in, ch_out, kernel, stride, padding, groups
         super().__init__(c1, c2, k, s, g=math.gcd(c1, c2), act=act)
 
 
 class DWConvTranspose2d(nn.ConvTranspose2d):
-    # Depth-wise transpose convolution class
+    # Depth-wise transpose convolution
     def __init__(self, c1, c2, k=1, s=1, p1=0, p2=0):  # ch_in, ch_out, kernel, stride, padding, padding_out
         super().__init__(c1, c2, k, s, p1, p2, groups=math.gcd(c1, c2))
 

--- a/models/common.py
+++ b/models/common.py
@@ -30,7 +30,7 @@ from utils.torch_utils import copy_attr, smart_inference_mode
 
 def autopad(k, p=None, d=1):  # kernel, padding
     if d > 1:
-        k = d*(k-1)+1 if isinstance(k, int) else [d*(x-1)+1 for x in k]  # actual kernel-size
+        k = d * (k - 1) + 1 if isinstance(k, int) else [d * (x - 1) + 1 for x in k]  # actual kernel-size
     # Pad to 'same'
     if p is None:
         p = k // 2 if isinstance(k, int) else [x // 2 for x in k]  # auto-pad

--- a/models/common.py
+++ b/models/common.py
@@ -28,7 +28,9 @@ from utils.plots import Annotator, colors, save_one_box
 from utils.torch_utils import copy_attr, smart_inference_mode
 
 
-def autopad(k, p=None):  # kernel, padding
+def autopad(k, p=None, d=1):  # kernel, padding
+    if d > 1:
+        k = d*(k-1)+1 if isinstance(k, int) else [d*(x-1)+1 for x in k]  # actual kernel-size
     # Pad to 'same'
     if p is None:
         p = k // 2 if isinstance(k, int) else [x // 2 for x in k]  # auto-pad
@@ -37,9 +39,9 @@ def autopad(k, p=None):  # kernel, padding
 
 class Conv(nn.Module):
     # Standard convolution
-    def __init__(self, c1, c2, k=1, s=1, p=None, g=1, act=True):  # ch_in, ch_out, kernel, stride, padding, groups
+    def __init__(self, c1, c2, k=1, s=1, p=None, g=1, d=1, act=True):  # ch_in, ch_out, kernel, stride, padding, groups
         super().__init__()
-        self.conv = nn.Conv2d(c1, c2, k, s, autopad(k, p), groups=g, bias=False)
+        self.conv = nn.Conv2d(c1, c2, k, s, autopad(k, p, d), groups=g, dilation=d, bias=False)
         self.bn = nn.BatchNorm2d(c2)
         self.act = nn.SiLU() if act is True else (act if isinstance(act, nn.Module) else nn.Identity())
 

--- a/models/common.py
+++ b/models/common.py
@@ -28,10 +28,10 @@ from utils.plots import Annotator, colors, save_one_box
 from utils.torch_utils import copy_attr, smart_inference_mode
 
 
-def autopad(k, p=None, d=1):  # kernel, padding
+def autopad(k, p=None, d=1):  # kernel, padding, dilation
+    # Pad to 'same' shape outputs
     if d > 1:
         k = d * (k - 1) + 1 if isinstance(k, int) else [d * (x - 1) + 1 for x in k]  # actual kernel-size
-    # Pad to 'same'
     if p is None:
         p = k // 2 if isinstance(k, int) else [x // 2 for x in k]  # auto-pad
     return p

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -251,6 +251,7 @@ def fuse_conv_and_bn(conv, bn):
                           kernel_size=conv.kernel_size,
                           stride=conv.stride,
                           padding=conv.padding,
+                          dilation=conv.dilation,
                           groups=conv.groups,
                           bias=True).requires_grad_(False).to(conv.weight.device)
 


### PR DESCRIPTION
1. Add dilated property in basic conv
2. A few changes to enable fuse_conv_and_bn and autopad function to work for dilated convolution

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to convolution operations with added dilation support.

### 📊 Key Changes
- `autopad` method now supports `dilation`, ensuring padding calculations consider it.
- `Conv` class constructor now includes `dilation` parameter.
- Added `dilation` to the attributes of fused convolutions in `fuse_conv_and_bn`.

### 🎯 Purpose & Impact
- 🔧 Enhances the convolution layers by allowing dilation, improving the capability to control the reception field and feature resolution.
- 🚀 Potentially improves model performance for tasks requiring dilated convolutions, broadening YOLOv5 applicability.
- 💡 Enables users to utilize dilated convolutions without significant changes to their existing codebase.