### PR TITLE
Add `join_threads()`

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -41,10 +41,9 @@ def join_threads():
     # Join all daemon threads, i.e. atexit.register(lambda: join_threads())
     main_thread = threading.current_thread()
     for t in threading.enumerate():
-        if t is main_thread:
-            continue
-        print(f'Joining thread {t.name}')
-        t.join()
+        if t is not main_thread:
+            print(f'Joining thread {t.name}')
+            t.join()
 
 
 def notebook_init(verbose=True):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -37,12 +37,13 @@ def threaded(func):
     return wrapper
 
 
-def join_threads():
+def join_threads(verbose=False):
     # Join all daemon threads, i.e. atexit.register(lambda: join_threads())
     main_thread = threading.current_thread()
     for t in threading.enumerate():
         if t is not main_thread:
-            print(f'Joining thread {t.name}')
+            if verbose:
+                print(f'Joining thread {t.name}')
             t.join()
 
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -37,6 +37,16 @@ def threaded(func):
     return wrapper
 
 
+def join_threads():
+    # Join all daemon threads, i.e. atexit.register(lambda: join_threads())
+    main_thread = threading.current_thread()
+    for t in threading.enumerate():
+        if t is main_thread:
+            continue
+        print(f'Joining thread {t.name}')
+        t.join()
+
+
 def notebook_init(verbose=True):
     # Check system software and hardware
     print('Checking setup...')


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced daemon thread handling in Ultralytics YOLOv5 by adding a method to join threads at exit.

### 📊 Key Changes
- Introduced a new function `join_threads(verbose=False)`.
- This function iterates through all running threads and joins daemon threads to the main thread before exiting the program.

### 🎯 Purpose & Impact
- **Purpose**: Ensures that all background processes (daemon threads) are properly concluded before the main program exits.
- **Impact**: Improves the cleanup process of the software, ensuring that there are no hanging threads that could potentially lead to resource leaks or prevent the application from terminating correctly.
- Users may experience a more graceful shutdown of the application with verbose feedback (if enabled) about the threads being joined.