### PR TITLE
Bugfix: update dataloaders.py

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -532,13 +532,14 @@ class LoadImagesAndLabels(Dataset):
         # Update labels
         include_class = []  # filter labels to include only these classes (optional)
         include_class_array = np.array(include_class).reshape(1, -1)
-        self.segments = list(self.segments) # convert from tuple to list to allow changes incase of include_class
+        self.segments = list(self.segments)  # convert from tuple to list to allow changes incase of include_class
         for i, (label, segment) in enumerate(zip(self.labels, self.segments)):
             if include_class:
                 j = (label[:, 0:1] == include_class_array).any(1)
                 self.labels[i] = label[j]
                 if segment:
-                    self.segments[i] = np.array(segment)[j] # convert segment from list to np array to pass the bools list j
+                    self.segments[i] = np.array(segment)[
+                        j]  # convert segment from list to np array to pass the bools list j
             if single_cls:  # single-class training, merge all classes into 0
                 self.labels[i][:, 0] = 0
 

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -532,12 +532,13 @@ class LoadImagesAndLabels(Dataset):
         # Update labels
         include_class = []  # filter labels to include only these classes (optional)
         include_class_array = np.array(include_class).reshape(1, -1)
+        self.segments = list(self.segments) # convert from tuple to list to allow changes incase of include_class
         for i, (label, segment) in enumerate(zip(self.labels, self.segments)):
             if include_class:
                 j = (label[:, 0:1] == include_class_array).any(1)
                 self.labels[i] = label[j]
                 if segment:
-                    self.segments[i] = segment[j]
+                    self.segments[i] = np.array(segment)[j] # convert segment from list to np array to pass the bools list j
             if single_cls:  # single-class training, merge all classes into 0
                 self.labels[i][:, 0] = 0
 


### PR DESCRIPTION
**Problem:** Filtering classes while training a yolov5-segment model

**Description:**
In-case of filtering some classes in **segment training** using `include_class` list

https://github.com/ultralytics/yolov5/blob/2370a5513ebf67bd10b8d15fd6353e008380bc43/utils/dataloaders.py#L533-L540

you'll recieve the following error on the line afterwards (utils/dataloaders.py#L540)

```
Traceback:
File "<path>/yolov5/utils/dataloaders.py", line 540, in __init__
    self.segments[i] = segment[j]
TypeError: only integer scalar arrays can be converted to a scalar index
```
Changing to:
```python
self.segments[i] = np.array(segment)[j]
```
you'll receive the following error:
```
Traceback:
File "<path>/yolov5/utils/dataloaders.py", line 539, in __init__
    self.segments[i] = np.array(segment)[j]
TypeError: 'tuple' object does not support item assignment
```
So we need to convert `self.segments` as well to list before the loop to make it work 

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced data filtering by class in data loader.

### 📊 Key Changes
- 🔄 Converted `self.segments` from a tuple to a list to enable modifications.
- 🎛 Added compatibility for filtering by class, allowing to include only specified classes.
- 🛠 Fixed segment handling to align with label filtering by converting segments to a NumPy array when applying boolean indexing.

### 🎯 Purpose & Impact
- 🎨 This change allows users to more easily filter dataset classes, useful when training models on specific categories.
- 🧠 Updates to data loader logic will streamline data preparation, potentially improving training efficiency and model performance.
- 💡 Non-expert users may find it easier to work with subsets of data, enhancing the usability of the tool.