### PR TITLE
Remove `check_requirements('flatbuffers==1.12')`

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -40,6 +40,7 @@ jobs:
           pip list
       - name: Benchmark DetectionModel
         run: |
+          python export.py --include tflite --int8 --weights yolov5s.pt yolov5s-seg.pt
           python benchmarks.py --data coco128.yaml --weights ${{ matrix.model }}.pt --img 320 --hard-fail 0.29
       - name: Benchmark SegmentationModel
         run: |

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -40,7 +40,6 @@ jobs:
           pip list
       - name: Benchmark DetectionModel
         run: |
-          python export.py --include tflite --int8 --weights yolov5s.pt yolov5s-seg.pt
           python benchmarks.py --data coco128.yaml --weights ${{ matrix.model }}.pt --img 320 --hard-fail 0.29
       - name: Benchmark SegmentationModel
         run: |

--- a/export.py
+++ b/export.py
@@ -534,8 +534,6 @@ def run(
     if coreml:  # CoreML
         f[4], _ = export_coreml(model, im, file, int8, half)
     if any((saved_model, pb, tflite, edgetpu, tfjs)):  # TensorFlow formats
-        if int8 or edgetpu:  # TFLite --int8 bug https://github.com/ultralytics/yolov5/issues/5707
-            check_requirements('flatbuffers==1.12')  # required before `import tensorflow`
         assert not tflite or not tfjs, 'TFLite and TF.js models must be exported separately, please pass only one type.'
         assert not isinstance(model, ClassificationModel), 'ClassificationModel export to TF formats not yet supported.'
         f[5], s_model = export_saved_model(model.cpu(),


### PR DESCRIPTION
Legacy constraint, no longer required.

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced TensorFlow export compatibility in YOLOv5.

### 📊 Key Changes
- 🛠 Removed version check for `flatbuffers` before importing TensorFlow.
- 🧹 Cleaned up TensorFlow export conditions to ensure clearer logic and prevent simultaneous export of TFLite and TF.js formats.

### 🎯 Purpose & Impact
- ✔️ Improves the smoothness and reliability of exporting models to TensorFlow formats.
- 🚀 Enables users to export their models to their desired format without encountering version-related import errors that previously existed due to the `flatbuffers` dependency.
- 🔍 Ensures users can confidently export models by enforcing separate export paths for TFLite and TF.js, preventing confusion and potential errors.