### PR TITLE
add option to save metrics to csv

### DIFF
--- a/val.py
+++ b/val.py
@@ -23,9 +23,9 @@ import argparse
 import json
 import os
 import sys
-import csvwriter
 from pathlib import Path
 
+import csvwriter
 import numpy as np
 import torch
 from tqdm import tqdm
@@ -114,7 +114,7 @@ def run(
         save_hybrid=False,  # save label+prediction hybrid results to *.txt
         save_conf=False,  # save confidences in --save-txt labels
         save_json=False,  # save a COCO-JSON results file
-        save_metrics=False, # save table of metrics to csv file
+        save_metrics=False,  # save table of metrics to csv file
         project=ROOT / 'runs/val',  # save to project/name
         name='exp',  # save to project/name
         exist_ok=False,  # existing project/name ok, do not increment
@@ -278,13 +278,13 @@ def run(
         ap50, ap = ap[:, 0], ap.mean(1)  # AP@0.5, AP@0.5:0.95
         mp, mr, map50, map = p.mean(), r.mean(), ap50.mean(), ap.mean()
     nt = np.bincount(stats[3].astype(int), minlength=nc)  # number of targets per class
-    
+
     # save metrics to csv file for easier analysis
     if save_metrics:
         metrics_for_txt = []
         metrics_for_txt.append(['Name', 'Class', 'Images', 'Instances', 'P', 'R', 'mAP50', 'mAP50-95'])
         metrics_for_txt.append([name, 'all', seen, nt.sum(), mp, mr, map50, map])
-    
+
     # Print results
     pf = '%22s' + '%11i' * 2 + '%11.3g' * 4  # print format
     LOGGER.info(pf % ('all', seen, nt.sum(), mp, mr, map50, map))
@@ -297,7 +297,7 @@ def run(
             LOGGER.info(pf % (names[c], seen, nt[c], p[i], r[i], ap50[i], ap[i]))
             if save_metrics:
                 metrics_for_txt.append([name, names[c], seen, nt[c], p[i], r[i], ap50[i], ap[i]])
-    
+
     # save metrics to txt
     if save_metrics:
         import csv
@@ -306,7 +306,7 @@ def run(
             writer = csv.writer(f)
             for class_metric_list in metrics_for_txt:
                 writer.writerow(class_metric_list)
-        
+
         LOGGER.info(f"Metrics saved to {colorstr('bold', metrics_output_path)}")
 
     # Print speeds

--- a/val.py
+++ b/val.py
@@ -20,12 +20,12 @@ Usage - formats:
 """
 
 import argparse
+import csv
 import json
 import os
 import sys
 from pathlib import Path
 
-import csv
 import numpy as np
 import torch
 from tqdm import tqdm

--- a/val.py
+++ b/val.py
@@ -25,7 +25,7 @@ import os
 import sys
 from pathlib import Path
 
-import csvwriter
+import csv
 import numpy as np
 import torch
 from tqdm import tqdm


### PR DESCRIPTION
This is just a small change in `val.py` to make saving/downstream analysis of metrics easier. It doesn't appear to be covered elsewhere from what I've checked. I was comparing quite a few different models with changes in parameters and needed an automated way of comparing performance. 

It includes a flag `--save-metrics` to save all metrics produced in val.py to a csv. Somewhat related to #5341

Signed-off-by: Guy Coleman <51358498+geezacoleman@users.noreply.github.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement in model evaluation with CSV metrics export.

### 📊 Key Changes
- Importing of the `csv` module in `val.py`.
- Addition of `save_metrics` argument to enable saving of evaluation metrics in CSV format.
- Creation of code blocks that compile evaluation metrics into a CSV-friendly list.
- Writing the compiled metrics into a CSV file at the specified output path (`metrics.csv`).

### 🎯 Purpose & Impact
- **Purpose**: To allow users to save detailed model evaluation metrics such as precision (P), recall (R), mean Average Precision at 0.5 IoU (mAP50), and mAP at 0.5:0.95 IoU (mAP50-95) into a CSV file for easier analysis and reporting.
- **Impact**: Users can now easily compare metrics across different models and share results without needing to parse console logs or custom scripts. This feature enhances the transparency and accessibility of model evaluation for both casual users and ML researchers or engineers. 📈🔍