### PR TITLE
Update ClassificationModel default training `imgsz=224`

### DIFF
--- a/classify/train.py
+++ b/classify/train.py
@@ -3,7 +3,7 @@
 Train a YOLOv5 classifier model on a classification dataset
 
 Usage - Single-GPU training:
-    $ python classify/train.py --model yolov5s-cls.pt --data imagenette160 --epochs 5 --img 128
+    $ python classify/train.py --model yolov5s-cls.pt --data imagenette160 --epochs 5 --img 224
 
 Usage - Multi-GPU DDP training:
     $ python -m torch.distributed.run --nproc_per_node 4 --master_port 1 classify/train.py --model yolov5s-cls.pt --data imagenet --epochs 5 --img 224 --device 0,1,2,3
@@ -272,7 +272,7 @@ def parse_opt(known=False):
     parser.add_argument('--data', type=str, default='imagenette160', help='cifar10, cifar100, mnist, imagenet, ...')
     parser.add_argument('--epochs', type=int, default=10, help='total training epochs')
     parser.add_argument('--batch-size', type=int, default=64, help='total batch size for all GPUs')
-    parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=128, help='train, val image size (pixels)')
+    parser.add_argument('--imgsz', '--img', '--img-size', type=int, default=224, help='train, val image size (pixels)')
     parser.add_argument('--nosave', action='store_true', help='only save final checkpoint')
     parser.add_argument('--cache', type=str, nargs='?', const='ram', help='--cache images in "ram" (default) or "disk"')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')


### PR DESCRIPTION
To match classify/val.py and classify/predict.py

Helps https://github.com/ultralytics/yolov5/issues/9462

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
YOLOv5 classification model now trains with higher resolution images by default.

### 📊 Key Changes
- The default input image size for training has been changed from 128 to 224 pixels.
- The example usage in the documentation has been updated to reflect this new default image size.

### 🎯 Purpose & Impact
- 🎨 Enhances the model's ability to learn from higher resolution images, which can potentially improve classification accuracy.
- 🧠 May impact computational requirements, as higher resolution images consume more memory and processing power.
- 📈 Users should see an improvement in the model performance on classification tasks with adequate hardware.