### PR TITLE
Add `macos-latest` runner for CoreML benchmarks

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         python-version: [ '3.9' ]  # requires python<=3.9
         model: [ yolov5n ]
     steps:

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         python-version: [ '3.9' ]  # requires python<=3.9
         model: [ yolov5n ]
     steps:

--- a/models/common.py
+++ b/models/common.py
@@ -514,8 +514,7 @@ class DetectMultiBackend(nn.Module):
                 conf, cls = y['confidence'].max(1), y['confidence'].argmax(1).astype(np.float)
                 y = np.concatenate((box, conf.reshape(-1, 1), cls.reshape(-1, 1)), 1)
             else:
-                k = 'var_' + str(sorted(int(k.replace('var_', '')) for k in y)[-1])  # output key
-                y = y[k]  # output
+                y = list(reversed(y.values()))  # reversed for segmentation models (pred, proto)
         elif self.paddle:  # PaddlePaddle
             im = im.cpu().numpy().astype("float32")
             self.input_handle.copy_from_cpu(im)


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model output handling for segmentation in YOLOv5.

### 📊 Key Changes
- Simplified the logic for handling outputs in models that include segmentation tasks.
- The previous method of identifying the last layer's output by key has been replaced.
- Outputs are now retrieved by reversing the order of model values which is particularly relevant for certain segmentation models.

### 🎯 Purpose & Impact
- The change aims to streamline the post-processing step in YOLOv5's forward pass, especially for models that perform segmentation tasks.
- This can potentially make the code easier to maintain and understand, as it removes the need for dynamically constructing the key based on the outputs available.
- Users can expect a more consistent handling of outputs, which may, in turn, enhance the usability of YOLOv5 for various computer vision tasks including segmentation.
- There might be a performance improvement in scenarios where segmentation model outputs are used, due to a more direct access to the required output tensors. 🚀