### PR TITLE
Accelerate video inference

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -232,8 +232,9 @@ class LoadImages:
         if self.video_flag[self.count]:
             # Read video
             self.mode = 'video'
-            ret_val, im0 = self.cap.read()
-            self.cap.set(cv2.CAP_PROP_POS_FRAMES, self.vid_stride * (self.frame + 1))  # read at vid_stride
+            for _ in range(self.vid_stride):
+                self.cap.grab()
+            ret_val, im0 = self.cap.retrieve()
             while not ret_val:
                 self.count += 1
                 self.cap.release()

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -232,10 +232,9 @@ class LoadImages:
         if self.video_flag[self.count]:
             # Read video
             self.mode = 'video'
-            self.cap.grab()
-            ret_val, im0 = self.cap.retrieve()
-            for _ in range(self.vid_stride - 1):
+            for _ in range(self.vid_stride):
                 self.cap.grab()
+            ret_val, im0 = self.cap.retrieve()
             while not ret_val:
                 self.count += 1
                 self.cap.release()

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -232,9 +232,10 @@ class LoadImages:
         if self.video_flag[self.count]:
             # Read video
             self.mode = 'video'
-            for _ in range(self.vid_stride):
-                self.cap.grab()
+            self.cap.grab()
             ret_val, im0 = self.cap.retrieve()
+            for _ in range(self.vid_stride - 1):
+                self.cap.grab()
             while not ret_val:
                 self.count += 1
                 self.cap.release()


### PR DESCRIPTION
@glenn-jocher 
I hope this PR finds you well.
I adjust code of reading video, using 'cap.grab()' and 'cap. retrieve'.
It's a small fix.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved video frame retrieval in data loading process for YOLOv5.

### 📊 Key Changes
- Replaced a single `cap.read()` call with `cap.grab()` called in a loop, followed by `cap.retrieve()` for video frames.
- The number of times `cap.grab()` is called is determined by `self.vid_stride`, ensuring that frames are skipped according to the stride specified.

### 🎯 Purpose & Impact
- 🎯 The update optimizes video processing by skipping over frames more efficiently when a stride is used.
- ✨ This can lead to better memory management and potentially faster data loading, especially when processing videos with high frame rates.
- 🚀 Users can expect more consistent performance when training YOLOv5 on video datasets with frame skipping.