### PR TITLE
AutoShape integer image-size fix

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -692,7 +692,7 @@ class AutoShape(nn.Module):
                 s = im.shape[:2]  # HWC
                 shape0.append(s)  # image shape
                 g = max(size) / max(s)  # gain
-                shape1.append([y * g for y in s])
+                shape1.append([int(y * g) for y in s])
                 ims[i] = im if im.data.contiguous else np.ascontiguousarray(im)  # update
             shape1 = [make_divisible(x, self.stride) for x in np.array(shape1).max(0)] if self.pt else size  # inf shape
             x = [letterbox(im, shape1, auto=False)[0] for im in ims]  # pad


### PR DESCRIPTION
We have a division at line 694, and then a multiplication at line 695, so it makes `y*g` not an integer. And since `shape1` will be used at line 697 to ensure the size is divisible by the `stride`, this may lead to different image size.

In my experiment, my image is [640, 640], it's divisible by the default stride 32, but I found that the result is changed to [672, 672] after line 697. So the final detection result is slightly different from that directly using the `detect.py` script, which does not call the AutoShape methods. 


Signed-off-by: janus-zheng <106574221+janus-zheng@users.noreply.github.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjustment of image shape calculation for more reliable resizing in YOLOv5.

### 📊 Key Changes
- Changed the resizing calculation to ensure image dimensions are integers after scaling.

### 🎯 Purpose & Impact
- 🎨 Ensures that the image's new dimensions are precise integers, preventing potential errors or inconsistencies during image processing.
- 💼 This minor but important tweak can lead to more robust performance of the model, as it avoids issues that can arise when non-integer dimensions are used in further processing steps.