### PR TITLE
Copy-Paste zero value fix

### DIFF
--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -250,12 +250,10 @@ def copy_paste(im, labels, segments, p=0.5):
             if (ioa < 0.30).all():  # allow 30% obscuration of existing labels
                 labels = np.concatenate((labels, [[l[0], *box]]), 0)
                 segments.append(np.concatenate((w - s[:, 0:1], s[:, 1:2]), 1))
-                cv2.drawContours(im_new, [segments[j].astype(np.int32)], -1, (255, 255, 255), cv2.FILLED)
+                cv2.drawContours(im_new, [segments[j].astype(np.int32)], -1, (1, 1, 1), cv2.FILLED)
 
-        result = cv2.bitwise_and(src1=im, src2=im_new)
-        result = cv2.flip(result, 1)  # augment segments (flip left-right)
-        i = result > 0  # pixels to replace
-        # i[:, :] = result.max(2).reshape(h, w, 1)  # act over ch
+        result = np.flip(im, 1)  # augment segments (flip left-right)
+        i = np.flip(im_new.astype(bool), 1)
         im[i] = result[i]  # cv2.imwrite('debug.jpg', im)  # debug
 
     return im, labels, segments

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -252,8 +252,8 @@ def copy_paste(im, labels, segments, p=0.5):
                 segments.append(np.concatenate((w - s[:, 0:1], s[:, 1:2]), 1))
                 cv2.drawContours(im_new, [segments[j].astype(np.int32)], -1, (1, 1, 1), cv2.FILLED)
 
-        result = np.flip(im, 1)  # augment segments (flip left-right)
-        i = np.flip(im_new.astype(bool), 1)
+        result = cv2.flip(im, 1)  # augment segments (flip left-right)
+        i = cv2.flip(im_new, 1).astype(bool)
         im[i] = result[i]  # cv2.imwrite('debug.jpg', im)  # debug
 
     return im, labels, segments


### PR DESCRIPTION
@Laughing-q @AyushExel copy-paste zero-value fix here, verified working.

![train_batch0](https://user-images.githubusercontent.com/26833433/201677143-78b4d5d8-3ccd-41c7-8b96-522b6fff066e.jpg)

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved Copy-Paste augmentation logic for better training efficiency in YOLOv5.

### 📊 Key Changes
- Changed the color filled in contours from white `(255, 255, 255)` to `(1, 1, 1)` during the Copy-Paste augmentation process.
- Simplified the combination of the original and augmented images by removing the bitwise_and operation and redundant pixel replacement logic.
- Retained only the essential image flipping operation and updated how the augmented image pixels are combined with the original.

### 🎯 Purpose & Impact
- 🎯 The adjustments streamline the Copy-Paste augmentation, potentially improving the training speed and efficiency.
- 🚀 Users might notice faster training times due to the more straightforward augmentation process.
- 📉 The change could reduce computational overhead, indirectly benefiting users with less powerful hardware.