### PR TITLE
Allow users to specify how to override a ClearML Task

### DIFF
--- a/train.py
+++ b/train.py
@@ -472,12 +472,6 @@ def parse_opt(known=False):
     parser.add_argument('--upload_dataset', nargs='?', const=True, default=False, help='Upload data, "val" option')
     parser.add_argument('--bbox_interval', type=int, default=-1, help='Set bounding-box image logging interval')
     parser.add_argument('--artifact_alias', type=str, default='latest', help='Version of dataset artifact to use')
-    parser.add_argument('--reuse_last_task',
-                        nargs='?',
-                        default=False,
-                        const=True,
-                        help='If given will override newest task ID only if task has no artifacts, only ClearML.'
-                        'Can also give specific ID as argument to override instead. Is meant to prevent clutter.')
 
     return parser.parse_known_args()[0] if known else parser.parse_args()
 

--- a/train.py
+++ b/train.py
@@ -472,8 +472,9 @@ def parse_opt(known=False):
     parser.add_argument('--upload_dataset', nargs='?', const=True, default=False, help='Upload data, "val" option')
     parser.add_argument('--bbox_interval', type=int, default=-1, help='Set bounding-box image logging interval')
     parser.add_argument('--artifact_alias', type=str, default='latest', help='Version of dataset artifact to use')
-    parser.add_argument('--reuse_last_task', action='store_true', help='Override last task ID if it has no artifacts'
-                                                                       '(only ClearML) Is meant to prevent clutter')
+    parser.add_argument('--reuse_last_task', nargs='?', default=False, const=True,
+                        help='If given will override newest task ID only if task has no artifacts, only ClearML.'
+                        'Can also give specific ID as argument to override instead. Is meant to prevent clutter.')
 
     return parser.parse_known_args()[0] if known else parser.parse_args()
 

--- a/train.py
+++ b/train.py
@@ -472,6 +472,8 @@ def parse_opt(known=False):
     parser.add_argument('--upload_dataset', nargs='?', const=True, default=False, help='Upload data, "val" option')
     parser.add_argument('--bbox_interval', type=int, default=-1, help='Set bounding-box image logging interval')
     parser.add_argument('--artifact_alias', type=str, default='latest', help='Version of dataset artifact to use')
+    parser.add_argument('--reuse_last_task', action='store_true', help='Override last task ID if it has no artifacts'
+                                                                       '(only ClearML) Is meant to prevent clutter')
 
     return parser.parse_known_args()[0] if known else parser.parse_args()
 

--- a/train.py
+++ b/train.py
@@ -472,7 +472,10 @@ def parse_opt(known=False):
     parser.add_argument('--upload_dataset', nargs='?', const=True, default=False, help='Upload data, "val" option')
     parser.add_argument('--bbox_interval', type=int, default=-1, help='Set bounding-box image logging interval')
     parser.add_argument('--artifact_alias', type=str, default='latest', help='Version of dataset artifact to use')
-    parser.add_argument('--reuse_last_task', nargs='?', default=False, const=True,
+    parser.add_argument('--reuse_last_task',
+                        nargs='?',
+                        default=False,
+                        const=True,
                         help='If given will override newest task ID only if task has no artifacts, only ClearML.'
                         'Can also give specific ID as argument to override instead. Is meant to prevent clutter.')
 

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -89,6 +89,7 @@ class ClearmlLogger:
                 task_name=opt.name if opt.name != 'exp' else 'Training',
                 tags=['YOLOv5'],
                 output_uri=True,
+                reuse_last_task_id=opt.reuse_last_task,
                 auto_connect_frameworks={'pytorch': False}
                 # We disconnect pytorch auto-detection, because we added manual model save points in the code
             )

--- a/utils/loggers/clearml/clearml_utils.py
+++ b/utils/loggers/clearml/clearml_utils.py
@@ -89,7 +89,7 @@ class ClearmlLogger:
                 task_name=opt.name if opt.name != 'exp' else 'Training',
                 tags=['YOLOv5'],
                 output_uri=True,
-                reuse_last_task_id=opt.reuse_last_task,
+                reuse_last_task_id=opt.exist_ok,
                 auto_connect_frameworks={'pytorch': False}
                 # We disconnect pytorch auto-detection, because we added manual model save points in the code
             )


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->
## Context
As discussed here: https://github.com/ultralytics/yolov5/pull/9865#issuecomment-1332353839
Thank you @mikel-brostrom for bringing this to light.

## Changes
Add a new command line argument `--reuse_last_task` named such that it may later be reused by other loggers.
Not providing it, will make ClearML never override a task
Providing it, will allow ClearML to override the most recent task only if it doesn't have artifacts logged (model weights)
You can also add a custom Task ID as such `--reuse_last_task fdf3586060bd4ef5bed277f64da646e9` to override a specific task.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced ClearML Logger integration with YOLOv5 for task reuse.

### 📊 Key Changes
- Added `reuse_last_task_id` parameter to ClearML logger initialization.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: Allows users to reuse the last task ID in ClearML if the existence of the task is acknowledged (controlled by `exist_ok` in options).
- 💡 **Impact**: Users can continue logging from a previous run, making experiment tracking more flexible and less cluttered with redundant entries.