### PR TITLE
Albumentations from hyp

### DIFF
--- a/data/hyps/hyp.scratch-high.yaml
+++ b/data/hyps/hyp.scratch-high.yaml
@@ -46,14 +46,14 @@ perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
 # Transforms are applied in declaration's order
 # One can declare any albumentations-compatible transforms
 # add a "module" key to specify a module other than "albumentations"
-# params can be transfoms. 
+# params can be transfoms.
 # To do so, provide an intermediate key-value pair
 #   where key is either $transform or $transform_list
 albumentations:
   - name: "ToGray"
     p: 0.33
   - name: OneOf
-    params: 
+    params:
       transforms:
         $transform_list:
           - name: "Blur"

--- a/data/hyps/hyp.scratch-high.yaml
+++ b/data/hyps/hyp.scratch-high.yaml
@@ -41,21 +41,23 @@ scale: 0.5  # image scale (+/- gain)
 shear: 0.0  # image shear (+/- deg)
 perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
 
-# Albumentations transform list
+# Albumentations transform list (root is a Compose transform)
 # Applied only if albumentations module installed
 # Transforms are applied in declaration's order
 # One can declare any albumentations-compatible transforms
 # add a "module" key to specify a module other than "albumentations"
+# params can be transfoms. 
+# To do so, provide an intermediate key-value pair
+#   where key is either $transform or $transform_list
 albumentations:
   - name: "ToGray"
     p: 0.33
-  - name: "Blur"
-    p: 0.01
-  - name: "MedianBlur"
-    p: 0.01
-  - name: "CLAHE"
-    p: 0.01
-  - name: "ImageCompression"
-    p: 0.1
-    params:
-      quality_lower: 75
+  - name: OneOf
+    params: 
+      transforms:
+        $transform_list:
+          - name: "Blur"
+          - name: "MedianBlur"
+          - name: "ImageCompression"
+            params:
+              quality_lower: 75

--- a/data/hyps/hyp.scratch-high.yaml
+++ b/data/hyps/hyp.scratch-high.yaml
@@ -19,16 +19,43 @@ iou_t: 0.20  # IoU training threshold
 anchor_t: 4.0  # anchor-multiple threshold
 # anchors: 3  # anchors per output layer (0 to ignore)
 fl_gamma: 0.0  # focal loss gamma (efficientDet default gamma=1.5)
+
+# Complex transforms
+mosaic: 1.0  # image mosaic (probability)
+mixup: 0.0  # image mixup (probability)
+copy_paste: 0.0  # segment copy-paste (probability)
+
+# HSV transforms, disable this if provided in albumentations
 hsv_h: 0.015  # image HSV-Hue augmentation (fraction)
 hsv_s: 0.7  # image HSV-Saturation augmentation (fraction)
 hsv_v: 0.4  # image HSV-Value augmentation (fraction)
-degrees: 0.0  # image rotation (+/- deg)
-translate: 0.1  # image translation (+/- fraction)
-scale: 0.9  # image scale (+/- gain)
-shear: 0.0  # image shear (+/- deg)
-perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
+
+# Flip transforms, disable this if provided in albumentations
 flipud: 0.0  # image flip up-down (probability)
 fliplr: 0.5  # image flip left-right (probability)
-mosaic: 1.0  # image mosaic (probability)
-mixup: 0.1  # image mixup (probability)
-copy_paste: 0.1  # segment copy-paste (probability)
+
+# Geometric transforms applied to each image individualy
+degrees: 0.0  # image rotation (+/- deg)
+translate: 0.1  # image translation (+/- fraction)
+scale: 0.5  # image scale (+/- gain)
+shear: 0.0  # image shear (+/- deg)
+perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
+
+# Albumentations transform list
+# Applied only if albumentations module installed
+# Transforms are applied in declaration's order
+# One can declare any albumentations-compatible transforms
+# add a "module" key to specify a module other than "albumentations"
+albumentations:
+  - name: "ToGray"
+    p: 0.33
+  - name: "Blur"
+    p: 0.01
+  - name: "MedianBlur"
+    p: 0.01
+  - name: "CLAHE"
+    p: 0.01
+  - name: "ImageCompression"
+    p: 0.1
+    params:
+      quality_lower: 75

--- a/data/hyps/hyp.scratch-low.yaml
+++ b/data/hyps/hyp.scratch-low.yaml
@@ -46,14 +46,14 @@ perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
 # Transforms are applied in declaration's order
 # One can declare any albumentations-compatible transforms
 # add a "module" key to specify a module other than "albumentations"
-# params can be transfoms. 
+# params can be transfoms.
 # To do so, provide an intermediate key-value pair
 #   where key is either $transform or $transform_list
 albumentations:
   - name: "ToGray"
     p: 0.33
   - name: OneOf
-    params: 
+    params:
       transforms:
         $transform_list:
           - name: "Blur"

--- a/data/hyps/hyp.scratch-low.yaml
+++ b/data/hyps/hyp.scratch-low.yaml
@@ -41,21 +41,23 @@ scale: 0.5  # image scale (+/- gain)
 shear: 0.0  # image shear (+/- deg)
 perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
 
-# Albumentations transform list
+# Albumentations transform list (root is a Compose transform)
 # Applied only if albumentations module installed
 # Transforms are applied in declaration's order
 # One can declare any albumentations-compatible transforms
 # add a "module" key to specify a module other than "albumentations"
+# params can be transfoms. 
+# To do so, provide an intermediate key-value pair
+#   where key is either $transform or $transform_list
 albumentations:
   - name: "ToGray"
     p: 0.33
-  - name: "Blur"
-    p: 0.01
-  - name: "MedianBlur"
-    p: 0.01
-  - name: "CLAHE"
-    p: 0.01
-  - name: "ImageCompression"
-    p: 0.1
-    params:
-      quality_lower: 75
+  - name: OneOf
+    params: 
+      transforms:
+        $transform_list:
+          - name: "Blur"
+          - name: "MedianBlur"
+          - name: "ImageCompression"
+            params:
+              quality_lower: 75

--- a/data/hyps/hyp.scratch-low.yaml
+++ b/data/hyps/hyp.scratch-low.yaml
@@ -19,16 +19,43 @@ iou_t: 0.20  # IoU training threshold
 anchor_t: 4.0  # anchor-multiple threshold
 # anchors: 3  # anchors per output layer (0 to ignore)
 fl_gamma: 0.0  # focal loss gamma (efficientDet default gamma=1.5)
+
+# Complex transforms
+mosaic: 1.0  # image mosaic (probability)
+mixup: 0.0  # image mixup (probability)
+copy_paste: 0.0  # segment copy-paste (probability)
+
+# HSV transforms, disable this if provided in albumentations
 hsv_h: 0.015  # image HSV-Hue augmentation (fraction)
 hsv_s: 0.7  # image HSV-Saturation augmentation (fraction)
 hsv_v: 0.4  # image HSV-Value augmentation (fraction)
+
+# Flip transforms, disable this if provided in albumentations
+flipud: 0.0  # image flip up-down (probability)
+fliplr: 0.5  # image flip left-right (probability)
+
+# Geometric transforms applied to each image individualy
 degrees: 0.0  # image rotation (+/- deg)
 translate: 0.1  # image translation (+/- fraction)
 scale: 0.5  # image scale (+/- gain)
 shear: 0.0  # image shear (+/- deg)
 perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
-flipud: 0.0  # image flip up-down (probability)
-fliplr: 0.5  # image flip left-right (probability)
-mosaic: 1.0  # image mosaic (probability)
-mixup: 0.0  # image mixup (probability)
-copy_paste: 0.0  # segment copy-paste (probability)
+
+# Albumentations transform list
+# Applied only if albumentations module installed
+# Transforms are applied in declaration's order
+# One can declare any albumentations-compatible transforms
+# add a "module" key to specify a module other than "albumentations"
+albumentations:
+  - name: "ToGray"
+    p: 0.33
+  - name: "Blur"
+    p: 0.01
+  - name: "MedianBlur"
+    p: 0.01
+  - name: "CLAHE"
+    p: 0.01
+  - name: "ImageCompression"
+    p: 0.1
+    params:
+      quality_lower: 75

--- a/data/hyps/hyp.scratch-med.yaml
+++ b/data/hyps/hyp.scratch-med.yaml
@@ -46,14 +46,14 @@ perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
 # Transforms are applied in declaration's order
 # One can declare any albumentations-compatible transforms
 # add a "module" key to specify a module other than "albumentations"
-# params can be transfoms. 
+# params can be transfoms.
 # To do so, provide an intermediate key-value pair
 #   where key is either $transform or $transform_list
 albumentations:
   - name: "ToGray"
     p: 0.33
   - name: OneOf
-    params: 
+    params:
       transforms:
         $transform_list:
           - name: "Blur"

--- a/data/hyps/hyp.scratch-med.yaml
+++ b/data/hyps/hyp.scratch-med.yaml
@@ -41,21 +41,23 @@ scale: 0.5  # image scale (+/- gain)
 shear: 0.0  # image shear (+/- deg)
 perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
 
-# Albumentations transform list
+# Albumentations transform list (root is a Compose transform)
 # Applied only if albumentations module installed
 # Transforms are applied in declaration's order
 # One can declare any albumentations-compatible transforms
 # add a "module" key to specify a module other than "albumentations"
+# params can be transfoms. 
+# To do so, provide an intermediate key-value pair
+#   where key is either $transform or $transform_list
 albumentations:
   - name: "ToGray"
     p: 0.33
-  - name: "Blur"
-    p: 0.01
-  - name: "MedianBlur"
-    p: 0.01
-  - name: "CLAHE"
-    p: 0.01
-  - name: "ImageCompression"
-    p: 0.1
-    params:
-      quality_lower: 75
+  - name: OneOf
+    params: 
+      transforms:
+        $transform_list:
+          - name: "Blur"
+          - name: "MedianBlur"
+          - name: "ImageCompression"
+            params:
+              quality_lower: 75

--- a/data/hyps/hyp.scratch-med.yaml
+++ b/data/hyps/hyp.scratch-med.yaml
@@ -19,16 +19,43 @@ iou_t: 0.20  # IoU training threshold
 anchor_t: 4.0  # anchor-multiple threshold
 # anchors: 3  # anchors per output layer (0 to ignore)
 fl_gamma: 0.0  # focal loss gamma (efficientDet default gamma=1.5)
+
+# Complex transforms
+mosaic: 1.0  # image mosaic (probability)
+mixup: 0.0  # image mixup (probability)
+copy_paste: 0.0  # segment copy-paste (probability)
+
+# HSV transforms, disable this if provided in albumentations
 hsv_h: 0.015  # image HSV-Hue augmentation (fraction)
 hsv_s: 0.7  # image HSV-Saturation augmentation (fraction)
 hsv_v: 0.4  # image HSV-Value augmentation (fraction)
-degrees: 0.0  # image rotation (+/- deg)
-translate: 0.1  # image translation (+/- fraction)
-scale: 0.9  # image scale (+/- gain)
-shear: 0.0  # image shear (+/- deg)
-perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
+
+# Flip transforms, disable this if provided in albumentations
 flipud: 0.0  # image flip up-down (probability)
 fliplr: 0.5  # image flip left-right (probability)
-mosaic: 1.0  # image mosaic (probability)
-mixup: 0.1  # image mixup (probability)
-copy_paste: 0.0  # segment copy-paste (probability)
+
+# Geometric transforms applied to each image individualy
+degrees: 0.0  # image rotation (+/- deg)
+translate: 0.1  # image translation (+/- fraction)
+scale: 0.5  # image scale (+/- gain)
+shear: 0.0  # image shear (+/- deg)
+perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
+
+# Albumentations transform list
+# Applied only if albumentations module installed
+# Transforms are applied in declaration's order
+# One can declare any albumentations-compatible transforms
+# add a "module" key to specify a module other than "albumentations"
+albumentations:
+  - name: "ToGray"
+    p: 0.33
+  - name: "Blur"
+    p: 0.01
+  - name: "MedianBlur"
+    p: 0.01
+  - name: "CLAHE"
+    p: 0.01
+  - name: "ImageCompression"
+    p: 0.1
+    params:
+      quality_lower: 75

--- a/train.py
+++ b/train.py
@@ -210,6 +210,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                                        gs,
                                        single_cls,
                                        hyp=hyp,
+                                       augment=True,
                                        cache=None if noval else opt.cache,
                                        rect=True,
                                        rank=-1,

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -45,7 +45,7 @@ class Albumentations:
                 check_version(A.__version__, '1.0.3', hard=True)
             except ImportError:
                 LOGGER.error(f'{prefix} albumentations module not available (hyps.albumentations ignored)')
-            except Exception as what:
+            except Exception:
                 LOGGER.error(f'{prefix} wrong albumentations version : 1.0.3 required (hyps.albumentations ignored)')
             else:
                 # try to load transforms

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -87,7 +87,7 @@ class Albumentations:
                 '$t' -> the value is expected to be a transform
                 '$tl' -> the value is expected to be a list of tranforms
         """
-        assert isinstance(config, dict), f'dict required'
+        assert isinstance(config, dict), 'dict required'
 
         assert 'name' in config, 'missing key "name"'
         name = config['name']

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -83,7 +83,7 @@ class Albumentations:
             try:
                 Transform = getattr(module, name)
             except Exception:
-                raise Exception('"{}" not found in module "{}"'.format(name, module_name))
+                raise Exception(f'"{name}" not found in module "{module_name}"')
             # build the transform with all params
             transform = Transform(p=p, **params)
             LOGGER.info(f'{prefix} @T{cid} {module_name}.{name} p={p}')

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -79,12 +79,12 @@ class Albumentations:
 
             - name (str)
             - [module (str) = 'albumentations']
-            - [params (dict) = {}]
+            - [params (dict) = dict()]
             - [p (float) = 1.0]
 
             params are checked recursively.
             if any [sub-]value is a key-value pair (dict)
-            where the key is 
+            where the key is
                 '$t' -> the value is expected to be a transform
                 '$tl' -> the value is expected to be a list of tranforms
         """
@@ -101,7 +101,7 @@ class Albumentations:
             try:
                 module = import_module(module_name)
             except Exception:
-                raise Exception('module "%s" not found' % module_name)
+                raise Exception(f'module {module_name} not found')
         # load Transform class from module
         try:
             Transform = getattr(module, name)

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -3,9 +3,9 @@
 Image augmentation functions
 """
 
-from difflib import IS_LINE_JUNK
 import math
 import random
+from difflib import IS_LINE_JUNK
 from importlib import import_module
 
 import cv2
@@ -52,11 +52,10 @@ class Albumentations:
                 # try to load transforms
                 # first level is expected to be a list of transforms
                 try:
-                    transforms = self.recursively_parse(
-                        '', {self.TRANSFORM_LIST_KEY: config}, A, prefix)
+                    transforms = self.recursively_parse('', {self.TRANSFORM_LIST_KEY: config}, A, prefix)
                     # combine transforms
                     transform = A.Compose(transforms,
-                        bbox_params=A.BboxParams(format='yolo', label_fields=['class_labels']))
+                                          bbox_params=A.BboxParams(format='yolo', label_fields=['class_labels']))
                 except Exception as what:
                     raise Exception(f'bad transform config {what:s}')
         self.transform = transform
@@ -84,7 +83,7 @@ class Albumentations:
 
             params are checked recursively.
             if any [sub-]value is a key-value pair (dict)
-            where the key is 
+            where the key is
                 '$t' -> the value is expected to be a transform
                 '$tl' -> the value is expected to be a list of tranforms
         """
@@ -117,40 +116,30 @@ class Albumentations:
         LOGGER.info(f'{prefix} {root} {module_name}.{name} p={p}')
         # load params
         params = config.get('params', {})
-        params = cls.recursively_parse(
-            f'{root}/params', params, A, prefix)
+        params = cls.recursively_parse(f'{root}/params', params, A, prefix)
         # build the transform with all params
         transform = Transform(p=p, **params)
         return transform
 
-
     @classmethod
     def recursively_parse(cls, root: str, param, A, prefix):
         if cls.is_transform(param):
-            parsed = cls.transform_factory(
-                root, param[cls.TRANSFORM_KEY], A, prefix)
+            parsed = cls.transform_factory(root, param[cls.TRANSFORM_KEY], A, prefix)
 
         elif cls.is_transform_list(param):
             parsed = [
-                cls.transform_factory(
-                    f'{root}/@{cid}', sub_config, A, prefix)
-                for cid, sub_config 
-                in enumerate(param[cls.TRANSFORM_LIST_KEY])
-            ]
+                cls.transform_factory(f'{root}/@{cid}', sub_config, A, prefix)
+                for cid, sub_config in enumerate(param[cls.TRANSFORM_LIST_KEY])]
 
         elif isinstance(param, list):
             parsed = [
-                cls.recursively_parse_params(
-                    f'{root}/@{cid}', sub_param, A, prefix)
-                for cid, sub_param in enumerate(param)
-            ]
+                cls.recursively_parse_params(f'{root}/@{cid}', sub_param, A, prefix)
+                for cid, sub_param in enumerate(param)]
 
         elif isinstance(param, dict):
             parsed = {
-                key: cls.recursively_parse_params(
-                    f'{root}/@{key}', sub_param, A, prefix)
-                for key, sub_param in param.items()
-            }
+                key: cls.recursively_parse_params(f'{root}/@{key}', sub_param, A, prefix)
+                for key, sub_param in param.items()}
         else:
             parsed = param
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -45,7 +45,7 @@ class Albumentations:
             except ImportError:
                 LOGGER.error(f'{prefix} albumentations module not available (hyps.albumentations ignored)')
             except Exception as what:
-                LOGGER.error(f'{prefix} albumentations module not available (hyps.albumentations ignored)')
+                LOGGER.error(f'{prefix} wrong albumentations version : 1.0.3 required (hyps.albumentations ignored)')
             else:
                 # try to load transforms
                 transforms = filter(
@@ -81,19 +81,22 @@ class Albumentations:
             module_name = config.get('module')
             if module_name is None:
                 module = A
+                module_name = 'albumentations'
             else:
                 # load module from name
                 try:
                     module = import_module(module_name)
                 except Exception:
                     raise Exception('module "%s" not found' % module_name)
-                # load Transform class from module
-                try:
-                    Transform = getattr(module, name)
-                except Exception:
-                    raise Exception('"%s" not found in module "%s"' % (name, module_name))
-                # build the transform with all params
-                return Transform(p=p, **params)
+            # load Transform class from module
+            try:
+                Transform = getattr(module, name)
+            except Exception:
+                raise Exception('"%s" not found in module "%s"' % (name, module_name))
+            # build the transform with all params
+            transform = Transform(p=p, **params)
+            LOGGER.info(f'{prefix} @T{cid} {module_name}.{name} p={p}')
+            return transform
 
         except Exception as what:
             LOGGER.error('bad albumentations transform config @%d : %s' % (cid, what))

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -403,7 +403,7 @@ class LoadImagesAndLabels(Dataset):
         self.mosaic_border = [-img_size // 2, -img_size // 2]
         self.stride = stride
         self.path = path
-        self.albumentations = Albumentations() if augment else None
+        self.albumentations = Albumentations(hyp) if augment else None
 
         try:
             f = []  # image files
@@ -610,16 +610,17 @@ class LoadImagesAndLabels(Dataset):
             nl = len(labels)  # update after albumentations
 
             # HSV color-space
-            augment_hsv(img, hgain=hyp['hsv_h'], sgain=hyp['hsv_s'], vgain=hyp['hsv_v'])
+            if 'hsv_h' in hyp:
+                augment_hsv(img, hgain=hyp['hsv_h'], sgain=hyp['hsv_s'], vgain=hyp['hsv_v'])
 
             # Flip up-down
-            if random.random() < hyp['flipud']:
+            if ('flipud' in hyp) and (random.random() < hyp['flipud']):
                 img = np.flipud(img)
                 if nl:
                     labels[:, 2] = 1 - labels[:, 2]
 
             # Flip left-right
-            if random.random() < hyp['fliplr']:
+            if ('fliplr' in hyp) and (random.random() < hyp['fliplr']):
                 img = np.fliplr(img)
                 if nl:
                     labels[:, 1] = 1 - labels[:, 1]

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -666,13 +666,13 @@ class LoadImagesAndLabels(Dataset):
                 augment_hsv(img, hgain=hyp['hsv_h'], sgain=hyp['hsv_s'], vgain=hyp['hsv_v'])
 
             # Flip up-down
-            if ('flipud' in hyp) and (random.random() < hyp['flipud']):
+            if random.random() < hyp.get('flipud', 0.0):
                 img = np.flipud(img)
                 if nl:
                     labels[:, 2] = 1 - labels[:, 2]
 
             # Flip left-right
-            if ('fliplr' in hyp) and (random.random() < hyp['fliplr']):
+            if random.random() < hyp.get('fliplr', 0.0):
                 img = np.fliplr(img)
                 if nl:
                     labels[:, 1] = 1 - labels[:, 1]


### PR DESCRIPTION
Here is (a new better) attempt at using the full potential of Albumentations.
You can provide your (additionnal) transform list in the hyp file with this syntax :

``` yaml
# Albumentations transform list
# Applied only if albumentations module installed
# Transforms are applied in declaration's order
# One can declare any albumentations-compatible transforms
# add a "module" key to specify a module other than "albumentations"
albumentations:
  - name: "ToGray"
    p: 0.33
  - name: "Blur"
    p: 0.01
  - name: "MedianBlur"
    p: 0.01
  - name: "CLAHE"
    p: 0.01
  - name: "ImageCompression"
    p: 0.1
    params:
      quality_lower: 75
``` 

- The *albumentations* key is optionnal, so it is retro-compatible with old hyp files. If no albumentations is found, then none is used.
- You can use any *albumentations-compatible* transform. The usable transforms are not restricted to the albumentations module. That means that you can write custom transforms and use it. To do so, you need to add the *module* key to your transform to tell where the custom class is to be found.
-  What is nice with this is that you can add augmentations without changing yolo's code, only your config files. So you dont need to fork and get yolov version issues.
- If a list of albumentations transforms is provided in the hyp file but the albumentations module is not installed, a warning will be loggeg and they will be ignored (a warrning is better than a crash ? i dont know but i had to choose). 

What about the existing augmentation keys ? 

``` yaml
# Geometric transforms applied to each image individualy
degrees: 90.0          # image rotation (+/- deg)
translate: 0.1        # image translation (+/- fraction)
scale: 0.5            # image scale (+/- gain)
shear: 20.0           # image shear (+/- deg)
perspective: 0.0      # image perspective (+/- fraction), range 0-0.001

# HSV & Flip transforms, disable this if provided in albumentations
hsv_h: 0.015          # image HSV-Hue augmentation (fraction)
hsv_s: 0.7            # image HSV-Saturation augmentation (fraction)
hsv_v: 0.4            # image HSV-Value augmentation (fraction)
flipud: 0.2           # image flip up-down (probability)
fliplr: 0.5           # image flip left-right (probability)
```

To keep retro-compatible, they are still used but optionnal. So you got 2 options: 
1. keep them and dont put color or flip transforms in albumentations
2. comment/remove them and add color and flip transforms in albumentations




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced augmentation capabilities in YOLOv5 with the integration of Albumentations library.

### 📊 Key Changes
- Added support for complex image transformations such as mosaic, mixup, and copy-paste.
- Expanded HSV and flip transformations with more configurable options.
- Reduced the default image scale gain from 0.9 to 0.5 for a more diverse dataset.
- Included a new Albumentations class to load user-defined transform lists from `.yaml` files.
- Updated `train.py` and `dataloaders.py` to use the new Albumentations class when augmenting images.
- The Albumentations class employs a recursive function to parse and instantiate specified augmentations.

### 🎯 Purpose & Impact
- 🆕 Provides users with a broader range of data augmentation techniques, enhancing the robustness and generalization of models.
- 🛠 Gives developers flexibility to specify custom transformations in the `.yaml` configuration files, making it easier to experiment with data augmentation.
- 👩‍💻 By outsourcing complex transformations to the Albumentations library, it simplifies the augmentation code and optimizes performance.