### PR TITLE
Skip output normalization for TF classification models in DetectMultiBackend

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -578,7 +578,8 @@ class DetectMultiBackend(nn.Module):
                         x = (x.astype(np.float32) - zero_point) * scale  # re-scale
                     y.append(x)
             y = [x if isinstance(x, np.ndarray) else x.numpy() for x in y]
-            y[0][..., :4] *= [w, h, w, h]  # xywh normalized to pixels
+            if y[0].shape[-1] != 1:  # if not classification
+                y[0][..., :4] *= [w, h, w, h]  # xywh normalized to pixels
 
         if isinstance(y, (list, tuple)):
             return self.from_numpy(y[0]) if len(y) == 1 else [self.from_numpy(x) for x in y]


### PR DESCRIPTION
Resolving #10512


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved handling for non-detection models in YOLOv5 common model code.

### 📊 Key Changes
- Added a conditional check to ensure xywh scaling is only applied to detection outputs and not classification outputs.

### 🎯 Purpose & Impact
- 🎨 Ensures that the output scaling is applicable only to models that provide bounding box information, thereby preventing classification-only models from returning incorrect outputs.
- 🛠️ Increases the flexibility of YOLOv5's common model code to support different types of outputs without causing errors or misinterpretations for tasks that don't involve object localization.
- 🚀 Enhances overall robustness of the model inference, fostering usability across a wider range of machine learning tasks such as simple image classification that doesn't require bounding box predictions.