### PR TITLE
Fix dataloader filepath modification to perform replace only once and not for all occurences of string

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -470,7 +470,8 @@ class LoadImagesAndLabels(Dataset):
                     with open(p) as t:
                         t = t.read().strip().splitlines()
                         parent = str(p.parent) + os.sep
-                        f += [x.replace('./', parent, 1) if x.startswith('./') else x for x in t]  # local to global path
+                        f += [x.replace('./', parent, 1) if x.startswith('./') else x
+                              for x in t]  # local to global path
                         # f += [p.parent / x.lstrip(os.sep) for x in t]  # local to global path (pathlib)
                 else:
                     raise FileNotFoundError(f'{prefix}{p} does not exist')

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -470,7 +470,7 @@ class LoadImagesAndLabels(Dataset):
                     with open(p) as t:
                         t = t.read().strip().splitlines()
                         parent = str(p.parent) + os.sep
-                        f += [x.replace('./', parent) if x.startswith('./') else x for x in t]  # local to global path
+                        f += [x.replace('./', parent, 1) if x.startswith('./') else x for x in t]  # local to global path
                         # f += [p.parent / x.lstrip(os.sep) for x in t]  # local to global path (pathlib)
                 else:
                     raise FileNotFoundError(f'{prefix}{p} does not exist')

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -470,9 +470,8 @@ class LoadImagesAndLabels(Dataset):
                     with open(p) as t:
                         t = t.read().strip().splitlines()
                         parent = str(p.parent) + os.sep
-                        f += [x.replace('./', parent, 1) if x.startswith('./') else x
-                              for x in t]  # local to global path
-                        # f += [p.parent / x.lstrip(os.sep) for x in t]  # local to global path (pathlib)
+                        f += [x.replace('./', parent, 1) if x.startswith('./') else x for x in t]  # to global path
+                        # f += [p.parent / x.lstrip(os.sep) for x in t]  # to global path (pathlib)
                 else:
                     raise FileNotFoundError(f'{prefix}{p} does not exist')
             self.im_files = sorted(x.replace('/', os.sep) for x in f if x.split('.')[-1].lower() in IMG_FORMATS)


### PR DESCRIPTION
### Issue:
- Loading train/val data from parent/sibling folders
  - When you want to load training data in the following form: `./../../datasets/coco128/images/train/1.jpg`
  - The current implementation replaces all occurrences of `./` with `parent` path

### Fix:
- Replace only the first occurrence of `./` with parent path

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in path handling for dataset loading in YOLOv5.

### 📊 Key Changes
- Adjusted the method that converts local paths to global paths within the dataset loader code.
- Changed string replacement logic to ensure it correctly transforms local paths starting with './' to their global equivalent by replacing only the first instance of './'.

### 🎯 Purpose & Impact
- Ensures robust and accurate file path conversion across different operating systems and environments.
- Users should experience more reliable dataset loading, especially when local paths are used.
- Reduces potential bugs related to path handling that could affect model training and evaluation. 🐛➡️🚫