### PR TITLE
`--single-cls` segments fix

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -537,8 +537,6 @@ class LoadImagesAndLabels(Dataset):
                     self.segments[i] = segment[j]
             if single_cls:  # single-class training, merge all classes into 0
                 self.labels[i][:, 0] = 0
-                if segment:
-                    self.segments[i][:, 0] = 0
 
         # Rectangular Training
         if self.rect:


### PR DESCRIPTION
May resolve #10230

Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary 
Improved data loader logic for single-class training in YOLOv5.

### 📊 Key Changes 
- Removed redundant lines of code that unnecessarily modified `segments` during single-class training.

### 🎯 Purpose & Impact 
- The simplification of the data loader will result in cleaner code and potentially fewer bugs.
- Users performing single-class training will benefit from this change, although the impact on training performance or results should be minimal.
- 🚀 This contributes to the overall maintainability and readability of the YOLOv5 codebase.