### PR TITLE
Limit detections without explicit if condition

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -979,8 +979,7 @@ def non_max_suppression(
         c = x[:, 5:6] * (0 if agnostic else max_wh)  # classes
         boxes, scores = x[:, :4] + c, x[:, 4]  # boxes (offset by class), scores
         i = torchvision.ops.nms(boxes, scores, iou_thres)  # NMS
-        if i.shape[0] > max_det:  # limit detections
-            i = i[:max_det]
+        i = i[:min(i.shape[0], max_det)] # limit detections
         if merge and (1 < n < 3E3):  # Merge NMS (boxes merged using weighted mean)
             # update boxes as boxes(i,4) = weights(i,n) * boxes(n,4)
             iou = box_iou(boxes[i], boxes) > iou_thres  # iou matrix

--- a/utils/general.py
+++ b/utils/general.py
@@ -979,7 +979,7 @@ def non_max_suppression(
         c = x[:, 5:6] * (0 if agnostic else max_wh)  # classes
         boxes, scores = x[:, :4] + c, x[:, 4]  # boxes (offset by class), scores
         i = torchvision.ops.nms(boxes, scores, iou_thres)  # NMS
-        i = i[:min(i.shape[0], max_det)] # limit detections
+        i = i[:min(i.shape[0], max_det)]  # limit detections
         if merge and (1 < n < 3E3):  # Merge NMS (boxes merged using weighted mean)
             # update boxes as boxes(i,4) = weights(i,n) * boxes(n,4)
             iou = box_iou(boxes[i], boxes) > iou_thres  # iou matrix

--- a/utils/general.py
+++ b/utils/general.py
@@ -978,7 +978,7 @@ def non_max_suppression(
         c = x[:, 5:6] * (0 if agnostic else max_wh)  # classes
         boxes, scores = x[:, :4] + c, x[:, 4]  # boxes (offset by class), scores
         i = torchvision.ops.nms(boxes, scores, iou_thres)  # NMS
-        i = i[:min(i.shape[0], max_det)]  # limit detections
+        i = i[:max_det]  # limit detections
         if merge and (1 < n < 3E3):  # Merge NMS (boxes merged using weighted mean)
             # update boxes as boxes(i,4) = weights(i,n) * boxes(n,4)
             iou = box_iou(boxes[i], boxes) > iou_thres  # iou matrix


### PR DESCRIPTION
Signed-off-by: Yonghye Kwon <developer.0hye@gmail.com>

![image](https://user-images.githubusercontent.com/35001605/207758180-f3197f9c-2561-429e-ad73-430f6bcb9311.png)

`min` is slightly faster than `if` on average-case .

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of non-max suppression in YOLOv5.

### 📊 Key Changes
- Simplified the detection limiting code in the non-max suppression function.

### 🎯 Purpose & Impact
- **Purpose:** To streamline the execution of the non-max suppression by removing redundant condition checks.
- **Impact:** This change potentially improves the performance of the model by reducing the computational overhead. It will also make the codebase easier to maintain since there is less complexity in the logic. Users might experience slightly faster inference times and a cleaner code structure. 🚀