### PR TITLE
Fix --evolve NaN bug

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -1036,7 +1036,7 @@ def print_mutation(keys, results, hyp, save_dir, bucket, prefix=colorstr('evolve
 
     # Save yaml
     with open(evolve_yaml, 'w') as f:
-        data = pd.read_csv(evolve_csv)
+        data = pd.read_csv(evolve_csv, skipinitialspace=True)
         data = data.rename(columns=lambda x: x.strip())  # strip keys
         i = np.argmax(fitness(data.values[:, :4]))  #
         generations = len(data)


### PR DESCRIPTION
when there is `nan` in evolve.csv pandas read it as str  remove the space before fix that 

Signed-off-by: Michael Ben ami <31584614+mbenami@users.noreply.github.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved CSV parsing during evolution in YOLOv5's training process.

### 📊 Key Changes
- Added `skipinitialspace=True` in the `pd.read_csv()` call to address initial space issues during CSV parsing.
- Ensured CSV column names are stripped of leading/trailing spaces.

### 🎯 Purpose & Impact
- **Purpose**: To prevent potential bugs related to the handling of spaces in CSV files used in the evolution strategy of the YOLOv5 algorithm.
- **Impact**: Enhances the reliability and accuracy of the evolution process, potentially leading to better-performing models. Users training YOLOv5 models should experience a smoother evolutionary process without manual data cleaning. 🧬📈