### PR TITLE
Check online twice on AutoUpdate

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -369,7 +369,7 @@ def check_requirements(requirements=ROOT / 'requirements.txt', exclude=(), insta
     if s and install and AUTOINSTALL:  # check environment variable
         LOGGER.info(f"{prefix} YOLOv5 requirement{'s' * (n > 1)} {s}not found, attempting AutoUpdate...")
         try:
-            assert check_online(), "AutoUpdate skipped (offline)"
+            assert check_online() or check_online(), "AutoUpdate skipped (offline)"
             LOGGER.info(check_output(f'pip install {s} {cmds}', shell=True).decode())
             source = file if 'file' in locals() else requirements
             s = f"{prefix} {n} package{'s' * (n > 1)} updated per {source}\n" \


### PR DESCRIPTION
Increased robustness to network failures

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of AutoUpdate functionality in requirements check

### 📊 Key Changes
- Removed redundant code in checking for online status during AutoUpdate.

### 🎯 Purpose & Impact
- **Purpose:** To streamline the conditions checked when attempting to AutoUpdate YOLOv5 requirements.
- **Impact:** Simplifies the update logic, potentially making the codebase cleaner and the update mechanism slightly faster as it removes an unnecessary duplicate check. Users may not notice any direct changes, but it contributes to the overall robustness of the code.