### PR TITLE
Switch from suffix checks to archive checks

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -462,12 +462,13 @@ def check_font(font=FONT, progress=False):
 
 def check_dataset(data, autodownload=True):
     # Download, check and/or unzip dataset if not found locally
-    from zipfile import is_zipfile
     from tarfile import is_tarfile
+    from zipfile import is_zipfile
 
     # Download (optional)
     extract_dir = ''
-    if isinstance(data, (str, Path)) and (is_zipfile(str(data)) or is_tarfile(str(data))):  # i.e. gs://bucket/dir/coco128.zip
+    if isinstance(data,
+                  (str, Path)) and (is_zipfile(str(data)) or is_tarfile(str(data))):  # i.e. gs://bucket/dir/coco128.zip
         download(data, dir=f'{DATASETS_DIR}/{Path(data).stem}', unzip=True, delete=False, curl=False, threads=1)
         data = next((DATASETS_DIR / Path(data).stem).rglob('*.yaml'))
         extract_dir, autodownload = data.parent, False
@@ -609,8 +610,8 @@ def download(url, dir='.', unzip=True, delete=True, curl=False, threads=1, retry
                 else:
                     LOGGER.warning(f'❌ Failed to download {url}...')
 
-        from zipfile import is_zipfile
         from tarfile import is_tarfile
+        from zipfile import is_zipfile
 
         if unzip and success and (f.suffix in ('.gz') or is_zipfile(f) or is_tarfile(f)):
             LOGGER.info(f'Unzipping {f}...')

--- a/utils/general.py
+++ b/utils/general.py
@@ -462,10 +462,12 @@ def check_font(font=FONT, progress=False):
 
 def check_dataset(data, autodownload=True):
     # Download, check and/or unzip dataset if not found locally
+    from zipfile import is_zipfile
+    from tarfile import is_tarfile
 
     # Download (optional)
     extract_dir = ''
-    if isinstance(data, (str, Path)) and str(data).endswith('.zip'):  # i.e. gs://bucket/dir/coco128.zip
+    if isinstance(data, (str, Path)) and (is_zipfile(str(data)) or is_tarfile(str(data))):  # i.e. gs://bucket/dir/coco128.zip
         download(data, dir=f'{DATASETS_DIR}/{Path(data).stem}', unzip=True, delete=False, curl=False, threads=1)
         data = next((DATASETS_DIR / Path(data).stem).rglob('*.yaml'))
         extract_dir, autodownload = data.parent, False
@@ -607,11 +609,14 @@ def download(url, dir='.', unzip=True, delete=True, curl=False, threads=1, retry
                 else:
                     LOGGER.warning(f'❌ Failed to download {url}...')
 
-        if unzip and success and f.suffix in ('.zip', '.tar', '.gz'):
+        from zipfile import is_zipfile
+        from tarfile import is_tarfile
+
+        if unzip and success and (f.suffix in ('.gz') or is_zipfile(f) or is_tarfile(f)):
             LOGGER.info(f'Unzipping {f}...')
-            if f.suffix == '.zip':
+            if is_zipfile(f):
                 unzip_file(f, dir)  # unzip
-            elif f.suffix == '.tar':
+            elif is_tarfile(f):
                 os.system(f'tar xf {f} --directory {f.parent}')  # unzip
             elif f.suffix == '.gz':
                 os.system(f'tar xfz {f} --directory {f.parent}')  # unzip

--- a/utils/general.py
+++ b/utils/general.py
@@ -23,8 +23,9 @@ from itertools import repeat
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from subprocess import check_output
+from tarfile import is_tarfile
 from typing import Optional
-from zipfile import ZipFile
+from zipfile import ZipFile, is_zipfile
 
 import cv2
 import IPython
@@ -462,12 +463,10 @@ def check_font(font=FONT, progress=False):
 
 def check_dataset(data, autodownload=True):
     # Download, check and/or unzip dataset if not found locally
-    from tarfile import is_tarfile
-    from zipfile import is_zipfile
 
     # Download (optional)
     extract_dir = ''
-        if isinstance(data, (str, Path)) and (is_zipfile(data) or is_tarfile(data)):
+    if isinstance(data, (str, Path)) and (is_zipfile(data) or is_tarfile(data)):
         download(data, dir=f'{DATASETS_DIR}/{Path(data).stem}', unzip=True, delete=False, curl=False, threads=1)
         data = next((DATASETS_DIR / Path(data).stem).rglob('*.yaml'))
         extract_dir, autodownload = data.parent, False
@@ -609,10 +608,7 @@ def download(url, dir='.', unzip=True, delete=True, curl=False, threads=1, retry
                 else:
                     LOGGER.warning(f'❌ Failed to download {url}...')
 
-        from tarfile import is_tarfile
-        from zipfile import is_zipfile
-
-        if unzip and success and (f.suffix in ('.gz') or is_zipfile(f) or is_tarfile(f)):
+        if unzip and success and (f.suffix == '.gz' or is_zipfile(f) or is_tarfile(f)):
             LOGGER.info(f'Unzipping {f}...')
             if is_zipfile(f):
                 unzip_file(f, dir)  # unzip

--- a/utils/general.py
+++ b/utils/general.py
@@ -467,8 +467,7 @@ def check_dataset(data, autodownload=True):
 
     # Download (optional)
     extract_dir = ''
-    if isinstance(data,
-                  (str, Path)) and (is_zipfile(str(data)) or is_tarfile(str(data))):  # i.e. gs://bucket/dir/coco128.zip
+        if isinstance(data, (str, Path)) and (is_zipfile(data) or is_tarfile(data)):
         download(data, dir=f'{DATASETS_DIR}/{Path(data).stem}', unzip=True, delete=False, curl=False, threads=1)
         data = next((DATASETS_DIR / Path(data).stem).rglob('*.yaml'))
         extract_dir, autodownload = data.parent, False


### PR DESCRIPTION
When downloading an archive from a URL shortener service the extension is not added. As the archive checks where based on the extension they were not being unzipped.

This uses archive packages to check the file type and not rely on the extension.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to dataset downloading by supporting various compression formats.

### 📊 Key Changes
- Expanded dataset download capabilities with added support for tar files.
- Refactored conditionals by utilizing `is_zipfile` and `is_tarfile` functions for file type checking instead of suffix string comparison.

### 🎯 Purpose & Impact
- **Purpose:** Provide a more robust way to handle different archive file types when downloading datasets for YOLOv5, making the process more error-proof and accommodating a wider range of compressed file formats.
- **Impact:** Users will benefit from a more flexible dataset downloading process, with the tool automatically recognizing zip and tar archives without relying on the file extension alone. This could prevent issues when files do not have the expected file extension but are valid archives.