### PR TITLE
Fix `min_items`

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -509,8 +509,8 @@ class LoadImagesAndLabels(Dataset):
 
         # Filter images
         if min_items:
-            include = np.array([len(x) > min_items for x in self.labels]).nonzero()[0].astype(int)
-            LOGGER.info(f'{prefix}{nf - len(include)}/{nf} images filtered from dataset')
+            include = np.array([len(x) >= min_items for x in self.labels]).nonzero()[0].astype(int)
+            LOGGER.info(f'{prefix}{n - len(include)}/{n} images filtered from dataset')
             self.im_files = [self.im_files[i] for i in include]
             self.label_files = [self.label_files[i] for i in include]
             self.labels = [self.labels[i] for i in include]


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of image filtering logic in data loader.

### 📊 Key Changes
- Updated the conditional check from `len(x) > min_items` to `len(x) >= min_items` for determining which images to include in a dataset.
- Fixed the logging message to correctly display the number of images filtered from the dataset using `n` instead of `nf`.

### 🎯 Purpose & Impact
- The modification ensures images with exactly `min_items` number of annotations will also be included in the dataset, rather than strictly more than `min_items`.
- The updated logging message provides accurate feedback on the dataset filtering process, aiding in debugging and dataset understanding.
- 🧑‍💻 Developers will benefit from more precise dataset creation, and 📈 model training may improve due to the inclusion of additional valid images.
- 🖼️ Users leveraging the Ultralytics YOLOv5 framework for object detection tasks may experience slightly increased dataset sizes and potentially more robust training results.