### PR TITLE
Continue on Docker failure (all backends)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ jobs:
     if: github.repository == 'ultralytics/yolov5'
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -30,7 +31,6 @@ jobs:
 
       - name: Build and push arm64 image
         uses: docker/build-push-action@v3
-        continue-on-error: true
         with:
           context: .
           platforms: linux/arm64


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved GitHub Actions workflow for YOLOv5 Docker image deployment 🚀

### 📊 Key Changes
- Enabled `continue-on-error: true` in the GitHub Actions workflow for the Docker job.
- The `continue-on-error` parameter has been moved from the "Build and push arm64 image" step to the job level.

### 🎯 Purpose & Impact
- 🛠️ **Purpose:** Ensures that the entire Docker job can proceed in the face of errors, rather than stopping at the first failure within a specific step.
- ✅ **Impact:** This should improve the robustness of the continuous integration/continuous deployment (CI/CD) pipeline. Users can expect more consistent Docker image updates, even if one part of the build process encounters issues.