### PR TITLE
Apply make_divisible for ONNX models in Autoshape

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -694,7 +694,8 @@ class AutoShape(nn.Module):
                 g = max(size) / max(s)  # gain
                 shape1.append([int(y * g) for y in s])
                 ims[i] = im if im.data.contiguous else np.ascontiguousarray(im)  # update
-            shape1 = [make_divisible(x, self.stride) for x in np.array(shape1).max(0)] if self.pt else size  # inf shape
+            shape1 = [make_divisible(x, self.stride)
+                for x in np.array(shape1).max(0)] if self.pt or self.model.onnx else size  # inf shape
             x = [letterbox(im, shape1, auto=False)[0] for im in ims]  # pad
             x = np.ascontiguousarray(np.array(x).transpose((0, 3, 1, 2)))  # stack and BHWC to BCHW
             x = torch.from_numpy(x).to(p.device).type_as(p) / 255  # uint8 to fp16/32

--- a/models/common.py
+++ b/models/common.py
@@ -694,8 +694,7 @@ class AutoShape(nn.Module):
                 g = max(size) / max(s)  # gain
                 shape1.append([int(y * g) for y in s])
                 ims[i] = im if im.data.contiguous else np.ascontiguousarray(im)  # update
-            shape1 = [make_divisible(x, self.stride)
-                      for x in np.array(shape1).max(0)] if self.pt or self.model.onnx else size  # inf shape
+            shape1 = [make_divisible(x, self.stride) for x in np.array(shape1).max(0)]  # inf shape
             x = [letterbox(im, shape1, auto=False)[0] for im in ims]  # pad
             x = np.ascontiguousarray(np.array(x).transpose((0, 3, 1, 2)))  # stack and BHWC to BCHW
             x = torch.from_numpy(x).to(p.device).type_as(p) / 255  # uint8 to fp16/32

--- a/models/common.py
+++ b/models/common.py
@@ -695,7 +695,7 @@ class AutoShape(nn.Module):
                 shape1.append([int(y * g) for y in s])
                 ims[i] = im if im.data.contiguous else np.ascontiguousarray(im)  # update
             shape1 = [make_divisible(x, self.stride)
-                for x in np.array(shape1).max(0)] if self.pt or self.model.onnx else size  # inf shape
+                      for x in np.array(shape1).max(0)] if self.pt or self.model.onnx else size  # inf shape
             x = [letterbox(im, shape1, auto=False)[0] for im in ims]  # pad
             x = np.ascontiguousarray(np.array(x).transpose((0, 3, 1, 2)))  # stack and BHWC to BCHW
             x = torch.from_numpy(x).to(p.device).type_as(p) / 255  # uint8 to fp16/32


### PR DESCRIPTION
At line 697 we have this `make_divisible` function applied on input images for pytorch models. 

- Context: we want to run inference on varied input sizes instead of fixed image size.
- When I test an image of size [720, 720] for a pytorch model (e.g., yolov5n.pt), we can see that it will be reshaped to [736, 736] by the function. This is as expected.
- When I test the same image for the onnx model (e.g., yolov5n.onnx, exported with `--dynamic`), I got an error and it's due to the indivisible problem

```
onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Non-zero status code returned while running Concat node. Name:'Concat_143' Status Message: concat.cc:156 PrepareForCompute Non concat axis dimensions must match: Axis 3 has mismatched dimensions of 45 and 46
```

The simple solution is to enable the `make_divisible` function for onnx model too.

Signed-off-by: janus-zheng <106574221+janus-zheng@users.noreply.github.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced image pre-processing in YOLOv5's inference pipeline.

### 📊 Key Changes
- Streamlined the image sizing process during the inference stage, removing a conditional check for PyTorch training.

### 🎯 Purpose & Impact
- 👍 Improves the efficiency of image pre-processing by eliminating unnecessary code when not in training mode.
- 🚀 Potentially increases the speed of model inference, leading to faster results for end-users.
- 🧑‍💻 Provides a more simplified codebase for developers working with the inference part of YOLOv5's code.