### PR TITLE
Update export.py

### DIFF
--- a/export.py
+++ b/export.py
@@ -48,8 +48,8 @@ TensorFlow.js:
 
 import argparse
 import contextlib
-import json
 import glob
+import json
 import os
 import platform
 import re
@@ -95,8 +95,7 @@ def export_formats():
         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
         ['TensorFlow.js', 'tfjs', '_web_model', False, False],
         ['PaddlePaddle', 'paddle', '_paddle_model', True, True],
-        ['DepthAI', 'depthai', '.blob', True, False],
-    ]
+        ['DepthAI', 'depthai', '.blob', True, False],]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'CPU', 'GPU'])
 
 
@@ -189,6 +188,7 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr('ONNX
             LOGGER.info(f'{prefix} simplifier failure: {e}')
     return f, model_onnx
 
+
 @try_export
 def export_depthai(file, prefix=colorstr('DepthAI:')):
     check_requirements('blobconverter')
@@ -198,6 +198,7 @@ def export_depthai(file, prefix=colorstr('DepthAI:')):
     subprocess.run(cmd.split(), check=False, env=os.environ, timeout=60)  # export
     blob_file = glob.glob(f + "/*.blob")[0]
     return blob_file, None
+
 
 @try_export
 def export_openvino(file, metadata, half, prefix=colorstr('OpenVINO:')):
@@ -605,8 +606,8 @@ def run(
             f[9], _ = export_tfjs(file)
     if paddle:  # PaddlePaddle
         f[10], _ = export_paddle(model, im, file, metadata)
-        
-    if depthai:        
+
+    if depthai:
         f[11], _ = export_depthai(file)
 
     # Finish

--- a/export.py
+++ b/export.py
@@ -16,6 +16,7 @@ TensorFlow Lite             | `tflite`                      | yolov5s.tflite
 TensorFlow Edge TPU         | `edgetpu`                     | yolov5s_edgetpu.tflite
 TensorFlow.js               | `tfjs`                        | yolov5s_web_model/
 PaddlePaddle                | `paddle`                      | yolov5s_paddle_model/
+DepthAI                     | `depthai`                     | yolov5s_openvino_2021.4_6shave.blob/
 
 Requirements:
     $ pip install -r requirements.txt coremltools onnx onnx-simplifier onnxruntime openvino-dev tensorflow-cpu  # CPU
@@ -36,6 +37,7 @@ Inference:
                                  yolov5s.tflite             # TensorFlow Lite
                                  yolov5s_edgetpu.tflite     # TensorFlow Edge TPU
                                  yolov5s_paddle_model       # PaddlePaddle
+                                 yolov5s_shave.blob         # Depthai
 
 TensorFlow.js:
     $ cd .. && git clone https://github.com/zldrobit/tfjs-yolov5-example.git && cd tfjs-yolov5-example
@@ -47,6 +49,7 @@ TensorFlow.js:
 import argparse
 import contextlib
 import json
+import glob
 import os
 import platform
 import re
@@ -91,7 +94,9 @@ def export_formats():
         ['TensorFlow Lite', 'tflite', '.tflite', True, False],
         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
         ['TensorFlow.js', 'tfjs', '_web_model', False, False],
-        ['PaddlePaddle', 'paddle', '_paddle_model', True, True],]
+        ['PaddlePaddle', 'paddle', '_paddle_model', True, True],
+        ['DepthAI', 'depthai', '.blob', True, False],
+    ]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'CPU', 'GPU'])
 
 
@@ -184,6 +189,15 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr('ONNX
             LOGGER.info(f'{prefix} simplifier failure: {e}')
     return f, model_onnx
 
+@try_export
+def export_depthai(file, prefix=colorstr('DepthAI:')):
+    check_requirements('blobconverter')
+    LOGGER.info(f'\n{prefix} starting export with depthai...')
+    f = os.path.dirname(file)
+    cmd = f"blobconverter --onnx {file.with_suffix('.onnx')} --output-dir {f} --data-type FP16 --shaves 6"
+    subprocess.run(cmd.split(), check=False, env=os.environ, timeout=60)  # export
+    blob_file = glob.glob(f + "/*.blob")[0]
+    return blob_file, None
 
 @try_export
 def export_openvino(file, metadata, half, prefix=colorstr('OpenVINO:')):
@@ -517,7 +531,7 @@ def run(
     fmts = tuple(export_formats()['Argument'][1:])  # --include arguments
     flags = [x in include for x in fmts]
     assert sum(flags) == len(include), f'ERROR: Invalid --include {include}, valid --include arguments are {fmts}'
-    jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle = flags  # export booleans
+    jit, onnx, xml, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle, depthai = flags  # export booleans
     file = Path(url2file(weights) if str(weights).startswith(('http:/', 'https:/')) else weights)  # PyTorch weights
 
     # Load PyTorch model
@@ -560,7 +574,7 @@ def run(
         f[0], _ = export_torchscript(model, im, file, optimize)
     if engine:  # TensorRT required before ONNX
         f[1], _ = export_engine(model, im, file, half, dynamic, simplify, workspace, verbose)
-    if onnx or xml:  # OpenVINO requires ONNX
+    if onnx or xml or depthai:  # OpenVINO, depthai requires ONNX
         f[2], _ = export_onnx(model, im, file, opset, dynamic, simplify)
     if xml:  # OpenVINO
         f[3], _ = export_openvino(file, metadata, half)
@@ -591,6 +605,9 @@ def run(
             f[9], _ = export_tfjs(file)
     if paddle:  # PaddlePaddle
         f[10], _ = export_paddle(model, im, file, metadata)
+        
+    if depthai:        
+        f[11], _ = export_depthai(file)
 
     # Finish
     f = [str(x) for x in f if x]  # filter out '' and None
@@ -636,7 +653,7 @@ def parse_opt():
         '--include',
         nargs='+',
         default=['torchscript'],
-        help='torchscript, onnx, openvino, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle')
+        help='torchscript, onnx, openvino, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle, depthai')
     opt = parser.parse_args()
     print_args(vars(opt))
     return opt


### PR DESCRIPTION
DepthAI blob model export support

Signed-off-by: hardikdava <39372750+hardikdava@users.noreply.github.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added DepthAI export functionality to YOLOv5.

### 📊 Key Changes
- A new export target `DepthAI` has been integrated into the export script.
- Corresponding `depthai` options included in export format, command-line arguments, and flags.

### 🎯 Purpose & Impact
- 🚀 Enables users to export YOLOv5 models to be compatible with DepthAI devices, such as OAK-D cameras.
- 👨‍💻 Expands the application of YOLOv5 models to new hardware, allowing for more versatile deployments.
- 🌐 Enhances model accessibility by adding support for another platform, appealing to a broader user base.