### PR TITLE
Remove scikit-learn constraint on coremltools 6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ seaborn>=0.11.0
 # onnx-simplifier>=0.4.1  # ONNX simplifier
 # nvidia-pyindex  # TensorRT export
 # nvidia-tensorrt  # TensorRT export
-# scikit-learn==0.19.2  # CoreML quantization
+# scikit-learn  # CoreML quantization
 # tensorflow>=2.4.1  # TF exports (-cpu, -aarch64, -macos)
 # tensorflowjs>=3.9.0  # TF.js export
 # openvino-dev  # OpenVINO export


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Update to machine learning requirements list.

### 📊 Key Changes
- 🔧 Unpinned the version requirement for `scikit-learn` in `requirements.txt`.

### 🎯 Purpose & Impact
- ✨ This change allows for greater flexibility by not restricting to a specific version of `scikit-learn`, which can lead to better compatibility with other packages and fewer conflicts.
- 🔄 Users can benefit from the latest features and improvements in `scikit-learn` without the need to manually override the version requirement.
- 🔍 Developers may need to monitor compatibility with new versions of `scikit-learn` going forward, which could introduce breaking changes or require updates to the codebase.