### PR TITLE
Update scikit-learn constraint per coremltools 6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ seaborn>=0.11.0
 # onnx-simplifier>=0.4.1  # ONNX simplifier
 # nvidia-pyindex  # TensorRT export
 # nvidia-tensorrt  # TensorRT export
-# scikit-learn  # CoreML quantization
+# scikit-learn<=1.1.2  # CoreML quantization
 # tensorflow>=2.4.1  # TF exports (-cpu, -aarch64, -macos)
 # tensorflowjs>=3.9.0  # TF.js export
 # openvino-dev  # OpenVINO export


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updating scikit-learn version requirement for CoreML quantization compatibility.

### 📊 Key Changes
- Modified the version requirement for scikit-learn in the `requirements.txt`.
- The version of scikit-learn is now limited to 1.1.2 or lower.

### 🎯 Purpose & Impact
- 🎯 Ensures compatibility with CoreML quantization by preventing the installation of potentially incompatible newer scikit-learn versions.
- 🚀 Users working with CoreML quantization can expect more stable and reliable performance with the specific scikit-learn version set.
- 🛠 This change may impact users who require a newer version of scikit-learn for other parts of their workflow; they'll have to manage versioning accordingly.