### PR TITLE
Remove duplicate line in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ ignore =
     F401  # module imported but unused
     W504  # line break after binary operator
     E127  # continuation line over-indented for visual indent
-    W504  # line break after binary operator
     E231  # missing whitespace after ‘,’, ‘;’, or ‘:’
     E501  # line too long
     F403  # ‘from module import *’ used; unable to detect undefined names


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

I found that W504 rule of flake8 in `setup.cfg` is duplicated, so I send this PR to remove the second W504 rule.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Code Quality by Removing Redundant Lint Exception.

### 📊 Key Changes
- Eliminated a duplicate lint exception (`W504 line break after binary operator`).

### 🎯 Purpose & Impact
- **Purpose**: To clean up the `setup.cfg` file by removing unnecessary repetition, which may have been a minor oversight.
- **Impact**: Maintainers and contributors will work with a cleaner configuration file. No direct impact on end users, but it contributes to maintaining high standards in code quality and readability. 🛠️