### PR TITLE
Remove ipython from `check_requirements` exclude list

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -39,7 +39,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
 
     if not verbose:
         LOGGER.setLevel(logging.WARNING)
-    check_requirements(exclude=('ipython', 'opencv-python', 'tensorboard', 'thop'))
+    check_requirements(exclude=('opencv-python', 'tensorboard', 'thop'))
     name = Path(name)
     path = name.with_suffix('.pt') if name.suffix == '' and not name.is_dir() else name  # checkpoint path
     try:


### PR DESCRIPTION
May resolve https://github.com/ultralytics/yolov5/commit/e3ff7806769444de864060494d1be8e18ce046a1#commitcomment-87136818

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in dependency checks for YOLOv5 models.

### 📊 Key Changes
- Removed 'ipython' from the list of excluded requirements in `check_requirements` function call.

### 🎯 Purpose & Impact
- **Purpose:** This change ensures that 'ipython' is now a checked dependency, meaning it is considered necessary for the correct operation of YOLOv5 when setting up the environment.
  
- **Impact:** Users installing YOLOv5 will need to have 'ipython' installed to avoid setup errors. This can also improve user experience by preemptively solving potential issues related to missing 'ipython' dependency.