### PR TITLE
Load a coco json file with a dataset directory defined in a yaml file

### DIFF
--- a/val.py
+++ b/val.py
@@ -302,7 +302,7 @@ def run(
     # Save JSON
     if save_json and len(jdict):
         w = Path(weights[0] if isinstance(weights, list) else weights).stem if weights is not None else ''  # weights
-        anno_json = str(Path('../datasets/coco/annotations/instances_val2017.json'))  # annotations
+        anno_json = str(Path(os.path.join(data["path"], "annotations/instances_val2017.json")))  # annotations
         pred_json = str(save_dir / f"{w}_predictions.json")  # predictions
         LOGGER.info(f'\nEvaluating pycocotools mAP... saving {pred_json}...')
         with open(pred_json, 'w') as f:


### PR DESCRIPTION
Signed-off-by: Yonghye Kwon <developer.0hye@gmail.com>

I think that someone may modify directory in `coco.yaml` like me.

So I modified code, it can make us load coco json file with a dataset directory defined in yaml file.


<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved annotation path handling in validation script for YOLOv5.

### 📊 Key Changes
- Changed the hardcoded path to COCO annotations within the validation script to a dynamic path based on the `data` dictionary.

### 🎯 Purpose & Impact
- 💡 **Purpose:** This change makes the code more flexible by allowing it to work with different dataset paths, rather than assuming that the COCO dataset is located in a specific directory (`../datasets/coco/annotations/`). This accommodates users who may have their datasets stored in different locations.
- ✅ **Impact:** Users will experience easier integration with their custom dataset paths, leading to a smoother workflow when validating models using datasets other than the default COCO dataset. This can potentially increase the user-friendliness of the YOLOv5 framework for custom dataset validations.