### PR TITLE
AutoBatch `cudnn.benchmark=True` fix

### DIFF
--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -34,7 +34,7 @@ def autobatch(model, imgsz=640, fraction=0.8, batch_size=16):
         LOGGER.info(f'{prefix}CUDA not detected, using default CPU batch-size {batch_size}')
         return batch_size
     if torch.backends.cudnn.benchmark:
-        LOGGER.info(f'{prefix}requires torch.backends.cudnn.benchmark=False, using default batch-size {batch_size}')
+        LOGGER.info(f'{prefix} ⚠️ Requires torch.backends.cudnn.benchmark=False, using default batch-size {batch_size}')
         return batch_size
 
     # Inspect CUDA memory

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 
 import numpy as np
 import torch
+from torch.backends import cudnn
 
 from utils.general import LOGGER, colorstr
 from utils.torch_utils import profile
@@ -46,11 +47,14 @@ def autobatch(model, imgsz=640, fraction=0.8, batch_size=16):
 
     # Profile batch sizes
     batch_sizes = [1, 2, 4, 8, 16]
+    bm = cudnn.benchmark
+    cudnn.benchmark = False  # avoid benchmark interference https://github.com/ultralytics/yolov5/issues/9287
     try:
         img = [torch.empty(b, 3, imgsz, imgsz) for b in batch_sizes]
         results = profile(img, model, n=3, device=device)
     except Exception as e:
         LOGGER.warning(f'{prefix}{e}')
+    cudnn.benchmark = bm  # reset to original value
 
     # Fit a solution
     y = [x[2] for x in results if x]  # memory [2]

--- a/utils/general.py
+++ b/utils/general.py
@@ -223,7 +223,7 @@ def init_seeds(seed=0, deterministic=False):
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)  # for Multi-GPU, exception safe
-    torch.backends.cudnn.benchmark = True  # for faster training
+    # torch.backends.cudnn.benchmark = True  # AutoBatch problem https://github.com/ultralytics/yolov5/issues/9287
     if deterministic and check_version(torch.__version__, '1.12.0'):  # https://github.com/ultralytics/yolov5/pull/8213
         torch.use_deterministic_algorithms(True)
         torch.backends.cudnn.deterministic = True


### PR DESCRIPTION
May resolve https://github.com/ultralytics/yolov5/issues/9287

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Redefined conditions for batch size determination and disabled CUDNN benchmark by default.

### 📊 Key Changes
- Added a condition to return the default batch size when `torch.backends.cudnn.benchmark` is enabled.
- Commented out the line that sets `torch.backends.cudnn.benchmark` to True by default, referencing an issue in the YOLOv5 repository.

### 🎯 Purpose & Impact
- The added condition helps to avoid altering the batch size if CUDNN's benchmarking feature is activated. This can ensure stability and avoid performance degradation in certain cases.
- Disabling the CUDNN benchmark by default aims to bypass potential problems with the AutoBatch feature, as reported in an issue. This change prioritizes model and training stability over the possible but not guaranteed speed improvements benchmarking might provide.
- Users may notice a change in training speed, but with a likely increase in predictability and stability during model training, especially when reproducing results across different runs.