### PR TITLE
Apple MPS -> CPU NMS fallback strategy

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -843,6 +843,8 @@ def non_max_suppression(
     if isinstance(prediction, (list, tuple)):  # YOLOv5 model in validation model, output = (inference_out, loss_out)
         prediction = prediction[0]  # select only inference output
 
+    if 'mps' in prediction.device.type:  # MPS not fully supported yet, convert tensors to CPU before NMS
+        prediction = prediction.cpu()
     bs = prediction.shape[0]  # batch size
     nc = prediction.shape[2] - nm - 5  # number of classes
     xc = prediction[..., 4] > conf_thres  # candidates


### PR DESCRIPTION
Until more ops are fully supported this update will allow for seamless MPS inference (but slower MPS to CPU transfer before NMS, so slower NMS times).

```
python detect.py --device mps
```

Partially resolves https://github.com/ultralytics/yolov5/issues/9596

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced compatibility for Metal Performance Shaders (MPS) in non_max_suppression function.

### 📊 Key Changes
- Added a check to see if the MPS backend is being used.
- Converting prediction tensors to CPU if they are on an MPS device before Non-Maximum Suppression (NMS).

### 🎯 Purpose & Impact
- **Purpose:** To ensure the `non_max_suppression` function works even if the MPS backend is used, preventing any potential issues due to incomplete MPS support.
- **Impact:** Users working on Apple silicon Macs that leverage MPS for accelerated machine learning tasks will now experience smoother operation with YOLOv5, ensuring wider hardware compatibility. 🍏💻✨