### PR TITLE
Add `results.save(save_dir='path', exist_ok=False)`

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -775,12 +775,12 @@ class Detections:
     def show(self, labels=True):
         self._run(show=True, labels=labels)  # show results
 
-    def save(self, labels=True, save_dir='runs/detect/exp'):
-        save_dir = increment_path(save_dir, exist_ok=save_dir != 'runs/detect/exp', mkdir=True)  # increment save_dir
+    def save(self, labels=True, save_dir='runs/detect/exp', exist_ok=False):
+        save_dir = increment_path(save_dir, exist_ok, mkdir=True)  # increment save_dir
         self._run(save=True, labels=labels, save_dir=save_dir)  # save results
 
-    def crop(self, save=True, save_dir='runs/detect/exp'):
-        save_dir = increment_path(save_dir, exist_ok=save_dir != 'runs/detect/exp', mkdir=True) if save else None
+    def crop(self, save=True, save_dir='runs/detect/exp', exist_ok=False):
+        save_dir = increment_path(save_dir, exist_ok, mkdir=True) if save else None
         return self._run(crop=True, save=save, save_dir=save_dir)  # crop results
 
     def render(self, labels=True):


### PR DESCRIPTION
Partially resolves https://github.com/ultralytics/yolov5/issues/9522

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlining output directory management for saving and cropping operations in YOLOv5 detection results.

### 📊 Key Changes
- Altered the `save` method by introducing an `exist_ok` parameter, controlling the overwrite behavior for existing directories.
- Updated the `crop` method with a new `exist_ok` parameter to match the save method's behavior.

### 🎯 Purpose & Impact
- 💾 **Enhanced Customization**: Users now have more control over how the results are saved, particularly when dealing with existing directories.
- 🔄 **Consistency Across Methods**: Both `save` and `crop` methods now share a similar interface for directory handling, making the API more uniform.
- 🛠️ **Reduction of Default Overwrites**: By default, directories won't be overwritten, reducing the risk of unintentional data loss or confusion.
- 🤖 **Potential Automation Enhancements**: With the explicit `exist_ok` parameter, automation scripts that leverage these methods can be more precise and safer.