### PR TITLE
Update train.py

### DIFF
--- a/classify/train.py
+++ b/classify/train.py
@@ -6,7 +6,7 @@ Usage - Single-GPU training:
     $ python classify/train.py --model yolov5s-cls.pt --data imagenette160 --epochs 5 --img 224
 
 Usage - Multi-GPU DDP training:
-    $ python -m torch.distributed.run --nproc_per_node 4 --master_port 1 classify/train.py --model yolov5s-cls.pt --data imagenet --epochs 5 --img 224 --device 0,1,2,3
+    $ python -m torch.distributed.run --nproc_per_node 4 --master_port 2022 classify/train.py --model yolov5s-cls.pt --data imagenet --epochs 5 --img 224 --device 0,1,2,3
 
 Datasets:           --data mnist, fashion-mnist, cifar10, cifar100, imagenette, imagewoof, imagenet, or 'path/to/data'
 YOLOv5-cls models:  --model yolov5n-cls.pt, yolov5s-cls.pt, yolov5m-cls.pt, yolov5l-cls.pt, yolov5x-cls.pt


### PR DESCRIPTION
Setting `master_port` to 1 may cause `Permission denied` due to failure to bind the port. So it is better to set it to a port greater than 1024.

Signed-off-by: Wang Xin <xinwang614@gmail.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated the default master port for Multi-GPU DDP training in the classification training script.

### 📊 Key Changes
- Changed the master port from `1` to `2022` in the Multi-GPU DDP training command.

### 🎯 Purpose & Impact
- 🛠️ **Purpose**: Modifying the master port can resolve potential conflicts with other processes or system services using the old default port.
- 💻 **Impact**: Users running Multi-GPU Distributed Data Parallel (DDP) training now have a less common default port, reducing the likelihood of port-related issues. This update is specifically helpful for those running multiple training sessions on the same machine/network or dealing with restricted ports.