### PR TITLE
Fix `is_url('https://ultralytics.com')`

### DIFF
--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -21,7 +21,7 @@ def is_url(url, check=True):
     try:
         url = str(url)
         result = urllib.parse.urlparse(url)
-        assert all([result.scheme, result.netloc, result.path])  # check if is url
+        assert all([result.scheme, result.netloc])  # check if is url
         return (urllib.request.urlopen(url).getcode() == 200) if check else True  # check if exists online
     except (AssertionError, urllib.request.HTTPError):
         return False


### PR DESCRIPTION
Failing on missing path, i.e. no 'www.'

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of URL validation in download utility.

### 📊 Key Changes
- Simplified the URL validation check by removing the requirement that the URL must have a path component.

### 🎯 Purpose & Impact
- Improves URL checking logic to consider URLs without paths as valid.
- May prevent potential bugs related to URL validation and ensure that more types of URLs can be used without issues.
- Users might experience enhanced flexibility and fewer errors when interacting with functions that verify URLs. 🌐✅