### PR TITLE
Filter PyTorch 1.13  UserWarnings

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -32,6 +32,7 @@ except ImportError:
 
 # Suppress PyTorch warnings
 warnings.filterwarnings('ignore', message='User provided device_type of \'cuda\', but CUDA is not available. Disabling')
+warnings.filterwarnings('ignore', category=UserWarning)
 
 
 def smart_inference_mode(torch_1_9=check_version(torch.__version__, '1.9.0')):


### PR DESCRIPTION
When training a model, I get such warnings.
![image](https://user-images.githubusercontent.com/92794867/201962480-19113651-d481-4ba0-9ea0-942fe4d1b694.png)
Maybe we should filter pytorch 1.13  warning about `torch.distributed._all_gather_base` or replace it with `torch.distributed.all_gather_into_tensor`


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved warning management for CUDA availability in PyTorch.

### 📊 Key Changes
- Added suppression of general `UserWarning` category warnings in the `torch_utils.py` file.

### 🎯 Purpose & Impact
- 🛠 **Purpose:** To reduce user confusion by suppressing non-critical warnings that might not directly affect the user experience or functionality of the software.
- 🧑‍💻 **Impact:** Users will encounter a cleaner console output, with fewer distractions from warnings that do not require immediate action, enhancing user experience.