### PR TITLE
Fix xView dataloaders import

### DIFF
--- a/data/xView.yaml
+++ b/data/xView.yaml
@@ -87,7 +87,7 @@ download: |
   from PIL import Image
   from tqdm import tqdm
 
-  from utils.datasets import autosplit
+  from utils.dataloaders import autosplit
   from utils.general import download, xyxy2xywhn
 
 


### PR DESCRIPTION
May resolve https://github.com/ultralytics/yolov5/issues/5469

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved data handling in the YOLOv5 codebase by updating a utility module reference.

### 📊 Key Changes
- Updated the import statement of the `autosplit` function within the xView dataset configuration file.
- The `autosplit` function import path changed from `utils.datasets` to `utils.dataloaders`.

### 🎯 Purpose & Impact
- This change ensures that the `autosplit` function is correctly imported from its current location, indicating a refactor where utilities may have been reorganized for better code structure.
- Potential impacts include smoother dataset processing when using the xView dataset with YOLOv5, and preventing any import errors that could arise from the old path.
- Users can expect more organized code and possibly more efficient data preprocessing with this internal update. 🔄