### PR TITLE
Exclude `ipython` from hubconf.py `check_requirements()`

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -37,7 +37,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
 
     if not verbose:
         LOGGER.setLevel(logging.WARNING)
-    check_requirements(exclude=('tensorboard', 'thop', 'opencv-python'))
+    check_requirements(exclude=('ipython', 'opencv-python', 'tensorboard', 'thop'))
     name = Path(name)
     path = name.with_suffix('.pt') if name.suffix == '' and not name.is_dir() else name  # checkpoint path
     try:


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of dependency checks in model loading routine.

### 📊 Key Changes
- Altered the list of excluded requirements during model initialization, adding 'ipython' to the exclusions.

### 🎯 Purpose & Impact
- **Purpose**: This change ensures that non-critical packages such as 'ipython' do not interfere with the model loading process, if they are not installed.
- **Impact**: Streamlines the user experience by preventing unnecessary warnings/errors about 'ipython' during model loading, especially for users who may not use 'ipython' in their workflow. This contributes to a smoother setup and fewer issues for new users getting started with the models.