### PR TITLE
docs: remove past Ultralytics Live Session event from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,6 @@ To request an Enterprise License please complete the form at <a href="https://ul
   </div>
 </div>
 
-
-## <div align="center">Ultralytics Live Session</div>
-
-<div align="center">
-
-[Ultralytics Live Session Ep. 2](https://youtu.be/QGRtEG7UjtE) ✨ will be streaming live on **Tuesday, December 13th at 19:00 CET** with [Joseph Nelson](https://github.com/josephofiowa) of [Roboflow](https://roboflow.com/?ref=ultralytics) who will join us to discuss the brand new Roboflow x Ultralytics HUB integration. Tune in to ask Glenn and Joseph about how you can make speed up workflows with seamless dataset integration! 🔥
-
-<a align="center" href="https://youtu.be/QGRtEG7UjtE" target="_blank">
-<img width="800" src="https://user-images.githubusercontent.com/85292283/205996456-bf3efa33-9c46-455e-b322-a64886cc7a0b.png"></a>
-</div>
-
 ## <div align="center">Segmentation ⭐ NEW</div>
 
 <div align="center">


### PR DESCRIPTION
Signed-off-by: Hisam Fahri <me@hisamafahri.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Removal of outdated Ultralytics live session section from README.

### 📊 Key Changes
- Deleted the Ultralytics live session promotional section and associated image link from the project's README file.

### 🎯 Purpose & Impact
- **Purpose:** The update likely aims to clean up the README to keep it relevant and focused, as the live session might have been outdated or no longer applicable.
- **Impact:** Users will no longer see information about the past live session when visiting the project's homepage, leading to a more streamlined and current presentation of information. 🧹✨