### PR TITLE
Add catch for misspelled `--task`

### DIFF
--- a/segment/val.py
+++ b/segment/val.py
@@ -463,6 +463,8 @@ def main(opt):
                 np.savetxt(f, y, fmt='%10.4g')  # save
             os.system('zip -r study.zip study_*.txt')
             plot_val_study(x=x)  # plot
+        else:
+            raise NotImplementedError(f'--task {opt.task} not in ("train", "val", "test", "speed", "study")')
 
 
 if __name__ == "__main__":

--- a/val.py
+++ b/val.py
@@ -400,7 +400,7 @@ def main(opt):
             os.system('zip -r study.zip study_*.txt')
             plot_val_study(x=x)  # plot
         else:
-            raise NotImplementedError(f'{opt.task} not in ["train", "val", "test", "speed", "study"].')
+            raise NotImplementedError(f'--task {opt.task} not in ("train", "val", "test", "speed", "study")')
 
 
 if __name__ == "__main__":

--- a/val.py
+++ b/val.py
@@ -402,6 +402,7 @@ def main(opt):
         else:
             raise NotImplementedError(f'{opt.task} not in ["train", "val", "test", "speed", "study"].')
 
+
 if __name__ == "__main__":
     opt = parse_opt()
     main(opt)

--- a/val.py
+++ b/val.py
@@ -399,7 +399,8 @@ def main(opt):
                 np.savetxt(f, y, fmt='%10.4g')  # save
             os.system('zip -r study.zip study_*.txt')
             plot_val_study(x=x)  # plot
-
+        else:
+            raise NotImplementedError(f'{opt.task} not in ["train", "val", "test", "speed", "study"].')
 
 if __name__ == "__main__":
     opt = parse_opt()


### PR DESCRIPTION
Signed-off-by: Leander van Eekelen <47320151+leandervaneekelen@users.noreply.github.com>

Fix #10419. Makes `val.py` fail loudly instead of silently on a misspelled `--task`.

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added error handling for unsupported tasks in the validation scripts.

### 📊 Key Changes
- 🛠️ Introduced a new conditional statement to `segment/val.py` and `val.py`.
- 🚫 Implemented an error raise for when an undefined `--task` argument is used.

### 🎯 Purpose & Impact
- **Enhanced Clarity**: Users will now receive a clear error message if they try to run the validation script with an unsupported task argument.
- **Preventative Measures**: Prevents accidental misuse of the script, guiding users towards correct usage.
- **User Experience**: Improves the user experience by making the script more robust and user-friendly.