### PR TITLE
Full-size proto code (optional)

### DIFF
--- a/models/tf.py
+++ b/models/tf.py
@@ -396,8 +396,8 @@ def parse_model(d, ch, model, imgsz):  # model_dict, input_channels(3)
 
         n = max(round(n * gd), 1) if n > 1 else n  # depth gain
         if m in [
-            nn.Conv2d, Conv, DWConv, DWConvTranspose2d, Bottleneck, SPP, SPPF, MixConv2d, Focus, CrossConv,
-            BottleneckCSP, C3, C3x]:
+                nn.Conv2d, Conv, DWConv, DWConvTranspose2d, Bottleneck, SPP, SPPF, MixConv2d, Focus, CrossConv,
+                BottleneckCSP, C3, C3x]:
             c1, c2 = ch[f], args[0]
             c2 = make_divisible(c2 * gw, 8) if c2 != no else c2
 

--- a/models/tf.py
+++ b/models/tf.py
@@ -356,7 +356,7 @@ class TFUpsample(keras.layers.Layer):
     # TF version of torch.nn.Upsample()
     def __init__(self, size, scale_factor, mode, w=None):  # warning: all arguments needed including 'w'
         super().__init__()
-        assert scale_factor % 2 == 0, "scale_factor must be 2"
+        assert scale_factor % 2 == 0, "scale_factor must be multiple of 2"
         self.upsample = lambda x: tf.image.resize(x, (x.shape[1] * scale_factor, x.shape[2] * scale_factor), mode)
         # self.upsample = keras.layers.UpSampling2D(size=scale_factor, interpolation=mode)
         # with default arguments: align_corners=False, half_pixel_centers=False

--- a/models/tf.py
+++ b/models/tf.py
@@ -333,7 +333,7 @@ class TFSegment(TFDetect):
 
     def call(self, x):
         p = self.proto(x[0])
-        # p = TFUpsample(None, scale_factor=4, mode='nearest')(self.proto(x[0]))
+        # p = TFUpsample(None, scale_factor=4, mode='nearest')(self.proto(x[0]))  # (optional) full-size protos
         p = tf.transpose(p, [0, 3, 1, 2])  # from shape(1,160,160,32) to shape(1,32,160,160)
         x = self.detect(self, x)
         return (x, p) if self.training else (x[0], p)


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced TensorFlow model upscaling capabilities in YOLOv5.

### 📊 Key Changes
- Optional full-size protos added via a commented out TFUpsample call.
- TFUpsample class updated to support scale factors that are multiples of 2, rather than only supporting a scale factor of 2.

### 🎯 Purpose & Impact
- 🎈 The optional code for full-size protos provides flexibility to experiment with different upscaling options during the model's prototyping phase, possibly enhancing the model's detection capabilities.
- 📈 The TFUpsample changes allow more versatile image scaling, which facilitates experimentation with different image resolutions and could lead to optimized performance and accuracy in object detection. 

Overall, these changes promote flexible model refinement and potentially contribute to more finely-tuned object detection models for developers and users of the YOLOv5 TensorFlow implementation.