### PR TITLE
Add force_reload=True when loading model using torch hub

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -963,7 +963,7 @@
         "# YOLOv5 PyTorch HUB Inference (DetectionModels only)\n",
         "import torch\n",
         "\n",
-        "model = torch.hub.load('ultralytics/yolov5', 'yolov5s')  # yolov5n - yolov5x6 or custom\n",
+        "model = torch.hub.load('ultralytics/yolov5', 'yolov5s', force_reload=True)  # yolov5n - yolov5x6 or custom\n",
         "im = 'https://ultralytics.com/images/zidane.jpg'  # file, Path, PIL.Image, OpenCV, nparray, list\n",
         "results = model(im)  # inference\n",
         "results.print()  # or .show(), .save(), .crop(), .pandas(), etc."


### PR DESCRIPTION
Signed-off-by: Yonghye Kwon <developer.0hye@gmail.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

It is related to #6948.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model reloading in YOLOv5 tutorial notebook.

### 📊 Key Changes
- The tutorial Jupyter notebook now includes a `force_reload` parameter when loading the YOLOv5 model with `torch.hub.load`.

### 🎯 Purpose & Impact
- **Purpose:** To ensure that the latest model is always downloaded and loaded, even if a cached version exists.
- **Impact:** Users will always run inference with the most updated version of YOLOv5, which is especially helpful for newcomers experimenting with the tutorial notebook or for those who need to test recent changes. This minor update promotes best practices in model loading. 🔄🆕