### PR TITLE
`smart_optimizer()` revert to weight with decay

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -319,12 +319,13 @@ def smart_optimizer(model, name='Adam', lr=0.001, momentum=0.9, decay=1e-5):
     g = [], [], []  # optimizer parameter groups
     bn = tuple(v for k, v in nn.__dict__.items() if 'Norm' in k)  # normalization layers, i.e. BatchNorm2d()
     for v in model.modules():
-        if hasattr(v, 'bias') and isinstance(v.bias, nn.Parameter):  # bias (no decay)
-            g[2].append(v.bias)
-        if isinstance(v, bn):  # weight (no decay)
-            g[1].append(v.weight)
-        elif hasattr(v, 'weight') and isinstance(v.weight, nn.Parameter):  # weight (with decay)
-            g[0].append(v.weight)
+        for p_name, p in v.named_parameters(recurse=0):
+            if p_name == 'bias':  # bias (no decay)
+                g[2].append(p)
+            elif p_name == 'weight' and isinstance(v, bn):  # weight (no decay)
+                g[1].append(p)
+            else:
+                g[0].append(p)  # weight (with decay)
 
     if name == 'Adam':
         optimizer = torch.optim.Adam(g[2], lr=lr, betas=(momentum, 0.999))  # adjust beta1 to momentum


### PR DESCRIPTION
If a parameter does not fall into any other category

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced parameter grouping in optimizer setup for YOLOv5 models.

### 📊 Key Changes
- Refactored the way parameters are added to optimizer groups, simplifying the code.
- Switched to using `named_parameters` method to iterate over parameters, which is a more general approach.
- Parameters are now grouped based on their name rather than just their type, allowing for potential custom-named parameters to be correctly categorized for optimization.

### 🎯 Purpose & Impact
- **Purpose:** To ensure that all model parameters are correctly grouped for optimization, with or without weight decay, based on their role in the model (e.g., weights or biases).
- **Impact:** This change leads to more ensure comprehensive optimization of all model parameters, potentially improving model training efficiency and accuracy. This could benefit users by providing better-performing models with possibly faster convergence times.