### PR TITLE
Add `--source screen` for screenshot inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ the latest YOLOv5 [release](https://github.com/ultralytics/yolov5/releases) and 
 python detect.py --source 0  # webcam
                           img.jpg  # image
                           vid.mp4  # video
+                          screen  # screenshot
                           path/  # directory
                           'path/*.jpg'  # glob
                           'https://youtu.be/Zgi9g1ksQHc'  # YouTube

--- a/classify/predict.py
+++ b/classify/predict.py
@@ -42,7 +42,7 @@ ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.common import DetectMultiBackend
 from utils.augmentations import classify_transforms
-from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadStreams
+from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadScreenshots, LoadStreams
 from utils.general import (LOGGER, Profile, check_file, check_img_size, check_imshow, check_requirements, colorstr, cv2,
                            increment_path, print_args, strip_optimizer)
 from utils.plots import Annotator
@@ -52,7 +52,7 @@ from utils.torch_utils import select_device, smart_inference_mode
 @smart_inference_mode()
 def run(
         weights=ROOT / 'yolov5s-cls.pt',  # model.pt path(s)
-        source=ROOT / 'data/images',  # file/dir/URL/glob, 0 for webcam
+        source=ROOT / 'data/images',  # file/dir/URL/glob/screen/0(webcam)
         data=ROOT / 'data/coco128.yaml',  # dataset.yaml path
         imgsz=(224, 224),  # inference size (height, width)
         device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
@@ -74,6 +74,7 @@ def run(
     is_file = Path(source).suffix[1:] in (IMG_FORMATS + VID_FORMATS)
     is_url = source.lower().startswith(('rtsp://', 'rtmp://', 'http://', 'https://'))
     webcam = source.isnumeric() or source.endswith('.txt') or (is_url and not is_file)
+    screenshot = source.lower().startswith('screen')
     if is_url and is_file:
         source = check_file(source)  # download
 
@@ -91,6 +92,8 @@ def run(
     if webcam:
         view_img = check_imshow()
         dataset = LoadStreams(source, img_size=imgsz, transforms=classify_transforms(imgsz[0]), vid_stride=vid_stride)
+    elif screenshot:
+        dataset = LoadScreenshots(source, img_size=imgsz, stride=stride, auto=pt)
     else:
         dataset = LoadImages(source, img_size=imgsz, transforms=classify_transforms(imgsz[0]), vid_stride=vid_stride)
     bs = len(dataset)  # batch_size
@@ -187,7 +190,7 @@ def run(
 def parse_opt():
     parser = argparse.ArgumentParser()
     parser.add_argument('--weights', nargs='+', type=str, default=ROOT / 'yolov5s-cls.pt', help='model path(s)')
-    parser.add_argument('--source', type=str, default=ROOT / 'data/images', help='file/dir/URL/glob, 0 for webcam')
+    parser.add_argument('--source', type=str, default=ROOT / 'data/images', help='file/dir/URL/glob/screen/0(webcam)')
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='(optional) dataset.yaml path')
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[224], help='inference size h,w')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')

--- a/detect.py
+++ b/detect.py
@@ -82,7 +82,7 @@ def run(
     is_file = Path(source).suffix[1:] in (IMG_FORMATS + VID_FORMATS)
     is_url = source.lower().startswith(('rtsp://', 'rtmp://', 'http://', 'https://'))
     webcam = source.isnumeric() or source.endswith('.txt') or (is_url and not is_file)
-    screenshot = source.lower().startswith('screen')  # screenshot
+    screenshot = source.lower().startswith('screen')
     if is_url and is_file:
         source = check_file(source)  # download
 

--- a/detect.py
+++ b/detect.py
@@ -216,11 +216,7 @@ def run(
 def parse_opt():
     parser = argparse.ArgumentParser()
     parser.add_argument('--weights', nargs='+', type=str, default=ROOT / 'yolov5s.pt', help='model path(s)')
-    parser.add_argument(
-        '--source',
-        type=str,
-        default=ROOT / 'data/images',
-        help='file/dir/URL/glob/screenshot, 0 for webcam, "screen [screennumber] [left top width height]" for  screen')
+    parser.add_argument('--source', type=str, default=ROOT / 'data/images', help='file/dir/URL/glob/screen/0(webcam)')
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='(optional) dataset.yaml path')
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[640], help='inference size h,w')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='confidence threshold')

--- a/detect.py
+++ b/detect.py
@@ -40,7 +40,7 @@ if str(ROOT) not in sys.path:
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.common import DetectMultiBackend
-from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadStreams, LoadScreenshot
+from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadScreenshot, LoadStreams
 from utils.general import (LOGGER, Profile, check_file, check_img_size, check_imshow, check_requirements, colorstr, cv2,
                            increment_path, non_max_suppression, print_args, scale_coords, strip_optimizer, xyxy2xywh)
 from utils.plots import Annotator, colors, save_one_box
@@ -86,13 +86,13 @@ def run(
     if scrshot:
         # get all parames
         source, *params = source.split()
-        screen, left, top, width, height = 0, None, None, None, None # default to full screen 0
+        screen, left, top, width, height = 0, None, None, None, None  # default to full screen 0
         if len(params) == 1:
             screen = int(params[0])
         elif len(params) == 4:
-            left, top, width, height = [int(x) for x in params]
+            left, top, width, height = (int(x) for x in params)
         elif len(params) == 5:
-            screen, left, top, width, height = [int(x) for x in params]
+            screen, left, top, width, height = (int(x) for x in params)
 
     if is_url and is_file:
         source = check_file(source)  # download
@@ -113,7 +113,14 @@ def run(
         dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt, vid_stride=vid_stride)
         bs = len(dataset)  # batch_size
     elif scrshot:
-        dataset = LoadScreenshot(screen=screen, img_size=imgsz, stride=stride, auto=pt, left=left, top=top, width=width, height=height)
+        dataset = LoadScreenshot(screen=screen,
+                                 img_size=imgsz,
+                                 stride=stride,
+                                 auto=pt,
+                                 left=left,
+                                 top=top,
+                                 width=width,
+                                 height=height)
         bs = 1  # batch_size
     else:
         dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt, vid_stride=vid_stride)
@@ -228,7 +235,11 @@ def run(
 def parse_opt():
     parser = argparse.ArgumentParser()
     parser.add_argument('--weights', nargs='+', type=str, default=ROOT / 'yolov5s.pt', help='model path(s)')
-    parser.add_argument('--source', type=str, default=ROOT / 'data/images', help='file/dir/URL/glob, 0 for webcam, "screen [screennumber] [left top width height]" for  screen')
+    parser.add_argument(
+        '--source',
+        type=str,
+        default=ROOT / 'data/images',
+        help='file/dir/URL/glob, 0 for webcam, "screen [screennumber] [left top width height]" for  screen')
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='(optional) dataset.yaml path')
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[640], help='inference size h,w')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='confidence threshold')

--- a/detect.py
+++ b/detect.py
@@ -88,7 +88,7 @@ def run(
         source, *params = source.split()
         screen, left, top, width, height = 0, None, None, None, None # default to full screen 0
         if len(params) == 1:
-            screen = params[0]
+            screen = int(params[0])
         elif len(params) == 4:
             left, top, width, height = [int(x) for x in params]
         elif len(params) == 5:
@@ -113,7 +113,6 @@ def run(
         dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt, vid_stride=vid_stride)
         bs = len(dataset)  # batch_size
     elif scrshot:
-        # dataset = LoadScreenshot(0, img_size=imgsz, stride=stride, auto=pt)
         dataset = LoadScreenshot(screen=screen, img_size=imgsz, stride=stride, auto=pt, left=left, top=top, width=width, height=height)
         bs = 1  # batch_size
     else:

--- a/detect.py
+++ b/detect.py
@@ -82,7 +82,7 @@ def run(
     is_file = Path(source).suffix[1:] in (IMG_FORMATS + VID_FORMATS)
     is_url = source.lower().startswith(('rtsp://', 'rtmp://', 'http://', 'https://'))
     webcam = source.isnumeric() or source.endswith('.txt') or (is_url and not is_file)
-    scrshot = source.lower().startswith('screen')  # screenshot
+    screenshot = source.lower().startswith('screen')  # screenshot
 
     if is_url and is_file:
         source = check_file(source)  # download
@@ -102,7 +102,7 @@ def run(
         view_img = check_imshow()
         dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt, vid_stride=vid_stride)
         bs = len(dataset)  # batch_size
-    elif scrshot:
+    elif screenshot:
         dataset = LoadScreenshots(source, img_size=imgsz, stride=stride, auto=pt)
         bs = 1  # batch_size
     else:

--- a/detect.py
+++ b/detect.py
@@ -83,7 +83,6 @@ def run(
     is_url = source.lower().startswith(('rtsp://', 'rtmp://', 'http://', 'https://'))
     webcam = source.isnumeric() or source.endswith('.txt') or (is_url and not is_file)
     screenshot = source.lower().startswith('screen')  # screenshot
-
     if is_url and is_file:
         source = check_file(source)  # download
 

--- a/detect.py
+++ b/detect.py
@@ -50,7 +50,7 @@ from utils.torch_utils import select_device, smart_inference_mode
 @smart_inference_mode()
 def run(
         weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
-        source=ROOT / 'data/images',  # file/dir/URL/glob, 0 for webcam
+        source=ROOT / 'data/images',  # file/dir/URL/glob/screen/0(webcam)
         data=ROOT / 'data/coco128.yaml',  # dataset.yaml path
         imgsz=(640, 640),  # inference size (height, width)
         conf_thres=0.25,  # confidence threshold

--- a/detect.py
+++ b/detect.py
@@ -101,13 +101,11 @@ def run(
     if webcam:
         view_img = check_imshow()
         dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt, vid_stride=vid_stride)
-        bs = len(dataset)  # batch_size
     elif screenshot:
         dataset = LoadScreenshots(source, img_size=imgsz, stride=stride, auto=pt)
-        bs = 1  # batch_size
     else:
         dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt, vid_stride=vid_stride)
-        bs = 1  # batch_size
+    bs = len(dataset)  # batch_size
     vid_path, vid_writer = [None] * bs, [None] * bs
 
     # Run inference
@@ -222,7 +220,7 @@ def parse_opt():
         '--source',
         type=str,
         default=ROOT / 'data/images',
-        help='file/dir/URL/glob, 0 for webcam, "screen [screennumber] [left top width height]" for  screen')
+        help='file/dir/URL/glob/screenshot, 0 for webcam, "screen [screennumber] [left top width height]" for  screen')
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='(optional) dataset.yaml path')
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[640], help='inference size h,w')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='confidence threshold')

--- a/detect.py
+++ b/detect.py
@@ -40,7 +40,7 @@ if str(ROOT) not in sys.path:
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.common import DetectMultiBackend
-from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadScreenshot, LoadStreams
+from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadScreenshots, LoadStreams
 from utils.general import (LOGGER, Profile, check_file, check_img_size, check_imshow, check_requirements, colorstr, cv2,
                            increment_path, non_max_suppression, print_args, scale_coords, strip_optimizer, xyxy2xywh)
 from utils.plots import Annotator, colors, save_one_box
@@ -83,16 +83,6 @@ def run(
     is_url = source.lower().startswith(('rtsp://', 'rtmp://', 'http://', 'https://'))
     webcam = source.isnumeric() or source.endswith('.txt') or (is_url and not is_file)
     scrshot = source.lower().startswith('screen')  # screenshot
-    if scrshot:
-        # get all parames
-        source, *params = source.split()
-        screen, left, top, width, height = 0, None, None, None, None  # default to full screen 0
-        if len(params) == 1:
-            screen = int(params[0])
-        elif len(params) == 4:
-            left, top, width, height = (int(x) for x in params)
-        elif len(params) == 5:
-            screen, left, top, width, height = (int(x) for x in params)
 
     if is_url and is_file:
         source = check_file(source)  # download
@@ -113,14 +103,7 @@ def run(
         dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt, vid_stride=vid_stride)
         bs = len(dataset)  # batch_size
     elif scrshot:
-        dataset = LoadScreenshot(screen=screen,
-                                 img_size=imgsz,
-                                 stride=stride,
-                                 auto=pt,
-                                 left=left,
-                                 top=top,
-                                 width=width,
-                                 height=height)
+        dataset = LoadScreenshots(source, img_size=imgsz, stride=stride, auto=pt)
         bs = 1  # batch_size
     else:
         dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt, vid_stride=vid_stride)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ torch>=1.7.0
 torchvision>=0.8.1
 tqdm>=4.64.0
 # protobuf<=3.20.1  # https://github.com/ultralytics/yolov5/issues/8012
+mss
 
 # Logging -------------------------------------
 tensorboard>=2.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ torch>=1.7.0
 torchvision>=0.8.1
 tqdm>=4.64.0
 # protobuf<=3.20.1  # https://github.com/ultralytics/yolov5/issues/8012
-mss
 
 # Logging -------------------------------------
 tensorboard>=2.4.1
@@ -39,6 +38,7 @@ seaborn>=0.11.0
 ipython  # interactive notebook
 psutil  # system utilization
 thop>=0.1.1  # FLOPs computation
+# mss  # screenshots
 # albumentations>=1.0.3
 # pycocotools>=2.0  # COCO mAP
 # roboflow

--- a/segment/predict.py
+++ b/segment/predict.py
@@ -40,7 +40,7 @@ if str(ROOT) not in sys.path:
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.common import DetectMultiBackend
-from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadStreams
+from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadScreenshots, LoadStreams
 from utils.general import (LOGGER, Profile, check_file, check_img_size, check_imshow, check_requirements, colorstr, cv2,
                            increment_path, non_max_suppression, print_args, scale_coords, strip_optimizer, xyxy2xywh)
 from utils.plots import Annotator, colors, save_one_box
@@ -51,7 +51,7 @@ from utils.torch_utils import select_device, smart_inference_mode
 @smart_inference_mode()
 def run(
     weights=ROOT / 'yolov5s-seg.pt',  # model.pt path(s)
-    source=ROOT / 'data/images',  # file/dir/URL/glob, 0 for webcam
+    source=ROOT / 'data/images',  # file/dir/URL/glob/screen/0(webcam)
     data=ROOT / 'data/coco128.yaml',  # dataset.yaml path
     imgsz=(640, 640),  # inference size (height, width)
     conf_thres=0.25,  # confidence threshold
@@ -84,6 +84,7 @@ def run(
     is_file = Path(source).suffix[1:] in (IMG_FORMATS + VID_FORMATS)
     is_url = source.lower().startswith(('rtsp://', 'rtmp://', 'http://', 'https://'))
     webcam = source.isnumeric() or source.endswith('.txt') or (is_url and not is_file)
+    screenshot = source.lower().startswith('screen')
     if is_url and is_file:
         source = check_file(source)  # download
 
@@ -101,6 +102,8 @@ def run(
     if webcam:
         view_img = check_imshow()
         dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt, vid_stride=vid_stride)
+    elif screenshot:
+        dataset = LoadScreenshots(source, img_size=imgsz, stride=stride, auto=pt)
     else:
         dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt, vid_stride=vid_stride)
     bs = len(dataset)  # batch_size
@@ -222,7 +225,7 @@ def run(
 def parse_opt():
     parser = argparse.ArgumentParser()
     parser.add_argument('--weights', nargs='+', type=str, default=ROOT / 'yolov5s-seg.pt', help='model path(s)')
-    parser.add_argument('--source', type=str, default=ROOT / 'data/images', help='file/dir/URL/glob, 0 for webcam')
+    parser.add_argument('--source', type=str, default=ROOT / 'data/images', help='file/dir/URL/glob/screen/0(webcam)')
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='(optional) dataset.yaml path')
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[640], help='inference size h,w')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='confidence threshold')

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -445,6 +445,7 @@
         "python detect.py --source 0  # webcam\n",
         "                          img.jpg  # image \n",
         "                          vid.mp4  # video\n",
+        "                          screen  # screenshot\n",
         "                          path/  # directory\n",
         "                          'path/*.jpg'  # glob\n",
         "                          'https://youtu.be/Zgi9g1ksQHc'  # YouTube\n",

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -203,6 +203,7 @@ class LoadScreenshots:
         self.transforms = transforms
         self.auto = auto
         self.mode = 'image'
+        self.nf = 0  # number of files
         self.sct = mss.mss()
         # Get information of monitor
         self.monitor = self.sct.monitors[self.screen]
@@ -235,7 +236,8 @@ class LoadScreenshots:
             im = letterbox(im0, self.img_size, stride=self.stride, auto=self.auto)[0]  # padded resize
             im = im.transpose((2, 0, 1))[::-1]  # HWC to CHW, BGR to RGB
             im = np.ascontiguousarray(im)  # contiguous
-        return str(self.screen), im, im0, None, s  # screen, img, original img, im0s, s
+        self.nf += 1
+        return str(self.nf) + '_', im, im0, None, s  # screen, img, original img, im0s, s
 
 
 class LoadImages:

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -185,28 +185,22 @@ class _RepeatSampler:
         while True:
             yield from iter(self.sampler)
 
-
-class LoadScreenshot:
+class LoadScreenshots:
     # YOLOv5 image/video dataloader, i.e. `python detect.py --source "screen 0 100 100 512 256"`
-    def __init__(self,
-                 screen=0,
-                 left=None,
-                 top=None,
-                 width=None,
-                 height=None,
-                 img_size=640,
-                 stride=32,
-                 auto=True,
-                 transforms=None):
+    def __init__(self, source, img_size=640, stride=32, auto=True, transforms=None):
+        # get all parames
+        source, *params = source.split()
+        self.screen, self.left, self.top, self.width, self.height = 0, None, None, None, None # default to full screen 0
+        if len(params) == 1:
+            self.screen = int(params[0])
+        elif len(params) == 4:
+            self.left, self.top, self.width, self.height = [int(x) for x in params]
+        elif len(params) == 5:
+            self.screen, self.left, self.top, self.width, self.height = [int(x) for x in params]
         self.img_size = img_size
         self.stride = stride
         self.transforms = transforms
         self.auto = auto
-        self.screen = screen
-        self.left = left
-        self.top = top
-        self.width = width
-        self.height = height
         self.mode = 'image'
         self.sct = mss.mss()
         # Get information of monitor
@@ -218,7 +212,7 @@ class LoadScreenshot:
         if self.left is None:
             self.left = self.monitor["left"]
         else:
-            self.left = self.monitor["left"] + self.left
+            self.left = self.monitor["left"] + self.left  
         if self.width is None:
             self.width = self.monitor["width"]
         if self.height is None:

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -185,18 +185,19 @@ class _RepeatSampler:
         while True:
             yield from iter(self.sampler)
 
+
 class LoadScreenshots:
     # YOLOv5 image/video dataloader, i.e. `python detect.py --source "screen 0 100 100 512 256"`
     def __init__(self, source, img_size=640, stride=32, auto=True, transforms=None):
         # get all parames
         source, *params = source.split()
-        self.screen, self.left, self.top, self.width, self.height = 0, None, None, None, None # default to full screen 0
+        self.screen, self.left, self.top, self.width, self.height = 0, None, None, None, None  # default to full screen 0
         if len(params) == 1:
             self.screen = int(params[0])
         elif len(params) == 4:
-            self.left, self.top, self.width, self.height = [int(x) for x in params]
+            self.left, self.top, self.width, self.height = (int(x) for x in params)
         elif len(params) == 5:
-            self.screen, self.left, self.top, self.width, self.height = [int(x) for x in params]
+            self.screen, self.left, self.top, self.width, self.height = (int(x) for x in params)
         self.img_size = img_size
         self.stride = stride
         self.transforms = transforms
@@ -212,7 +213,7 @@ class LoadScreenshots:
         if self.left is None:
             self.left = self.monitor["left"]
         else:
-            self.left = self.monitor["left"] + self.left  
+            self.left = self.monitor["left"] + self.left
         if self.width is None:
             self.width = self.monitor["width"]
         if self.height is None:

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -18,8 +18,8 @@ from pathlib import Path
 from threading import Thread
 from urllib.parse import urlparse
 from zipfile import ZipFile
-import mss
 
+import mss
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -185,9 +185,19 @@ class _RepeatSampler:
         while True:
             yield from iter(self.sampler)
 
+
 class LoadScreenshot:
     # YOLOv5 image/video dataloader, i.e. `python detect.py --source "screen 0 100 100 512 256"`
-    def __init__(self, screen=0, left=None, top=None, width=None, height=None , img_size=640, stride=32, auto=True, transforms=None):
+    def __init__(self,
+                 screen=0,
+                 left=None,
+                 top=None,
+                 width=None,
+                 height=None,
+                 img_size=640,
+                 stride=32,
+                 auto=True,
+                 transforms=None):
         self.img_size = img_size
         self.stride = stride
         self.transforms = transforms
@@ -204,11 +214,11 @@ class LoadScreenshot:
         if self.top is None:
             self.top = self.monitor["top"]
         else:
-            self.top = self.monitor["top"]+self.top
+            self.top = self.monitor["top"] + self.top
         if self.left is None:
             self.left = self.monitor["left"]
         else:
-            self.left = self.monitor["left"]+self.left  
+            self.left = self.monitor["left"] + self.left
         if self.width is None:
             self.width = self.monitor["width"]
         if self.height is None:
@@ -217,10 +227,11 @@ class LoadScreenshot:
 
     def __iter__(self):
         return self
+
     def __next__(self):
         # mss screen capture
         # Get raw pixels from the screen, save it to a Numpy array
-        im0 = np.array(self.sct.grab(self.monitor))[:, :, :3] # [:, :, :3] BGRA to BGR
+        im0 = np.array(self.sct.grab(self.monitor))[:, :, :3]  # [:, :, :3] BGRA to BGR
         s = f"screen {self.screen} (LTWH): {self.left},{self.top},{self.width},{self.height}: "
 
         if self.transforms:
@@ -230,6 +241,7 @@ class LoadScreenshot:
             im = im.transpose((2, 0, 1))[::-1]  # HWC to CHW, BGR to RGB
             im = np.ascontiguousarray(im)  # contiguous
         return str(self.screen), im, im0, None, s  # screen, img, original img, im0s, s
+
 
 class LoadImages:
     # YOLOv5 image/video dataloader, i.e. `python detect.py --source image.jpg/vid.mp4`

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -190,6 +190,7 @@ class LoadScreenshots:
     def __init__(self, source, img_size=640, stride=32, auto=True, transforms=None):
         # source = [screen_number left top width height] (pixels)
         check_requirements('mss')
+        import mss
 
         source, *params = source.split()
         self.screen, left, top, width, height = 0, None, None, None, None  # default to full screen 0
@@ -219,8 +220,7 @@ class LoadScreenshots:
         return self
 
     def __next__(self):
-        # mss screen capture
-        # Get raw pixels from the screen, save it to a Numpy array
+        # mss screen capture: get raw pixels from the screen as np array
         im0 = np.array(self.sct.grab(self.monitor))[:, :, :3]  # [:, :, :3] BGRA to BGR
         s = f"screen {self.screen} (LTWH): {self.left},{self.top},{self.width},{self.height}: "
 

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -203,8 +203,12 @@ class LoadScreenshot:
         self.monitor = self.sct.monitors[self.screen]
         if self.top is None:
             self.top = self.monitor["top"]
+        else:
+            self.top = self.monitor["top"]+self.top
         if self.left is None:
             self.left = self.monitor["left"]
+        else:
+            self.left = self.monitor["left"]+self.left  
         if self.width is None:
             self.width = self.monitor["width"]
         if self.height is None:

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -202,8 +202,8 @@ class LoadScreenshots:
         self.stride = stride
         self.transforms = transforms
         self.auto = auto
-        self.mode = 'image'
-        self.nf = 0  # number of files
+        self.mode = 'stream'
+        self.frame = 0
         self.sct = mss.mss()
         # Get information of monitor
         self.monitor = self.sct.monitors[self.screen]
@@ -236,8 +236,8 @@ class LoadScreenshots:
             im = letterbox(im0, self.img_size, stride=self.stride, auto=self.auto)[0]  # padded resize
             im = im.transpose((2, 0, 1))[::-1]  # HWC to CHW, BGR to RGB
             im = np.ascontiguousarray(im)  # contiguous
-        self.nf += 1
-        return str(self.nf) + '_', im, im0, None, s  # screen, img, original img, im0s, s
+        self.frame += 1
+        return str(self.screen), im, im0, None, s  # screen, img, original img, im0s, s
 
 
 class LoadImages:

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -19,7 +19,6 @@ from threading import Thread
 from urllib.parse import urlparse
 from zipfile import ZipFile
 
-import mss
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -187,9 +186,9 @@ class _RepeatSampler:
 
 
 class LoadScreenshots:
-    # YOLOv5 image/video dataloader, i.e. `python detect.py --source "screen 0 100 100 512 256"`
+    # YOLOv5 screenshot dataloader, i.e. `python detect.py --source "screen 0 100 100 512 256"`
     def __init__(self, source, img_size=640, stride=32, auto=True, transforms=None):
-        # get all parames
+        check_requirements('mss')
         source, *params = source.split()
         self.screen, self.left, self.top, self.width, self.height = 0, None, None, None, None  # default to full screen 0
         if len(params) == 1:


### PR DESCRIPTION
add SCREENSHOT as source ([isse link](https://github.com/ultralytics/yolov5/issues/2045#issuecomment-1253875724))
you can use it like:
```
python .\detect.py --source screen   # default full screen(0)
python .\detect.py --source "screen 2"   # 2nd screen only if you have multiple monitors, can specify screen number
python .\detect.py --source "screen 500 600 256 256"   # Specify top, left, width and height
python .\detect.py --source "screen 1 500 100 256 256"   # Specify screen nunmber, top, left, width and height
```
Position parameters(left,top) is relative to the "screen"'s left and top,
if you have multiple monitors, the left and top of the screen my be NOT (0,0) !
About the screen can refer to the [mss document](https://python-mss.readthedocs.io/examples.html#part-of-the-screen-of-the-2nd-monitor)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Introducing screenshot detection to YOLOv5 with the new `screen` source option.

### 📊 Key Changes
- 🖥️ Added ability to take screenshots as input with `screen` source keyword.
- 🔎 Expanded input sources in `README.md`, notebook, and script help strings to include new screenshot functionality.
- 🧰 Integrated the `LoadScreenshots` class for fetching screen captures as a data source.
- ➕ Added a requirement for the `mss` library, which is necessary for screenshot functionality.

### 🎯 Purpose & Impact
- 🆕 The purpose of this change is to widen the input capabilities of YOLOv5 to include live screen captures, offering more flexibility for real-time applications.
- 📈 This will have a positive impact on users who wish to apply YOLOv5 object detection on their screen content without the need for pre-recorded media or additional hardware.
- 👨‍💻 Developers can now seamlessly integrate YOLOv5 into desktop applications that work with screen content, enhancing automation and monitoring solutions.