### PR TITLE
Error in utils/segment/general `masks2segments()`

### DIFF
--- a/utils/segment/general.py
+++ b/utils/segment/general.py
@@ -124,7 +124,7 @@ def masks_iou(mask1, mask2, eps=1e-7):
 def masks2segments(masks, strategy='largest'):
     # Convert masks(n,160,160) into segments(n,xy)
     segments = []
-    for x in masks.int().numpy().astype('uint8'):
+    for x in masks.int().cpu().numpy().astype('uint8'):
         c = cv2.findContours(x, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[0]
         if strategy == 'concat':  # concatenate all segments
             c = np.concatenate([x.reshape(-1, 2) for x in c])


### PR DESCRIPTION
When running segmentation predict on gpu, the conversion from tensor to numpy fails. Calling `.cpu()` before calling `.numpy()` solves this problem. 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced compatibility for YOLOv5 segmentation mask processing.

### 📊 Key Changes
- Modified the data handling in segment conversion to ensure tensor operations are CPU compatible.

### 🎯 Purpose & Impact
- **Purpose**: The change ensures that the segmentation mask conversion process can be executed on systems without GPU support by explicitly moving the mask tensor to the CPU.
- **Impact**: This improves the flexibility of the code, allowing it to run on a wider range of hardware, particularly benefiting users who may be working with CPU-only environments. It could potentially increase the accessibility of YOLOv5 for users with less powerful machines. 🖥️🚀