### PR TITLE
Validate --task speed CPU fix

### DIFF
--- a/segment/val.py
+++ b/segment/val.py
@@ -444,7 +444,7 @@ def main(opt):
 
     else:
         weights = opt.weights if isinstance(opt.weights, list) else [opt.weights]
-        opt.half = True  # FP16 for fastest results
+        opt.half = torch.cuda.is_available() and opt.device != 'cpu'  # FP16 for fastest results
         if opt.task == 'speed':  # speed benchmarks
             # python val.py --task speed --data coco.yaml --batch 1 --weights yolov5n.pt yolov5s.pt...
             opt.conf_thres, opt.iou_thres, opt.save_json = 0.25, 0.45, False

--- a/val.py
+++ b/val.py
@@ -380,7 +380,7 @@ def main(opt):
 
     else:
         weights = opt.weights if isinstance(opt.weights, list) else [opt.weights]
-        opt.half = True  # FP16 for fastest results
+        opt.half = torch.cuda.is_available() and opt.device != 'cpu'  # FP16 for fastest results
         if opt.task == 'speed':  # speed benchmarks
             # python val.py --task speed --data coco.yaml --batch 1 --weights yolov5n.pt yolov5s.pt...
             opt.conf_thres, opt.iou_thres, opt.save_json = 0.25, 0.45, False


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to FP16 precision handling during validation in YOLOv5.

### 📊 Key Changes
- Modified the automatic enabling of FP16 (`opt.half`) to check for GPU availability before activation.
- Removed hardcoded setting of `opt.half` to `True`, instead added a condition to check if CUDA is available and if the device is not CPU.

### 🎯 Purpose & Impact
- **Purpose**: To enable FP16 precision only when the system has CUDA-compatible GPUs, avoiding errors on CPU-only environments.
- **Impact**: Ensures more robust and error-free execution by dynamically adapting to the available hardware, improving user experience across different setups. Users with CPU-only configurations will not run into issues with FP16 precision being incorrectly enabled. 🚀