### PR TITLE
Segment prediction labels normalization fix

### DIFF
--- a/segment/predict.py
+++ b/segment/predict.py
@@ -156,7 +156,7 @@ def run(
                 # Segments
                 if save_txt:
                     segments = reversed(masks2segments(masks))
-                    segments = [scale_segments(im.shape[2:], x, im0.shape).round() for x in segments]
+                    segments = [scale_segments(im.shape[2:], x, im0.shape, normalize=True).round() for x in segments]
 
                 # Print results
                 for c in det[:, 5].unique():

--- a/segment/predict.py
+++ b/segment/predict.py
@@ -156,7 +156,7 @@ def run(
                 # Segments
                 if save_txt:
                     segments = reversed(masks2segments(masks))
-                    segments = [scale_segments(im.shape[2:], x, im0.shape, normalize=True).round() for x in segments]
+                    segments = [scale_segments(im.shape[2:], x, im0.shape, normalize=True) for x in segments]
 
                 # Print results
                 for c in det[:, 5].unique():

--- a/utils/general.py
+++ b/utils/general.py
@@ -822,7 +822,7 @@ def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None):
     return boxes
 
 
-def scale_segments(img1_shape, segments, img0_shape, ratio_pad=None):
+def scale_segments(img1_shape, segments, img0_shape, ratio_pad=None, normalize=False):
     # Rescale coords (xyxy) from img1_shape to img0_shape
     if ratio_pad is None:  # calculate from img0_shape
         gain = min(img1_shape[0] / img0_shape[0], img1_shape[1] / img0_shape[1])  # gain  = old / new
@@ -835,6 +835,9 @@ def scale_segments(img1_shape, segments, img0_shape, ratio_pad=None):
     segments[:, 1] -= pad[1]  # y padding
     segments /= gain
     clip_segments(segments, img0_shape)
+    if normalize:
+        segments[:, 0] /= img0_shape[0]
+        segments[:, 1] /= img0_shape[1]
     return segments
 
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -836,8 +836,8 @@ def scale_segments(img1_shape, segments, img0_shape, ratio_pad=None, normalize=F
     segments /= gain
     clip_segments(segments, img0_shape)
     if normalize:
-        segments[:, 0] /= img0_shape[0]
-        segments[:, 1] /= img0_shape[1]
+        segments[:, 0] /= img0_shape[1]  # width
+        segments[:, 1] /= img0_shape[0]  # height
     return segments
 
 
@@ -853,14 +853,14 @@ def clip_boxes(boxes, shape):
         boxes[:, [1, 3]] = boxes[:, [1, 3]].clip(0, shape[0])  # y1, y2
 
 
-def clip_segments(boxes, shape):
+def clip_segments(segments, shape):
     # Clip segments (xy1,xy2,...) to image shape (height, width)
-    if isinstance(boxes, torch.Tensor):  # faster individually
-        boxes[:, 0].clamp_(0, shape[1])  # x
-        boxes[:, 1].clamp_(0, shape[0])  # y
+    if isinstance(segments, torch.Tensor):  # faster individually
+        segments[:, 0].clamp_(0, shape[1])  # x
+        segments[:, 1].clamp_(0, shape[0])  # y
     else:  # np.array (faster grouped)
-        boxes[:, 0] = boxes[:, 0].clip(0, shape[1])  # x
-        boxes[:, 1] = boxes[:, 1].clip(0, shape[0])  # y
+        segments[:, 0] = segments[:, 0].clip(0, shape[1])  # x
+        segments[:, 1] = segments[:, 1].clip(0, shape[0])  # y
 
 
 def non_max_suppression(


### PR DESCRIPTION
Segment prediction labels normalization fix for #10196

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement of segmentation output normalization in YOLOv5's prediction pipeline.

### 📊 Key Changes
- Added `normalize` boolean parameter to the `scale_segments` function.
- Implemented normalization of segment coordinates within the `scale_segments` function when `normalize=True` is passed.
- Normalization adjusts the segment dimensions relative to the image width and height, rather than absolute pixel values.

### 🎯 Purpose & Impact
- **Purpose**: To provide an option for normalizing segment coordinates, making them relative to the image size (values between 0 and 1) instead of absolute pixel coordinates.
- **Impact**: This can ease post-processing and is beneficial for tasks that require consistent scale-invariant representation like multi-scale training or when integrating with systems that expect normalized coordinates.
- **Potential Benefit to Users**: Users now have the flexibility to choose between normalized or non-normalized segment outputs based on their specific use case or downstream application requirements.