### PR TITLE
Allowing model filenames that end in, e.g, "_saved_model" when .'s are present in the filename

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -403,11 +403,12 @@ def check_suffix(file='yolov5s.pt', suffix=('.pt',), msg=''):
     if file and suffix:
         if isinstance(suffix, str):
             suffix = [suffix]
-        for f in file if isinstance(file, (list, tuple)) else [file]:            
+        for f in file if isinstance(file, (list, tuple)) else [file]:
             # Allow a zero-length suffix for backwards compatibility.  In this case
             # no check is made against the required suffix list.
             s = Path(f).suffix.lower()
-            assert len(s) == 0 or any([f.strip('/').lower().endswith(s) for s in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
+            assert len(s) == 0 or any([f.strip('/').lower().endswith(s)
+                                       for s in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
 
 
 def check_yaml(file, suffix=('.yaml', '.yml')):

--- a/utils/general.py
+++ b/utils/general.py
@@ -407,7 +407,7 @@ def check_suffix(file='yolov5s.pt', suffix=('.pt',), msg=''):
             # Allow a zero-length suffix for backwards compatibility.  In this case
             # no check is made against the required suffix list.
             s = Path(f).suffix.lower()
-            assert len(s) == 0 or any([f.strip('/').lower().endswith(s) for s in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
+            assert len(s) == 0 or any([f.strip('/').lower().endswith(x) for x in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
 
 
 def check_yaml(file, suffix=('.yaml', '.yml')):

--- a/utils/general.py
+++ b/utils/general.py
@@ -407,7 +407,8 @@ def check_suffix(file='yolov5s.pt', suffix=('.pt',), msg=''):
             # Allow a zero-length suffix for backwards compatibility.  In this case
             # no check is made against the required suffix list.
             s = Path(f).suffix.lower()
-            assert len(s) == 0 or any([f.strip('/').lower().endswith(x) for x in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
+            assert len(s) == 0 or any([f.strip('/').lower().endswith(x)
+                                       for x in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
 
 
 def check_yaml(file, suffix=('.yaml', '.yml')):

--- a/utils/general.py
+++ b/utils/general.py
@@ -407,7 +407,7 @@ def check_suffix(file='yolov5s.pt', suffix=('.pt',), msg=''):
             # Allow a zero-length suffix for backwards compatibility.  In this case
             # no check is made against the required suffix list.
             s = Path(f).suffix.lower()
-            assert len(s) == 0 or any([f.strip('/').lower().endswith(x) for x in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
+            assert len(s) == 0 or any([str(f).strip('/').lower().endswith(x) for x in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
 
 
 def check_yaml(file, suffix=('.yaml', '.yml')):

--- a/utils/general.py
+++ b/utils/general.py
@@ -403,10 +403,11 @@ def check_suffix(file='yolov5s.pt', suffix=('.pt',), msg=''):
     if file and suffix:
         if isinstance(suffix, str):
             suffix = [suffix]
-        for f in file if isinstance(file, (list, tuple)) else [file]:
-            s = Path(f).suffix.lower()  # file suffix
-            if len(s):
-                assert s in suffix, f"{msg}{f} acceptable suffix is {suffix}"
+        for f in file if isinstance(file, (list, tuple)) else [file]:            
+            # Allow a zero-length suffix for backwards compatibility.  In this case
+            # no check is made against the required suffix list.
+            s = Path(f).suffix.lower()
+            assert len(s) == 0 or any([f.strip('/').lower().endswith(s) for s in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
 
 
 def check_yaml(file, suffix=('.yaml', '.yml')):

--- a/utils/general.py
+++ b/utils/general.py
@@ -407,12 +407,7 @@ def check_suffix(file='yolov5s.pt', suffix=('.pt',), msg=''):
             # Allow a zero-length suffix for backwards compatibility.  In this case
             # no check is made against the required suffix list.
             s = Path(f).suffix.lower()
-<<<<<<< HEAD
             assert len(s) == 0 or any([f.strip('/').lower().endswith(x) for x in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
-=======
-            assert len(s) == 0 or any([f.strip('/').lower().endswith(s)
-                                       for s in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
->>>>>>> 4914dc9ac92dfa6af364521fd1960f38b25f5141
 
 
 def check_yaml(file, suffix=('.yaml', '.yml')):

--- a/utils/general.py
+++ b/utils/general.py
@@ -407,7 +407,8 @@ def check_suffix(file='yolov5s.pt', suffix=('.pt',), msg=''):
             # Allow a zero-length suffix for backwards compatibility.  In this case
             # no check is made against the required suffix list.
             s = Path(f).suffix.lower()
-            assert len(s) == 0 or any([str(f).strip('/').lower().endswith(x) for x in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
+            assert len(s) == 0 or any([str(f).strip('/').lower().endswith(x)
+                                       for x in suffix]), f"{msg}{f} acceptable suffix is {suffix}"
 
 
 def check_yaml(file, suffix=('.yaml', '.yml')):


### PR DESCRIPTION
This addresses issue [9758](https://github.com/ultralytics/yolov5/issues/9758), re: using Path.suffix() (which splits on ".") to check for suffixes that are delimited by a mix of .'s and _'s.

Very low priority PR.

Repro and verification:

```
python detect.py
cp yolov5s.pt yolov5s_2022.10.10.pt
python export.py --weights yolov5s_2022.10.10.pt --include saved_model
python detect.py --weights yolov5s_2022.10.10_saved_model
```

Before fix:

AssertionError: yolov5s_2022.10.10_saved_model acceptable suffix is ['.pt', '.torchscript', '.onnx', '_openvino_model', '.engine', '.mlmodel', '_saved_model', '.pb', '.tflite', '_edgetpu.tflite', '_web_model', '_paddle_model']

Runs successfully after fix.

Still correctly rejects invalid extensions after fix:

```
cp yolov5s.pt yolov5s.invalid
python detect.py --weights yolov5.invalid
```

AssertionError: yolov5.invalid acceptable suffix is ['.pt', '.torchscript', '.onnx', '_openvino_model', '.engine', '.mlmodel', '_saved_model', '.pb', '.tflite', '_edgetpu.tflite', '_web_model', '_paddle_model']




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved file suffix validation for compatibility in the `yolov5` utility functions. 

### 📊 Key Changes
- Slightly modified the file suffix check logic.
- Added a condition to allow an empty file suffix for backwards compatibility.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: Ensure that files with no suffix are not erroneously rejected, maintaining compatibility with certain file naming conventions from earlier versions or other systems.
- 👍 **Impact**: Users with legacy file setups or those who do not use standard file suffix conventions can now use the model without encountering assertion errors related to file suffix checks.