### PR TITLE
Continue on Docker arm64 failure

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Build and push arm64 image
         uses: docker/build-push-action@v3
+        continue-on-error: true
         with:
           context: .
           platforms: linux/arm64


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Docker CI workflow with error tolerance for ARM64 builds.

### 📊 Key Changes
- Added `continue-on-error: true` to the ARM64 Docker build step in the CI workflow.

### 🎯 Purpose & Impact
- 🛠 **Purpose**: Enables the CI workflow to continue even if the ARM64 Docker image build fails, preventing one part of the workflow from blocking others.
- 🌐 **Impact**: This change should help maintainers better handle ARM64 build errors without disrupting the overall CI process, potentially speeding up development and issue resolution. Users can expect more consistent integration and deployment of updates.