### PR TITLE
Remove #YOLOVISION22 notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,4 @@
 <div align="center">
-
-  Hi, I'm [Glenn Jocher](https://www.linkedin.com/in/glenn-jocher/), author of [YOLOv5](https://github.com/ultralytics/yolov5) 🚀.
-
-  I'd like to invite you to attend the world's first-ever YOLO conference: [#YOLOVISION22](https://ultralytics.com/yolo-vision)!
-
-  This virtual event takes place on **September 27th, 2022** with talks from the world's leading vision AI experts from Google, OpenMMLab's MMDetection, Baidu's PaddlePaddle, Meituan's YOLOv6, Weight & Biases, Roboflow, Neural Magic, OctoML and of course Ultralytics YOLOv5 and many others.
-
-  Save your spot at https://ultralytics.com/yolo-vision!
-
-  <a align="center" href="https://ultralytics.com/yolo-vision" target="_blank">
-        <img width="850" src="https://user-images.githubusercontent.com/26833433/192165285-a13a370c-60dc-4bf2-9d63-0573fb8e4d44.jpg"></a>
-
-## <div align="center"></div>
-  <br>
-
   <p>
     <a align="center" href="https://ultralytics.com/yolov5" target="_blank">
       <img width="850" src="https://github.com/ultralytics/assets/raw/master/yolov5/v62/splash_readme.png"></a>


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updating README to remove outdated YOLO conference information.

### 📊 Key Changes
- Removed section inviting users to attend the now past YOLO conference, [#YOLOVISION22](https://ultralytics.com/yolo-vision), including details and image link to the event.

### 🎯 Purpose & Impact
- Keeps the repository's documentation current and free from outdated content.
- Ensures users are not confused or misled by past events, thus improving the clarity and relevance of the README file.