### PR TITLE
Bugfix: update dataloaders.py to fix "resize to 0"

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -737,11 +737,7 @@ class LoadImagesAndLabels(Dataset):
             r = self.img_size / max(h0, w0)  # ratio
             if r != 1:  # if sizes are not equal
                 interp = cv2.INTER_LINEAR if (self.augment or r > 1) else cv2.INTER_AREA
-
-                min_len = 32
-                w0_temp = min_len if int(w0 * r) < min_len else int(w0 * r)
-                h0_temp = min_len if int(h0 * r) < min_len else int(h0 * r)
-                im = cv2.resize(im, (w0_temp, h0_temp), interpolation=interp)
+                im = cv2.resize(im, (math.ceil(w0 * r), math.ceil(h0 * r)), interpolation=interp)
             return im, (h0, w0), im.shape[:2]  # im, hw_original, hw_resized
         return self.ims[i], self.im_hw0[i], self.im_hw[i]  # im, hw_original, hw_resized
 

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -737,8 +737,8 @@ class LoadImagesAndLabels(Dataset):
             r = self.img_size / max(h0, w0)  # ratio
             if r != 1:  # if sizes are not equal
                 interp = cv2.INTER_LINEAR if (self.augment or r > 1) else cv2.INTER_AREA
-                
-                min_len=32
+
+                min_len = 32
                 w0_temp = min_len if int(w0 * r) < min_len else int(w0 * r)
                 h0_temp = min_len if int(h0 * r) < min_len else int(h0 * r)
                 im = cv2.resize(im, (w0_temp, h0_temp), interpolation=interp)

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -737,7 +737,11 @@ class LoadImagesAndLabels(Dataset):
             r = self.img_size / max(h0, w0)  # ratio
             if r != 1:  # if sizes are not equal
                 interp = cv2.INTER_LINEAR if (self.augment or r > 1) else cv2.INTER_AREA
-                im = cv2.resize(im, (int(w0 * r), int(h0 * r)), interpolation=interp)
+                
+                min_len=32
+                w0_temp = min_len if int(w0 * r) < min_len else int(w0 * r)
+                h0_temp = min_len if int(h0 * r) < min_len else int(h0 * r)
+                im = cv2.resize(im, (w0_temp, h0_temp), interpolation=interp)
             return im, (h0, w0), im.shape[:2]  # im, hw_original, hw_resized
         return self.ims[i], self.im_hw0[i], self.im_hw[i]  # im, hw_original, hw_resized
 


### PR DESCRIPTION

- Problem: When the ratio of width to height of the image is too large, the short side will scale to 0, causing an error.
- Solution: Set minimum lower bound for short side.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved image resizing accuracy in data loader.

### 📊 Key Changes
- Changed the image resizing function from `int` to `math.ceil` for calculating new image dimensions.

### 🎯 Purpose & Impact
- **Enhanced Precision:** Using `math.ceil` ensures that the scaling ratio is always rounded up, preventing any loss of pixels during resizing. This can be especially important for very small objects in images.
- **Image Quality:** This may improve the preservation of image details when the image is scaled up, leading to potentially better object detection performance.
- **Downstream Effects:** The change could affect how models trained on resized images perform, although the impact is likely to be quite minor for most use cases.