### PR TITLE
Add Paddle exports to benchmarks

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -65,7 +65,7 @@ def run(
     model_type = type(attempt_load(weights, fuse=False))  # DetectionModel, SegmentationModel, etc.
     for i, (name, f, suffix, cpu, gpu) in export.export_formats().iterrows():  # index, (name, file, suffix, CPU, GPU)
         try:
-            assert i not in (9, 10, 11), 'inference not supported'  # Edge TPU, TF.js and Paddle are unsupported
+            assert i not in (9, 10), 'inference not supported'  # Edge TPU and TF.js are unsupported
             assert i != 5 or platform.system() == 'Darwin', 'inference only supported on macOS>=10.13'  # CoreML
             if 'cpu' in device.type:
                 assert cpu, 'inference not supported on CPU'

--- a/models/common.py
+++ b/models/common.py
@@ -460,8 +460,8 @@ class DetectMultiBackend(nn.Module):
             if cuda:
                 config.enable_use_gpu(memory_pool_init_size_mb=2048, device_id=0)
             predictor = pdi.create_predictor(config)
-            input_names = predictor.get_input_names()
-            input_handle = predictor.get_input_handle(input_names[0])
+            input_handle = predictor.get_input_handle(predictor.get_input_names()[0])
+            output_names = predictor.get_output_names()
         else:
             raise NotImplementedError(f'ERROR: {w} is not a supported format')
 
@@ -517,12 +517,10 @@ class DetectMultiBackend(nn.Module):
                 k = 'var_' + str(sorted(int(k.replace('var_', '')) for k in y)[-1])  # output key
                 y = y[k]  # output
         elif self.paddle:  # PaddlePaddle
-            im = im.cpu().numpy().astype("float32")
+            im = im.cpu().numpy().astype(np.float32)
             self.input_handle.copy_from_cpu(im)
             self.predictor.run()
-            output_names = self.predictor.get_output_names()
-            output_handle = self.predictor.get_output_handle(output_names[0])
-            y = output_handle.copy_to_cpu()
+            y = [self.predictor.get_output_handle(x).copy_to_cpu() for x in self.output_names]
         else:  # TensorFlow (SavedModel, GraphDef, Lite, Edge TPU)
             im = im.permute(0, 2, 3, 1).cpu().numpy()  # torch BCHW to numpy BHWC shape(1,320,192,3)
             if self.saved_model:  # SavedModel

--- a/utils/segment/plots.py
+++ b/utils/segment/plots.py
@@ -99,9 +99,9 @@ def plot_images_and_masks(images, targets, masks, paths=None, fname='images.jpg'
                         if mh != h or mw != w:
                             mask = image_masks[j].astype(np.uint8)
                             mask = cv2.resize(mask, (w, h))
-                            mask = mask.astype(np.bool)
+                            mask = mask.astype(bool)
                         else:
-                            mask = image_masks[j].astype(np.bool)
+                            mask = image_masks[j].astype(bool)
                         with contextlib.suppress(Exception):
                             im[y:y + h, x:x + w, :][mask] = im[y:y + h, x:x + w, :][mask] * 0.4 + np.array(color) * 0.6
                 annotator.fromarray(im)


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to YOLOv5 inference support and data processing.

### 📊 Key Changes
- Removed PaddlePaddle's output handle redundancies for efficiency.
- Enabled inference on all export formats except for Edge TPU and TF.js.
- Improved data type consistency and inference support across different formats.
- Simplified the way PaddlePaddle outputs are handled during forward passes.
- Updated mask data types from `np.bool` to Python's built-in `bool` for better compatibility.

### 🎯 Purpose & Impact
- 🚀 Enhances the model's compatibility and performance with various export formats, except for Edge TPU and TF.js, expanding the range of supported devices and platforms.
- 💡 Simplifies PaddlePaddle's code for output processing, potentially improving maintainability and reducing the likelihood of future bugs.
- 🧠 Changes to data types promote consistency across the codebase, likely reducing errors and ensuring smoother data handling processes.
- 🖼 Updates to image and mask plotting improve reliability and follow best practices in type usage, potentially affecting all visual outputs or segmented images, enhancing visualization quality.