### PR TITLE
Squeezenet reshape outputs fix

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -82,7 +82,7 @@ def reshape_classifier_output(model, n=1000):
         elif nn.Conv2d in types:
             i = types.index(nn.Conv2d)  # nn.Conv2d index
             if m[i].out_channels != n:
-                m[i] = nn.Conv2d(m[i].in_channels, n, m[i].kernel_size, m[i].stride, bias=m[i].bias)
+                m[i] = nn.Conv2d(m[i].in_channels, n, m[i].kernel_size, m[i].stride, bias=m[i].bias is not None)
 
 
 @contextmanager


### PR DESCRIPTION
@AyushExel

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced convolutional layer bias handling in YOLOv5's model utility.

### 📊 Key Changes
- Modified the `nn.Conv2d` constructor in the `reshape_classifier_output` function to correctly handle whether a bias should be applied.

### 🎯 Purpose & Impact
- **Consistency:** Ensures that when a convolutional layer is reshaped, the bias parameter is maintained according to the original configuration (presence or absence of bias).
- **Reliability:** Prior to this change, models that originally did not use bias could have a bias mistakenly introduced, which is fixed now.
- **User Impact:** Users will experience improved model manipulation functionality, particularly in custom object classification, with no unexpected behavior regarding bias in convolutional layers.