### PR TITLE
Mapped project and name to ClearML

### DIFF
--- a/utils/loggers/clearml/README.md
+++ b/utils/loggers/clearml/README.md
@@ -57,7 +57,7 @@ To enable ClearML experiment tracking, simply install the ClearML pip package.
 pip install clearml>=1.2.0
 ```
 
-This will enable integration with the YOLOv5 training script. Every training run from now on, will be captured and stored by the ClearML experiment manager. 
+This will enable integration with the YOLOv5 training script. Every training run from now on, will be captured and stored by the ClearML experiment manager.
 
 If you want to change the `project_name` or `task_name`, use the `--project` and `--name` arguments of the `train.py` script, by default the project will be called `YOLOv5` and the task `Training`.
 PLEASE NOTE: ClearML uses `/` as a delimter for subprojects, so be careful when using `/` in your project name!

--- a/utils/loggers/clearml/README.md
+++ b/utils/loggers/clearml/README.md
@@ -57,10 +57,18 @@ To enable ClearML experiment tracking, simply install the ClearML pip package.
 pip install clearml>=1.2.0
 ```
 
-This will enable integration with the YOLOv5 training script. Every training run from now on, will be captured and stored by the ClearML experiment manager. If you want to change the `project_name` or `task_name`, head over to our custom logger, where you can change it: `utils/loggers/clearml/clearml_utils.py`
+This will enable integration with the YOLOv5 training script. Every training run from now on, will be captured and stored by the ClearML experiment manager. 
+
+If you want to change the `project_name` or `task_name`, use the `--project` and `--name` arguments of the `train.py` script, by default the project will be called `YOLOv5` and the task `Training`.
+PLEASE NOTE: ClearML uses `/` as a delimter for subprojects, so be careful when using `/` in your project name!
 
 ```bash
 python train.py --img 640 --batch 16 --epochs 3 --data coco128.yaml --weights yolov5s.pt --cache
+```
+
+or with custom project and task name:
+```bash
+python train.py --project my_project --name my_training --img 640 --batch 16 --epochs 3 --data coco128.yaml --weights yolov5s.pt --cache
 ```
 
 This will capture:

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -85,8 +85,8 @@ class ClearmlLogger:
         self.data_dict = None
         if self.clearml:
             self.task = Task.init(
-                project_name='YOLOv5',
-                task_name='training',
+                project_name=opt.project if opt.project != 'runs/train' else 'YOLOv5',
+                task_name=opt.name if opt.name != 'exp' else 'Training',
                 tags=['YOLOv5'],
                 output_uri=True,
                 auto_connect_frameworks={'pytorch': False}


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

Simple fix to solve #10019 

Connects the YOLOv5 `--project` and `--name` arguments to the respective ClearML arguments and provides some extra documentation with it.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced ClearML integration in YOLOv5 with customizable project and task names for experiment tracking.

### 📊 Key Changes
- Introduced command line arguments `--project` and `--name` for the `train.py` script to customize `project_name` and `task_name` in ClearML.
- Default project and task names are now `YOLOv5` and `Training`, respectively.
- Warned users about ClearML using `/` as a delimiter for subprojects to avoid conflicts with the project naming scheme.

### 🎯 Purpose & Impact
- 🛠 **Flexibility**: Allows users to organize their training runs under custom project and task titles, improving manageability in the ClearML dashboard.
- 🚀 **Ease of Use**: Users can more easily identify and monitor different experiments without modifying the core code.
- ⚠️ **Clarity**: Helps prevent unintentional structuring of subprojects in ClearML due to the use of `/` in names, which can be confusing.