### PR TITLE
Fix cutout bug

### DIFF
--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -12,9 +12,8 @@ import torch
 import torchvision.transforms as T
 import torchvision.transforms.functional as TF
 
-from utils.general import LOGGER, check_version, colorstr, resample_segments, segment2box
+from utils.general import LOGGER, check_version, colorstr, resample_segments, segment2box, xywhn2xyxy
 from utils.metrics import bbox_ioa
-from utils.general import xywhn2xyxy
 
 IMAGENET_MEAN = 0.485, 0.456, 0.406  # RGB mean
 IMAGENET_STD = 0.229, 0.224, 0.225  # RGB standard deviation

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -14,6 +14,7 @@ import torchvision.transforms.functional as TF
 
 from utils.general import LOGGER, check_version, colorstr, resample_segments, segment2box
 from utils.metrics import bbox_ioa
+from utils.general import xywhn2xyxy
 
 IMAGENET_MEAN = 0.485, 0.456, 0.406  # RGB mean
 IMAGENET_STD = 0.229, 0.224, 0.225  # RGB standard deviation
@@ -281,7 +282,7 @@ def cutout(im, labels, p=0.5):
             # return unobscured labels
             if len(labels) and s > 0.03:
                 box = np.array([xmin, ymin, xmax, ymax], dtype=np.float32)
-                ioa = bbox_ioa(box, labels[:, 1:5])  # intersection over area
+                ioa = bbox_ioa(box, xywhn2xyxy(labels[:, 1:5], w, h))  # intersection over area
                 labels = labels[ioa < 0.60]  # remove >60% obscured labels
 
     return labels


### PR DESCRIPTION
Signed-off-by: Junjie Zhang <46258221+Oswells@users.noreply.github.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->
When I use cutout, I find that even if the object is completely covered, its gt_label is still retained on the image.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of cutout augmentation in data preprocessing to enhance object detection.

### 📊 Key Changes
- Imported `xywhn2xyxy` function within `augmentations.py`.
- Improved the `cutout` function by ensuring it considers the IOA (Intersection over Area) of bounding boxes in the image coordinate space.

### 🎯 Purpose & Impact
- The purpose of these changes is to increase the accuracy of the `cutout` data augmentation technique used during training.
- By converting labels to the correct coordinate format before calculating IOA, it ensures that the object detection model is trained on better quality data, potentially leading to improved model performance.
- Users can expect their models to handle partial occlusions in a more robust way, which can be particularly beneficial for real-world applications where objects are often partially obscured.