### PR TITLE
Continue on Docker fail (all backends) fix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,6 @@ jobs:
     if: github.repository == 'ultralytics/yolov5'
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -31,6 +30,7 @@ jobs:
 
       - name: Build and push arm64 image
         uses: docker/build-push-action@v3
+        continue-on-error: true
         with:
           context: .
           platforms: linux/arm64
@@ -40,6 +40,7 @@ jobs:
 
       - name: Build and push CPU image
         uses: docker/build-push-action@v3
+        continue-on-error: true
         with:
           context: .
           file: utils/docker/Dockerfile-cpu
@@ -48,6 +49,7 @@ jobs:
 
       - name: Build and push GPU image
         uses: docker/build-push-action@v3
+        continue-on-error: true
         with:
           context: .
           file: utils/docker/Dockerfile


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced robustness in Docker image deployment workflow 💼🐳

### 📊 Key Changes
- Removed the `continue-on-error` flag from the initial job setup.
- Added `continue-on-error: true` to individual Docker image build steps for arm64, CPU, and GPU.

### 🎯 Purpose & Impact
- **Purpose**: To ensure that if one image build fails (arm64, CPU, or GPU), the rest of the builds can continue instead of the entire job failing immediately. 🔄
- **Impact**: Increases the chances of successfully building and pushing at least some Docker images, avoiding an all-or-nothing scenario and ensuring partial progress in case of issues. This helps maintain a continuous delivery flow. 🚀

This change is most relevant to developers and users who rely on Ultralytics' Docker images, as it affects the reliability and availability of the published images.