### PR TITLE
Revert `--save-txt` to default False

### DIFF
--- a/classify/predict.py
+++ b/classify/predict.py
@@ -196,7 +196,7 @@ def parse_opt():
     parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[224], help='inference size h,w')
     parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
     parser.add_argument('--view-img', action='store_true', help='show results')
-    parser.add_argument('--save-txt', action='store_false', help='save results to *.txt')
+    parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
     parser.add_argument('--nosave', action='store_true', help='do not save images/videos')
     parser.add_argument('--augment', action='store_true', help='augmented inference')
     parser.add_argument('--visualize', action='store_true', help='visualize features')

--- a/classify/tutorial.ipynb
+++ b/classify/tutorial.ipynb
@@ -118,8 +118,7 @@
             "image 1/2 /content/yolov5/data/images/bus.jpg: 224x224 minibus 0.39, police van 0.24, amphibious vehicle 0.05, recreational vehicle 0.04, trolleybus 0.03, 3.9ms\n",
             "image 2/2 /content/yolov5/data/images/zidane.jpg: 224x224 suit 0.38, bow tie 0.19, bridegroom 0.18, rugby ball 0.04, stage 0.02, 4.1ms\n",
             "Speed: 0.3ms pre-process, 4.0ms inference, 1.5ms NMS per image at shape (1, 3, 224, 224)\n",
-            "Results saved to \u001b[1mruns/predict-cls/exp\u001b[0m\n",
-            "2 labels saved to runs/predict-cls/exp/labels\n"
+            "Results saved to \u001b[1mruns/predict-cls/exp\u001b[0m\n"
           ]
         }
       ],


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated argument behavior and documentation for classification predictions.

### 📊 Key Changes
- Changed the default action for the `--save-txt` argument from `store_false` to `store_true` in `classify/predict.py`.
- Removed a line in the `classify/tutorial.ipynb` notebook that indicated text label results were saved, to reflect the new default behavior.

### 🎯 Purpose & Impact
- The updated `--save-txt` argument makes it easier for users to save text results by default, improving the out-of-the-box experience.
- The tutorial update helps prevent confusion, ensuring that the documentation matches the actual behavior of the code.
- Potential impact includes users automatically receiving text files with results, which could be beneficial for record-keeping or further analysis without needing additional command line arguments. 📈