### PR TITLE
add support for custom augmentations

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -206,7 +206,7 @@ class DetectionModel(BaseModel):
         LOGGER.info('')
 
     def forward(self, x, augment: T.Compose = None, profile=False, visualize=False):
-        if not(augment is None):
+        if not (augment is None):
             return self._forward_augment(x, augment)  # augmented inference, None
         return self._forward_once(x, profile, visualize)  # single-scale inference, train
 

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -206,7 +206,7 @@ class DetectionModel(BaseModel):
         LOGGER.info('')
 
     def forward(self, x, augment: T.Compose=None, profile=False, visualize=False):
-        if not augment is None:
+        if not(augment is None):
             return self._forward_augment(x, augment)  # augmented inference, None
         return self._forward_once(x, profile, visualize)  # single-scale inference, train
 

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -205,7 +205,7 @@ class DetectionModel(BaseModel):
         self.info()
         LOGGER.info('')
 
-    def forward(self, x, augment: T.Compose=None, profile=False, visualize=False):
+    def forward(self, x, augment: T.Compose = None, profile=False, visualize=False):
         if not augment is None:
             return self._forward_augment(x, augment)  # augmented inference, None
         return self._forward_once(x, profile, visualize)  # single-scale inference, train

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -206,7 +206,7 @@ class DetectionModel(BaseModel):
         LOGGER.info('')
 
     def forward(self, x, augment: T.Compose = None, profile=False, visualize=False):
-        if not augment is None:
+        if not(augment is None):
             return self._forward_augment(x, augment)  # augmented inference, None
         return self._forward_once(x, profile, visualize)  # single-scale inference, train
 


### PR DESCRIPTION
I add faced the same [issue](https://github.com/ultralytics/yolov5/issues/303) and support for custom torchvision.Transforms like augmentations

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced YOLOv5 image augmentation with torchvision transformations during inference.

### 📊 Key Changes
- Introduced `torchvision.transforms` as `T` to allow advanced image transformations.
- Modified the `forward` function signature to accept a transform composition (`augment: T.Compose`) instead of a boolean flag.
- Updated `_forward_augment` to apply the `augment` transformations to images before running inference.

### 🎯 Purpose & Impact
- **Purpose**: To enable more sophisticated and customizable image transformations during model inference, improving the versatility and accuracy of the model under various conditions.
- **Impact**: Users can now pass custom torchvision transform pipelines to the model during inference, potentially improving results and allowing for experiments with different augmentations. This change could lead to better performance in real-world applications by simulating various scenarios that the model may encounter.