### PR TITLE
Fix clearml args logging when training is launch with run()

### DIFF
--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -102,7 +102,7 @@ class ClearmlLogger:
             self.task.set_base_docker("ultralytics/yolov5:latest",
                                       docker_arguments='--ipc=host -e="CLEARML_AGENT_SKIP_PYTHON_ENV_INSTALL=1"',
                                       docker_setup_bash_script='pip install clearml')
- 
+
             # Get ClearML Dataset Version if requested
             if opt.data.startswith('clearml://'):
                 # data_dict should have the following keys:

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -96,7 +96,7 @@ class ClearmlLogger:
             # Only the hyperparameters coming from the yaml config file
             # will have to be added manually!
             self.task.connect(hyp, name='Hyperparameters')
-
+            self.task.connect(opt, name='Args')
             # Get ClearML Dataset Version if requested
             if opt.data.startswith('clearml://'):
                 # data_dict should have the following keys:

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -97,7 +97,7 @@ class ClearmlLogger:
             # will have to be added manually!
             self.task.connect(hyp, name='Hyperparameters')
             self.task.connect(opt, name='Args')
-            
+
             # Make sure the code is easily remotely runnable by setting the docker image to use by the remote agent
             self.task.set_base_docker("ultralytics/yolov5:latest",
                                       docker_arguments='--ipc=host -e="CLEARML_AGENT_SKIP_PYTHON_ENV_INSTALL=1"',

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -102,6 +102,7 @@ class ClearmlLogger:
             self.task.set_base_docker("ultralytics/yolov5:latest",
                                       docker_arguments='--ipc=host -e="CLEARML_AGENT_SKIP_PYTHON_ENV_INSTALL=1"',
                                       docker_setup_bash_script='pip install clearml')
+ 
             # Get ClearML Dataset Version if requested
             if opt.data.startswith('clearml://'):
                 # data_dict should have the following keys:


### PR DESCRIPTION
This PR fixes #10341

My understading is that clearml logs automaticaly the argument from the first `argparse.parse_args` or `argparse.parse_known_args` call.

When calling run(), we :
1. Run the `argparse.parse_known_args` to get all default values 
2. Override values that are provided in kwargs

So clearml logs the values from step 1.

To fix this, we should pass the args to the `parse_known_args` call so the 2 steps are made at once and clearml get correct args values to log.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging capabilities in YOLOv5's integration with ClearML.

### 📊 Key Changes
- Added connection of `opt` (command-line arguments) to the ClearML task.

### 🎯 Purpose & Impact
- **Purpose**: To ensure that not just hyperparameters (`hyp`) but also command-line arguments (`opt`) are tracked in ClearML, allowing for a more comprehensive logging and tracking of experiment settings.
- **Impact**: This will enable users to have a better overview and control of their experiments by capturing all relevant parameters and configurations. Additionally, it improves reproducibility of experiments by ensuring that all user-defined settings are recorded. 🔄