### PR TITLE
bugfix: single_mask_loss

### DIFF
--- a/utils/segment/loss.py
+++ b/utils/segment/loss.py
@@ -113,7 +113,7 @@ class ComputeLoss:
         # Mask loss for one image
         pred_mask = (pred @ proto.view(self.nm, -1)).view(-1, *proto.shape[1:])  # (n,32) @ (32,80,80) -> (n,80,80)
         loss = F.binary_cross_entropy_with_logits(pred_mask, gt_mask, reduction="none")
-        return (crop_mask(loss, xyxy).mean(dim=(1, 2)) / area).mean()
+        return (crop_mask(loss, xyxy).sum(dim=(1, 2)) / area).mean()
 
     def build_targets(self, p, targets):
         # Build targets for compute_loss(), input targets(image,class,x,y,w,h)


### PR DESCRIPTION
Signed-off-by: erliding <42523282+erliding@users.noreply.github.com>

sum instead of average of the loss over space dim then normalized by box area

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of segmentation mask loss calculation in YOLOv5.

### 📊 Key Changes
- Adjusted the mask loss computation from mean to sum within the single_mask_loss function.

### 🎯 Purpose & Impact
- 📈 This change aims to improve the accuracy of the loss calculation by considering the total loss across the mask, rather than averaging it. This could potentially lead to better training performance and more accurate segmentation results.
- 👩‍💻 Users can expect models trained with this loss function update to perform better in segmentation tasks, which may result in more refined object boundaries.