### PR TITLE
Allow list for Comet artifact class 'names' field

### DIFF
--- a/utils/loggers/comet/__init__.py
+++ b/utils/loggers/comet/__init__.py
@@ -360,7 +360,7 @@ class CometLogger:
         elif type(metadata_names) == list:
             data_dict["names"] = {int(k): v for k, v in zip(range(len(metadata_names)), metadata_names)}
         else:
-            raise "Invalid 'names' field in data.yml, has to be a list or dictionary"
+            raise "Invalid 'names' field in dataset yaml file. Please use a list or dictionary"
 
         data_dict = self.update_data_paths(data_dict)
         return data_dict

--- a/utils/loggers/comet/__init__.py
+++ b/utils/loggers/comet/__init__.py
@@ -353,7 +353,7 @@ class CometLogger:
         metadata = logged_artifact.metadata
         data_dict = metadata.copy()
         data_dict["path"] = artifact_save_dir
-        
+
         metadata_names = metadata.get("names")
         if type(metadata_names) == dict:
             data_dict["names"] = {int(k): v for k, v in metadata.get("names").items()}

--- a/utils/loggers/comet/__init__.py
+++ b/utils/loggers/comet/__init__.py
@@ -353,7 +353,14 @@ class CometLogger:
         metadata = logged_artifact.metadata
         data_dict = metadata.copy()
         data_dict["path"] = artifact_save_dir
-        data_dict["names"] = {int(k): v for k, v in metadata.get("names").items()}
+        
+        metadata_names = metadata.get("names")
+        if type(metadata_names) == dict:
+            data_dict["names"] = {int(k): v for k, v in metadata.get("names").items()}
+        elif type(metadata_names) == list:
+            data_dict["names"] = {int(k): v for k, v in zip(range(len(metadata_names)), metadata_names)}
+        else:
+            raise "Invalid 'names' field in data.yml, has to be a list or dictionary"
 
         data_dict = self.update_data_paths(data_dict)
         return data_dict


### PR DESCRIPTION
In the Comet logger, when I run train.py, it wants to download the data artifact. It was requiring me to format the 'names' field in the data artifact metadata as a dictionary, so I've changed this so that it also accepts a list.

Signed-off-by: KristenKehrer <34010022+KristenKehrer@users.noreply.github.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced dataset artifact `names` handling in Comet Logger for YOLOv5.

### 📊 Key Changes
- Added support for `names` field as both dictionary and list in dataset metadata.
- Introduced a check to raise an error if `names` field is in an invalid format.

### 🎯 Purpose & Impact
- 🎨 The update provides flexibility, allowing `names` to be defined as either a list or a dictionary, making it easier to work with various dataset formats.
- 🚨 Raising an error for incorrect `names` format increases reliability, ensuring users are aware of configuration issues promptly.
- 🛠️ This leads to improved user experience by minimizing potential issues related to dataset metadata handling.