### PR TITLE
Add TFLite Metadata to TFLite and Edge TPU models

### DIFF
--- a/export.py
+++ b/export.py
@@ -417,9 +417,7 @@ def export_tflite(keras_model, im, file, metadata, int8, data, nms, agnostic_nms
         model_meta.subgraphMetadata = [subgraph]
 
         b = flatbuffers.Builder(0)
-        b.Finish(
-            model_meta.Pack(b),
-            _metadata.MetadataPopulator.METADATA_FILE_IDENTIFIER)
+        b.Finish(model_meta.Pack(b), _metadata.MetadataPopulator.METADATA_FILE_IDENTIFIER)
         metadata_buf = b.Output()
 
         populator = _metadata.MetadataPopulator.with_model_file(f)
@@ -583,7 +581,14 @@ def run(
         if pb or tfjs:  # pb prerequisite to tfjs
             f[6], _ = export_pb(s_model, file)
         if tflite or edgetpu:
-            f[7], _ = export_tflite(s_model, im, file, metadata, int8 or edgetpu, data=data, nms=nms, agnostic_nms=agnostic_nms)
+            f[7], _ = export_tflite(s_model,
+                                    im,
+                                    file,
+                                    metadata,
+                                    int8 or edgetpu,
+                                    data=data,
+                                    nms=nms,
+                                    agnostic_nms=agnostic_nms)
         if edgetpu:
             f[8], _ = export_edgetpu(file)
         if tfjs:

--- a/export.py
+++ b/export.py
@@ -457,7 +457,7 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
 def add_tflite_metadata(file, metadata, num_outputs):
     # Add metadata to *.tflite models per https://www.tensorflow.org/lite/models/convert/metadata
     with contextlib.suppress(ImportError):
-        check_requirements('tflite_support')
+        # check_requirements('tflite_support')
         from tflite_support import flatbuffers
         from tflite_support import metadata as _metadata
         from tflite_support import metadata_schema_py_generated as _metadata_fb

--- a/export.py
+++ b/export.py
@@ -372,6 +372,7 @@ def export_pb(keras_model, file, prefix=colorstr('TensorFlow GraphDef:')):
 def add_tflite_metadata(file, metadata, num_outputs):
     # Populate TFLite model with label file
     with contextlib.suppress(ImportError):
+        # check_requirements('tflite_support')
         from tflite_support import flatbuffers
         from tflite_support import metadata as _metadata
         from tflite_support import metadata_schema_py_generated as _metadata_fb

--- a/export.py
+++ b/export.py
@@ -457,7 +457,7 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
 def add_tflite_metadata(file, metadata, num_outputs):
     # Add metadata to *.tflite models per https://www.tensorflow.org/lite/models/convert/metadata
     with contextlib.suppress(ImportError):
-        # check_requirements('tflite_support')
+        check_requirements('tflite_support')
         from tflite_support import flatbuffers
         from tflite_support import metadata as _metadata
         from tflite_support import metadata_schema_py_generated as _metadata_fb

--- a/export.py
+++ b/export.py
@@ -369,16 +369,13 @@ def export_pb(keras_model, file, prefix=colorstr('TensorFlow GraphDef:')):
 
 
 def add_tflite_metadata(file, metadata, num_outputs):
-    # populate tflite model with label file
+    # Populate TFLite model with label file
     try:
         from tflite_support import flatbuffers
         from tflite_support import metadata as _metadata
         from tflite_support import metadata_schema_py_generated as _metadata_fb
 
-        tmp_meta_file = 'meta.txt'
-        if os.path.isfile(tmp_meta_file):
-            raise FileExistsError(f'{tmp_meta_file} already exists, rename or remove file')
-
+        tmp_meta_file = '/tmp/meta.txt'
         with open(tmp_meta_file, 'w') as meta_f:
             meta_f.write(str(metadata))
 

--- a/export.py
+++ b/export.py
@@ -91,7 +91,7 @@ def export_formats():
         ['TensorFlow Lite', 'tflite', '.tflite', True, False],
         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
         ['TensorFlow.js', 'tfjs', '_web_model', False, False],
-        ['PaddlePaddle', 'paddle', '_paddle_model', True, True], ]
+        ['PaddlePaddle', 'paddle', '_paddle_model', True, True],]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'CPU', 'GPU'])
 
 
@@ -447,9 +447,9 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}}}', r'{"outputs": {"Identity": {"name": "Identity"}, '
-                                                           r'"Identity_1": {"name": "Identity_1"}, '
-                                                           r'"Identity_2": {"name": "Identity_2"}, '
-                                                           r'"Identity_3": {"name": "Identity_3"}}}', json)
+            r'"Identity_1": {"name": "Identity_1"}, '
+            r'"Identity_2": {"name": "Identity_2"}, '
+            r'"Identity_3": {"name": "Identity_3"}}}', json)
         j.write(subst)
     return f, None
 

--- a/export.py
+++ b/export.py
@@ -367,6 +367,7 @@ def export_pb(keras_model, file, prefix=colorstr('TensorFlow GraphDef:')):
     tf.io.write_graph(graph_or_graph_def=frozen_func.graph, logdir=str(f.parent), name=f.name, as_text=False)
     return f, None
 
+
 def add_tflite_metadata(file, metadata, num_outputs):
     # populate tflite model with label file
     try:
@@ -585,13 +586,7 @@ def run(
         if pb or tfjs:  # pb prerequisite to tfjs
             f[6], _ = export_pb(s_model, file)
         if tflite or edgetpu:
-            f[7], _ = export_tflite(s_model,
-                                    im,
-                                    file,
-                                    int8 or edgetpu,
-                                    data=data,
-                                    nms=nms,
-                                    agnostic_nms=agnostic_nms)
+            f[7], _ = export_tflite(s_model, im, file, int8 or edgetpu, data=data, nms=nms, agnostic_nms=agnostic_nms)
             num_outputs = len(s_model.outputs)
             add_tflite_metadata(f[7], metadata, num_outputs)
         if edgetpu:

--- a/export.py
+++ b/export.py
@@ -369,39 +369,6 @@ def export_pb(keras_model, file, prefix=colorstr('TensorFlow GraphDef:')):
     return f, None
 
 
-def add_tflite_metadata(file, metadata, num_outputs):
-    # Populate TFLite model with label file
-    with contextlib.suppress(ImportError):
-        # check_requirements('tflite_support')
-        from tflite_support import flatbuffers
-        from tflite_support import metadata as _metadata
-        from tflite_support import metadata_schema_py_generated as _metadata_fb
-
-        tmp_file = Path('/tmp/meta.txt')
-        with open(tmp_file, 'w') as meta_f:
-            meta_f.write(str(metadata))
-
-        model_meta = _metadata_fb.ModelMetadataT()
-        label_file = _metadata_fb.AssociatedFileT()
-        label_file.name = tmp_file.name
-        model_meta.associatedFiles = [label_file]
-
-        subgraph = _metadata_fb.SubGraphMetadataT()
-        subgraph.inputTensorMetadata = [_metadata_fb.TensorMetadataT()]
-        subgraph.outputTensorMetadata = [_metadata_fb.TensorMetadataT()] * num_outputs
-        model_meta.subgraphMetadata = [subgraph]
-
-        b = flatbuffers.Builder(0)
-        b.Finish(model_meta.Pack(b), _metadata.MetadataPopulator.METADATA_FILE_IDENTIFIER)
-        metadata_buf = b.Output()
-
-        populator = _metadata.MetadataPopulator.with_model_file(file)
-        populator.load_metadata_buffer(metadata_buf)
-        populator.load_associated_files([str(tmp_file)])
-        populator.populate()
-        tmp_file.unlink()
-
-
 @try_export
 def export_tflite(keras_model, im, file, int8, data, nms, agnostic_nms, prefix=colorstr('TensorFlow Lite:')):
     # YOLOv5 TensorFlow Lite export
@@ -485,6 +452,39 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
             r'"Identity_3": {"name": "Identity_3"}}}', json)
         j.write(subst)
     return f, None
+
+
+def add_tflite_metadata(file, metadata, num_outputs):
+    # Add metadata to *.tflite models per https://www.tensorflow.org/lite/models/convert/metadata
+    with contextlib.suppress(ImportError):
+        # check_requirements('tflite_support')
+        from tflite_support import flatbuffers
+        from tflite_support import metadata as _metadata
+        from tflite_support import metadata_schema_py_generated as _metadata_fb
+
+        tmp_file = Path('/tmp/meta.txt')
+        with open(tmp_file, 'w') as meta_f:
+            meta_f.write(str(metadata))
+
+        model_meta = _metadata_fb.ModelMetadataT()
+        label_file = _metadata_fb.AssociatedFileT()
+        label_file.name = tmp_file.name
+        model_meta.associatedFiles = [label_file]
+
+        subgraph = _metadata_fb.SubGraphMetadataT()
+        subgraph.inputTensorMetadata = [_metadata_fb.TensorMetadataT()]
+        subgraph.outputTensorMetadata = [_metadata_fb.TensorMetadataT()] * num_outputs
+        model_meta.subgraphMetadata = [subgraph]
+
+        b = flatbuffers.Builder(0)
+        b.Finish(model_meta.Pack(b), _metadata.MetadataPopulator.METADATA_FILE_IDENTIFIER)
+        metadata_buf = b.Output()
+
+        populator = _metadata.MetadataPopulator.with_model_file(file)
+        populator.load_metadata_buffer(metadata_buf)
+        populator.load_associated_files([str(tmp_file)])
+        populator.populate()
+        tmp_file.unlink()
 
 
 @smart_inference_mode()

--- a/export.py
+++ b/export.py
@@ -91,7 +91,7 @@ def export_formats():
         ['TensorFlow Lite', 'tflite', '.tflite', True, False],
         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
         ['TensorFlow.js', 'tfjs', '_web_model', False, False],
-        ['PaddlePaddle', 'paddle', '_paddle_model', True, True], ]
+        ['PaddlePaddle', 'paddle', '_paddle_model', True, True],]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'CPU', 'GPU'])
 
 
@@ -479,9 +479,9 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}}}', r'{"outputs": {"Identity": {"name": "Identity"}, '
-                                                           r'"Identity_1": {"name": "Identity_1"}, '
-                                                           r'"Identity_2": {"name": "Identity_2"}, '
-                                                           r'"Identity_3": {"name": "Identity_3"}}}', json)
+            r'"Identity_1": {"name": "Identity_1"}, '
+            r'"Identity_2": {"name": "Identity_2"}, '
+            r'"Identity_3": {"name": "Identity_3"}}}', json)
         j.write(subst)
     return f, None
 

--- a/export.py
+++ b/export.py
@@ -91,7 +91,7 @@ def export_formats():
         ['TensorFlow Lite', 'tflite', '.tflite', True, False],
         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
         ['TensorFlow.js', 'tfjs', '_web_model', False, False],
-        ['PaddlePaddle', 'paddle', '_paddle_model', True, True],]
+        ['PaddlePaddle', 'paddle', '_paddle_model', True, True], ]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'CPU', 'GPU'])
 
 
@@ -447,9 +447,9 @@ def export_tfjs(file, prefix=colorstr('TensorFlow.js:')):
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}}}', r'{"outputs": {"Identity": {"name": "Identity"}, '
-            r'"Identity_1": {"name": "Identity_1"}, '
-            r'"Identity_2": {"name": "Identity_2"}, '
-            r'"Identity_3": {"name": "Identity_3"}}}', json)
+                                                           r'"Identity_1": {"name": "Identity_1"}, '
+                                                           r'"Identity_2": {"name": "Identity_2"}, '
+                                                           r'"Identity_3": {"name": "Identity_3"}}}', json)
         j.write(subst)
     return f, None
 
@@ -584,11 +584,9 @@ def run(
             f[6], _ = export_pb(s_model, file)
         if tflite or edgetpu:
             f[7], _ = export_tflite(s_model, im, file, int8 or edgetpu, data=data, nms=nms, agnostic_nms=agnostic_nms)
-            num_outputs = len(s_model.outputs)
-            add_tflite_metadata(f[7], metadata, num_outputs)
             if edgetpu:
                 f[8], _ = export_edgetpu(file)
-                add_tflite_metadata(f[8], metadata, num_outputs)
+            add_tflite_metadata(f[8] or f[7], metadata, num_outputs=len(s_model.outputs))
         if tfjs:
             f[9], _ = export_tfjs(file)
     if paddle:  # PaddlePaddle

--- a/models/common.py
+++ b/models/common.py
@@ -3,12 +3,12 @@
 Common modules
 """
 
+import ast
 import json
 import math
 import platform
 import warnings
 import zipfile
-import ast
 from collections import OrderedDict, namedtuple
 from copy import copy
 from pathlib import Path

--- a/models/common.py
+++ b/models/common.py
@@ -7,6 +7,8 @@ import json
 import math
 import platform
 import warnings
+import zipfile
+import ast
 from collections import OrderedDict, namedtuple
 from copy import copy
 from pathlib import Path
@@ -462,6 +464,11 @@ class DetectMultiBackend(nn.Module):
             interpreter.allocate_tensors()  # allocate
             input_details = interpreter.get_input_details()  # inputs
             output_details = interpreter.get_output_details()  # outputs
+            # load metadata
+            with zipfile.ZipFile(w, "r") as model:
+                meta_file = model.namelist()[0]
+                meta = ast.literal_eval(model.read(meta_file).decode("utf-8"))
+                stride, names = int(meta['stride']), meta['names']
         elif tfjs:  # TF.js
             raise NotImplementedError('ERROR: YOLOv5 TF.js inference is not supported')
         elif paddle:  # PaddlePaddle

--- a/models/common.py
+++ b/models/common.py
@@ -465,10 +465,13 @@ class DetectMultiBackend(nn.Module):
             input_details = interpreter.get_input_details()  # inputs
             output_details = interpreter.get_output_details()  # outputs
             # load metadata
-            with zipfile.ZipFile(w, "r") as model:
-                meta_file = model.namelist()[0]
-                meta = ast.literal_eval(model.read(meta_file).decode("utf-8"))
-                stride, names = int(meta['stride']), meta['names']
+            try:
+                with zipfile.ZipFile(w, "r") as model:
+                    meta_file = model.namelist()[0]
+                    meta = ast.literal_eval(model.read(meta_file).decode("utf-8"))
+                    stride, names = int(meta['stride']), meta['names']
+            except zipfile.BadZipFile:
+                pass
         elif tfjs:  # TF.js
             raise NotImplementedError('ERROR: YOLOv5 TF.js inference is not supported')
         elif paddle:  # PaddlePaddle

--- a/models/common.py
+++ b/models/common.py
@@ -465,13 +465,11 @@ class DetectMultiBackend(nn.Module):
             input_details = interpreter.get_input_details()  # inputs
             output_details = interpreter.get_output_details()  # outputs
             # load metadata
-            try:
+            with contextlib.suppress(zipfile.BadZipFile):
                 with zipfile.ZipFile(w, "r") as model:
                     meta_file = model.namelist()[0]
                     meta = ast.literal_eval(model.read(meta_file).decode("utf-8"))
                     stride, names = int(meta['stride']), meta['names']
-            except zipfile.BadZipFile:
-                pass
         elif tfjs:  # TF.js
             raise NotImplementedError('ERROR: YOLOv5 TF.js inference is not supported')
         elif paddle:  # PaddlePaddle

--- a/models/common.py
+++ b/models/common.py
@@ -4,6 +4,7 @@ Common modules
 """
 
 import ast
+import contextlib
 import json
 import math
 import platform


### PR DESCRIPTION
This PR embeds meta data to exported tflite models. The code makes use of the tflite-support library for the model export. For inference, this dependency is not necessary. The model can be unpacked as zipfile, were the meta data is stored as an integrated text file. While this procedure appears to be rather convoluted, it is the intended method according to Google's [documentation](https://www.tensorflow.org/lite/models/convert/metadata).

It seems the meta data does not survive the edgetpu-compiler. Should I refactor the code into a separate function which can be called at the end of the tflite and edgetpu export?

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced TensorFlow Lite exports with metadata addition and improved model metadata handling.

### 📊 Key Changes
- Added `add_tflite_metadata` function to append metadata to `.tflite` models.
- Included additional imports such as `contextlib`, `ast`, and `zipfile` for handling the new metadata functionalities.
- Altered conditional blocks to incorporate the new metadata addition within the TensorFlow Lite and Edge TPU export pathways.

### 🎯 Purpose & Impact
- **Purpose**: Incorporating metadata into TensorFlow Lite models simplifies model understanding and deployment on mobile or edge devices.
- **Impact**: Developers and users leveraging `.tflite` models can now benefit from integrated metadata, enhancing model portability and interoperability across different platforms and tools. This change could enhance the user experience by providing richer model information directly within the `.tflite` files. 📱💼