### PR TITLE
Segmentation `polygons2masks_overlap()` in `np.int32`

### DIFF
--- a/utils/segment/dataloaders.py
+++ b/utils/segment/dataloaders.py
@@ -308,8 +308,8 @@ def polygons2masks(img_size, polygons, color, downsample_ratio=1):
 
 def polygons2masks_overlap(img_size, segments, downsample_ratio=1):
     """Return a (640, 640) overlap mask."""
-    masks = np.zeros((img_size[0] // downsample_ratio, img_size[1] // downsample_ratio), 
-            dtype=np.int32 if len(segments) > 255 else np.uint8)
+    masks = np.zeros((img_size[0] // downsample_ratio, img_size[1] // downsample_ratio),
+                     dtype=np.int32 if len(segments) > 255 else np.uint8)
     areas = []
     ms = []
     for si in range(len(segments)):

--- a/utils/segment/dataloaders.py
+++ b/utils/segment/dataloaders.py
@@ -308,7 +308,7 @@ def polygons2masks(img_size, polygons, color, downsample_ratio=1):
 
 def polygons2masks_overlap(img_size, segments, downsample_ratio=1):
     """Return a (640, 640) overlap mask."""
-    masks = np.zeros((img_size[0] // downsample_ratio, img_size[1] // downsample_ratio), dtype=np.uint8)
+    masks = np.zeros((img_size[0] // downsample_ratio, img_size[1] // downsample_ratio), dtype=np.int32)
     areas = []
     ms = []
     for si in range(len(segments)):

--- a/utils/segment/dataloaders.py
+++ b/utils/segment/dataloaders.py
@@ -308,7 +308,8 @@ def polygons2masks(img_size, polygons, color, downsample_ratio=1):
 
 def polygons2masks_overlap(img_size, segments, downsample_ratio=1):
     """Return a (640, 640) overlap mask."""
-    masks = np.zeros((img_size[0] // downsample_ratio, img_size[1] // downsample_ratio), dtype=np.int32)
+    masks = np.zeros((img_size[0] // downsample_ratio, img_size[1] // downsample_ratio), 
+            dtype=np.int32 if len(segments) > 255 else np.uint8)
     areas = []
     ms = []
     for si in range(len(segments)):


### PR DESCRIPTION
May resolve https://github.com/ultralytics/yolov5/issues/9461

WARNING: Masks should be uint8 for fastest speed, change needs profiling results to determine impact.

@AyushExel @Laughing-q 

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved mask generation for overlapping segments in image segmentation tasks.

### 📊 Key Changes
- Altered the data type of the generated masks in `polygons2masks_overlap` function based on the number of segments.
- `np.uint8` is used when the number of segments is 255 or fewer.
- `np.int32` is utilized for scenarios with more than 255 segments.

### 🎯 Purpose & Impact
- 🎨 Enhances segmentation mask creation to support a larger number of overlapping regions.
- 🛠️ Solves the issue of mask overflow when dealing with a high count of segments, which typically results in incorrect mask values.
- 💡 This change will directly aid in the accurate training and inference of models on complex images with numerous overlapping objects, improving the robustness and reliability of image segmentation applications.