### PR TITLE
Disabled upload_dataset flag temporarily due to an artifact related bug

### DIFF
--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -136,7 +136,7 @@ class WandbLogger():
         if opt.upload_dataset:
             opt.upload_dataset = False
             LOGGER.info("Uploading Dataset functionality is not being supported temporarily due to a bug.")
-        
+
         # Pre-training routine --
         self.job_type = job_type
         self.wandb, self.wandb_run = wandb, None if not wandb else wandb.run

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -132,6 +132,11 @@ class WandbLogger():
         job_type (str) -- To set the job_type for this run
 
        """
+        # Temporary-fix
+        if opt.upload_dataset:
+            opt.upload_dataset = False
+            LOGGER.info("Uploading Dataset functionality is not being supported temporarily due to a bug.")
+        
         # Pre-training routine --
         self.job_type = job_type
         self.wandb, self.wandb_run = wandb, None if not wandb else wandb.run


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Temporary disablement of dataset uploading feature in WandB logger due to a bug.

### 📊 Key Changes
- The `upload_dataset` option in the WandB logger is forcefully set to `False`.
- A log message is added to inform users that the dataset uploading feature is temporarily unsupported.

### 🎯 Purpose & Impact
- 🛠️ **Prevent Errors**: Ensures that users are not affected by the current bug related to dataset uploading.
- 🚀 **Clear Communication**: Informs users about the temporary removal of the feature through a log message.
- 🌐 **User Experience**: Maintains the integrity of user experience by preventing the activation of a buggy feature until a fix is implemented.