### PR TITLE
fix: prevent logging config clobbering

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -126,8 +126,9 @@ def set_logging(name=None, verbose=VERBOSE):
     log.addHandler(handler)
 
 
-set_logging()  # run before defining LOGGER
-LOGGER = logging.getLogger("yolov5")  # define globally (used in train.py, val.py, detect.py, etc.)
+logger_name = "yolov5"
+set_logging(logger_name)  # run before defining LOGGER
+LOGGER = logging.getLogger(logger_name)  # define globally (used in train.py, val.py, detect.py, etc.)
 if platform.system() == 'Windows':
     for fn in LOGGER.info, LOGGER.warning:
         setattr(LOGGER, fn.__name__, lambda x: fn(emojis(x)))  # emoji safe logging


### PR DESCRIPTION
Fix for issue: https://github.com/ultralytics/yolov5/issues/10132

- Previous behavior: loading this repository with `torch.hub.load` clobbers the existing logging configuration by modifying the root logger's configuration.
- New behavior: loading this repository with `torch.hub.load` only clobbers the logging configuration for logger `yolov5` and its descendants.

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging initiation process with dynamic logger name setup in the YOLOv5 code.

### 📊 Key Changes
- Moved the "yolov5" logger name into a variable before initializing the logging.
- Called `set_logging()` with the new `logger_name` variable.

### 🎯 Purpose & Impact
- 🛠️ **Maintainability**: Defining the logger name as a variable makes the code more maintainable and clear.
- 🔍 **Clarity**: It's now easier to change the logger name in one place if needed in the future.
- 👥 **User Experience**: No direct impact on end users, but developers will appreciate the cleaner setup for logging.