### PR TITLE
Add DNN warning comment

### DIFF
--- a/export.py
+++ b/export.py
@@ -153,7 +153,7 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr('ONNX
         f,
         verbose=False,
         opset_version=opset,
-        do_constant_folding=True,
+        do_constant_folding=True,  # WARNING: DNN inference with torch>=1.12 may require do_constant_folding=False
         input_names=['images'],
         output_names=output_names,
         dynamic_axes=dynamic or None)


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated ONNX export settings for compatibility with PyTorch versions.

### 📊 Key Changes
- Added a comment warning regarding the `do_constant_folding` parameter in ONNX export.
- No actual code behavior change—only additional information for developers.

### 🎯 Purpose & Impact
- 🎓 The comment is aimed at informing developers that using PyTorch version 1.12 or newer might require setting `do_constant_folding=False` during ONNX export for successful DNN inference.
- 🔧 This update is a proactive measure to prevent potential issues with ONNX model deployment, ensuring smoother transitions for users upgrading their PyTorch version.
- 🤖 Users are unlikely to see immediate changes, but the comment provides crucial insights for troubleshooting and future-proofing their ONNX model exports.