### PR TITLE
Add best epoch print.

### DIFF
--- a/train.py
+++ b/train.py
@@ -426,7 +426,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                         callbacks.run('on_fit_epoch_end', list(mloss) + list(results) + lr, epoch, best_fitness, fi)
 
         callbacks.run('on_train_end', last, best, epoch, results)
-    LOGGER.info(f'\nBest_epoch: {best_epoch}.')
+    LOGGER.info(f'\nBest epoch: {best_epoch}.')
     torch.cuda.empty_cache()
     return results
 

--- a/train.py
+++ b/train.py
@@ -256,6 +256,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                 f'Using {train_loader.num_workers * WORLD_SIZE} dataloader workers\n'
                 f"Logging results to {colorstr('bold', save_dir)}\n"
                 f'Starting training for {epochs} epochs...')
+    best_epoch = 0
     for epoch in range(start_epoch, epochs):  # epoch ------------------------------------------------------------------
         callbacks.run('on_train_epoch_start')
         model.train()
@@ -363,6 +364,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
             stop = stopper(epoch=epoch, fitness=fi)  # early stop check
             if fi > best_fitness:
                 best_fitness = fi
+                best_epoch = epoch
             log_vals = list(mloss) + list(results) + lr
             callbacks.run('on_fit_epoch_end', log_vals, epoch, best_fitness, fi)
 
@@ -424,7 +426,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                         callbacks.run('on_fit_epoch_end', list(mloss) + list(results) + lr, epoch, best_fitness, fi)
 
         callbacks.run('on_train_end', last, best, epoch, results)
-
+    LOGGER.info(f'\nBest_epoch: {best_epoch}.')
     torch.cuda.empty_cache()
     return results
 


### PR DESCRIPTION
Sometimes we need know which epoch is the best, then to reduce epochs or do something else, but at now it seems we cannot directly known which epoch is the best, and the results.png or results.csv is not so convenient.

Signed-off-by: Mr.Fire <fire15@126.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary 
Improved model training feedback by tracking the best epoch performance.

### 📊 Key Changes
- Added a `best_epoch` variable to keep track of the epoch with the highest performance.
- Logged the best epoch when training concludes to provide users with information about when the model achieved its peak performance.

### 🎯 Purpose & Impact
- **Purpose:** To make it easier for users to identify which epoch yielded the best results during training.
- **Impact:** Users can now quickly determine the most effective training point, which may be useful for further analysis or for early stopping considerations. This enhancement improves the interpretability and monitoring of the training process. 🚀