### PR TITLE
Fix tick labels for background FN/FP

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -170,12 +170,12 @@ class ConfusionMatrix:
             if n and sum(j) == 1:
                 self.matrix[detection_classes[m1[j]], gc] += 1  # correct
             else:
-                self.matrix[self.nc, gc] += 1  # background FP
+                self.matrix[self.nc, gc] += 1  # true background
 
         if n:
             for i, dc in enumerate(detection_classes):
                 if not any(m1 == i):
-                    self.matrix[dc, self.nc] += 1  # background FN
+                    self.matrix[dc, self.nc] += 1  # predicted background
 
     def matrix(self):
         return self.matrix
@@ -197,6 +197,7 @@ class ConfusionMatrix:
         nc, nn = self.nc, len(names)  # number of classes, names
         sn.set(font_scale=1.0 if nc < 50 else 0.8)  # for label size
         labels = (0 < nn < 99) and (nn == nc)  # apply names to ticklabels
+        ticklabels = (names + ['background']) if labels else "auto"
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')  # suppress empty matrix RuntimeWarning: All-NaN slice encountered
             sn.heatmap(array,
@@ -208,8 +209,8 @@ class ConfusionMatrix:
                        fmt='.2f',
                        square=True,
                        vmin=0.0,
-                       xticklabels=names + ['background'] if labels else "auto",
-                       yticklabels=names + ['background'] if labels else "auto").set_facecolor((1, 1, 1))
+                       xticklabels=ticklabels,
+                       yticklabels=ticklabels).set_facecolor((1, 1, 1))
         ax.set_ylabel('True')
         ax.set_ylabel('Predicted')
         ax.set_title('Confusion Matrix')

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -208,8 +208,8 @@ class ConfusionMatrix:
                        fmt='.2f',
                        square=True,
                        vmin=0.0,
-                       xticklabels=names + ['background FN'] if labels else "auto",
-                       yticklabels=names + ['background FP'] if labels else "auto").set_facecolor((1, 1, 1))
+                       xticklabels=names + ['background'] if labels else "auto",
+                       yticklabels=names + ['background'] if labels else "auto").set_facecolor((1, 1, 1))
         ax.set_ylabel('True')
         ax.set_ylabel('Predicted')
         ax.set_title('Confusion Matrix')

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -208,8 +208,8 @@ class ConfusionMatrix:
                        fmt='.2f',
                        square=True,
                        vmin=0.0,
-                       xticklabels=names + ['background FP'] if labels else "auto",
-                       yticklabels=names + ['background FN'] if labels else "auto").set_facecolor((1, 1, 1))
+                       xticklabels=names + ['background FN'] if labels else "auto",
+                       yticklabels=names + ['background FP'] if labels else "auto").set_facecolor((1, 1, 1))
         ax.set_ylabel('True')
         ax.set_ylabel('Predicted')
         ax.set_title('Confusion Matrix')


### PR DESCRIPTION
Fix tick labels for background FN/FP in the confusion matrix.

They needs to be switched to each other.

This issue has been raised within #8000.

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved clarity in confusion matrix terminology.

### 📊 Key Changes
- Changed the annotation of false positives (FP) and false negatives (FN) to "true background" and "predicted background" for better clarity.
- Simplified confusion matrix plotting by creating a single `ticklabels` variable.
- Made sure that the `ticklabels` reflect the updated terminology and apply to both x and y axes.

### 🎯 Purpose & Impact
- The renaming of confusion matrix terms aims to reduce confusion about the background class in object detection, making it clearer what constitutes a background prediction versus a foreground object.
- Streamlining the plot code enhances maintainability and readability.
- Users of the YOLOv5 library can now interpret their models' performance with a more intuitive understanding of where the background class fits into their predictions, potentially improving the model refinement process. 📈🧠