### PR TITLE
Added support for 1-channel data in detect.py

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -76,6 +76,7 @@ def run(
         half=False,  # use FP16 half-precision inference
         dnn=False,  # use OpenCV DNN for ONNX inference
         vid_stride=1,  # video frame-rate stride
+        channels=3,  # number of channels of source data
 ):
     source = str(source)
     save_img = not nosave and not source.endswith('.txt')  # save inference images
@@ -108,7 +109,7 @@ def run(
     vid_path, vid_writer = [None] * bs, [None] * bs
 
     # Run inference
-    model.warmup(imgsz=(1 if pt or model.triton else bs, 3, *imgsz))  # warmup
+    model.warmup(imgsz=(1 if pt or model.triton else bs, channels, *imgsz))  # warmup
     seen, windows, dt = 0, [], (Profile(), Profile(), Profile())
     for path, im, im0s, vid_cap, s in dataset:
         with dt[0]:
@@ -241,6 +242,7 @@ def parse_opt():
     parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
     parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
     parser.add_argument('--vid-stride', type=int, default=1, help='video frame-rate stride')
+    parser.add_argument('--channels', type=int, default=3, help='number of channels of source data')
     opt = parser.parse_args()
     opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1  # expand
     print_args(vars(opt))


### PR DESCRIPTION
Signed-off-by: Louis Combaldieu <louis.combaldieu@auxilia-tech.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Support for custom channel numbers in YOLOv5 inference.

### 📊 Key Changes
- Added `channels` argument to the `run` function in `detect.py`
- Model warmup now uses the `channels` argument to handle different channel numbers
- New `--channels` command-line argument in `parse_opt()` to specify the number of channels

### 🎯 Purpose & Impact
- **Purpose:** This change allows YOLOv5 to process images with a custom number of channels, not just the standard 3 (RGB).
- **Potential Impact:** Users can now work with images with different numbers of channels (like grayscale images with 1 channel, or multispectral data with more than 3 channels), expanding the usability of YOLOv5 for various applications.