### PR TITLE
Early remove excess boxes to reduce overhead

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -943,7 +943,7 @@ def non_max_suppression(
             continue
 
         x = x[x[:, 4].argsort(descending=True)[:max_nms]]  # sort by confidence and remove excess boxes
-        
+
         # Compute conf
         x[:, 5:] *= x[:, 4:5]  # conf = obj_conf * cls_conf
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -942,6 +942,8 @@ def non_max_suppression(
         if not x.shape[0]:
             continue
 
+        x = x[x[:, 4].argsort(descending=True)[:max_nms]]  # sort by confidence and remove excess boxes
+        
         # Compute conf
         x[:, 5:] *= x[:, 4:5]  # conf = obj_conf * cls_conf
 
@@ -969,7 +971,6 @@ def non_max_suppression(
         n = x.shape[0]  # number of boxes
         if not n:  # no boxes
             continue
-        x = x[x[:, 4].argsort(descending=True)[:max_nms]]  # sort by confidence and remove excess boxes
 
         # Batched NMS
         c = x[:, 5:6] * (0 if agnostic else max_wh)  # classes


### PR DESCRIPTION
Signed-off-by: Yonghye Kwon <developer.0hye@gmail.com>

This change can reduce overhead for unnecessary computation for `xywh2xyxy` and `Compute conf` stage.

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved object detection performance by optimizing box selection in non-maximum suppression.

### 📊 Key Changes
- 📦 Added sorting by confidence and removal of excess boxes *before* computing the combined confidence score for each detection.
- 🚀 Removed redundant box sorting after computing the combined confidence to streamline the process.

### 🎯 Purpose & Impact
- 🏎️ Increases the efficiency of the non-maximum suppression algorithm, potentially speeding up the object detection process.
- ✅ Ensures that the most confident detections are considered first, which may improve the overall accuracy of the model.
- ⚡ Reduces computational overhead by eliminating unnecessary sorting operations, likely leading to faster inference times for users.