### PR TITLE
Added support for gradual unfreezing while training (transfer-learning)

### DIFF
--- a/train.py
+++ b/train.py
@@ -57,8 +57,8 @@ from utils.loggers.wandb.wandb_utils import check_wandb_resume
 from utils.loss import ComputeLoss
 from utils.metrics import fitness
 from utils.plots import plot_evolve
-from utils.torch_utils import (EarlyStopping, ModelEMA, de_parallel, select_device, smart_DDP, smart_optimizer,
-                               smart_resume, torch_distributed_zero_first, gradual_unfreeze)
+from utils.torch_utils import (EarlyStopping, ModelEMA, de_parallel, gradual_unfreeze, select_device, smart_DDP,
+                               smart_optimizer, smart_resume, torch_distributed_zero_first)
 
 LOCAL_RANK = int(os.getenv('LOCAL_RANK', -1))  # https://pytorch.org/docs/stable/elastic/run.html
 RANK = int(os.getenv('RANK', -1))
@@ -257,19 +257,22 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                 f"Logging results to {colorstr('bold', save_dir)}\n"
                 f'Starting training for {epochs} epochs...')
 
-    
     # checking unfreezing inputs.
     if gradual_unfreezing:
-        assert len(unfreezing_epochs) == len(unfreezing_layers), f"Length of unfreezeing layers {unfreezing_layers} not matched with {unfreezing_layers}"
-   
+        assert len(unfreezing_epochs) == len(
+            unfreezing_layers), f"Length of unfreezeing layers {unfreezing_layers} not matched with {unfreezing_layers}"
+
     for epoch in range(start_epoch, epochs):  # epoch ------------------------------------------------------------------
         callbacks.run('on_train_epoch_start')
 
         if gradual_unfreezing:
             if (epoch) in unfreezing_epochs:
                 gradual_unfreeze(model.named_parameters(), unfreezing_layers[unfreezing_epochs.index(epoch)])
-                LOGGER.info(colorstr('Unfreezing :  ') + f"Done at {(epoch + 1)} epoch & {unfreezing_layers[unfreezing_epochs.index(epoch)]} layer has unfroze.")
-    
+                LOGGER.info(
+                    colorstr('Unfreezing :  ') +
+                    f"Done at {(epoch + 1)} epoch & {unfreezing_layers[unfreezing_epochs.index(epoch)]} layer has unfroze."
+                )
+
         model.train()
 
         # Update image weights (optional, single-GPU only)
@@ -440,6 +443,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     torch.cuda.empty_cache()
     return results
 
+
 def parse_opt(known=False):
     parser = argparse.ArgumentParser()
     parser.add_argument('--weights', type=str, default=ROOT / 'yolov5s.pt', help='initial weights path')
@@ -477,8 +481,17 @@ def parse_opt(known=False):
     parser.add_argument('--seed', type=int, default=0, help='Global training seed')
     parser.add_argument('--local_rank', type=int, default=-1, help='Automatic DDP Multi-GPU argument, do not modify')
     parser.add_argument('--grad_unfreeze', action='store_true', help='Gradual Unfreezing ')
-    parser.add_argument('--unfreezing_layers',type=int, default=[], nargs='+', action='append', help='Index of layer for unfreezing')
-    parser.add_argument('--unfreeze_epochs', type=int, default=[], nargs='+', help='Unfreeze the layer at specified epoch')
+    parser.add_argument('--unfreezing_layers',
+                        type=int,
+                        default=[],
+                        nargs='+',
+                        action='append',
+                        help='Index of layer for unfreezing')
+    parser.add_argument('--unfreeze_epochs',
+                        type=int,
+                        default=[],
+                        nargs='+',
+                        help='Unfreeze the layer at specified epoch')
     # Logger arguments
     parser.add_argument('--entity', default=None, help='Entity')
     parser.add_argument('--upload_dataset', nargs='?', const=True, default=False, help='Upload data, "val" option')

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -429,14 +429,15 @@ class ModelEMA:
         # Update EMA attributes
         copy_attr(self.ema, model, include, exclude)
 
-# Unfreezing the layers at 
-def gradual_unfreeze(name_param, layer_ids): 
 
-    #  Get all layers parameter with respective id. 
-    unfreeze_layers = [f"model.{x}"  for x in layer_ids]
+# Unfreezing the layers at
+def gradual_unfreeze(name_param, layer_ids):
+
+    #  Get all layers parameter with respective id.
+    unfreeze_layers = [f"model.{x}" for x in layer_ids]
     for k, v in name_param:
         if any(x in k for x in unfreeze_layers):
             LOGGER.info(f'Unfreezing {k}')
             v.requires_grad = True
 
-    return  f'Unfreezing Completed for {layer_ids}'
+    return f'Unfreezing Completed for {layer_ids}'

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -428,3 +428,15 @@ class ModelEMA:
     def update_attr(self, model, include=(), exclude=('process_group', 'reducer')):
         # Update EMA attributes
         copy_attr(self.ema, model, include, exclude)
+
+# Unfreezing the layers at 
+def gradual_unfreeze(name_param, layer_ids): 
+
+    #  Get all layers parameter with respective id. 
+    unfreeze_layers = [f"model.{x}"  for x in layer_ids]
+    for k, v in name_param:
+        if any(x in k for x in unfreeze_layers):
+            LOGGER.info(f'Unfreezing {k}')
+            v.requires_grad = True
+
+    return  f'Unfreezing Completed for {layer_ids}'


### PR DESCRIPTION
Unfreezing layers during training is one the strategy used in  [ULMFIT](https://arxiv.org/abs/1801.06146) to fine-tune model. Based on that, I have updated code to unfreeze layers during training.  

# Compatibility Changes

-  Added `--grad_unfreeze` , to able the gradual unfreezing. 
- `--unfreezing_layers` ,  layer ids, (it is basically decided on number of layers has already frozen)
- `--unfreeze_epochs`,  Epoch number, where you want to unfreeze the layer. 


## Usage 
To use gradual unfreeze,  if only backbone is frozen & trained for 50 epochs.
`python train.py --data coco.yaml --cfg yolov5n.yaml --weights '' --batch-size 128  --grad_unfreeze  --unfreezing_layers 9   --unfreezing_layers  8  --unfreezing_layers  7  --unfreezing_layers 6  --unfreeze_epochs  15 20 25 30 35`

You can find issue here #9677 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Implemented Gradual Unfreezing in YOLOv5 training 🚀.

### 📊 Key Changes
- Added the `gradual_unfreeze` function to allow selective unfreezing of model layers during training.
- Updated `train.py` to support new command-line arguments for gradual unfreezing.
- Modified training loop to perform gradual unfreezing based on specified layers and epochs.

### 🎯 Purpose & Impact
- **Purpose**: To improve model fine-tuning by gradually unfreezing layers during training, allowing for more controlled learning.
- **Impact**: Users can now fine-tune models more effectively, potentially leading to better performance and quicker convergence. This could be especially useful when adapting pre-trained models to new datasets or tasks. 🆕✨