### PR TITLE
Update clip_boxes function in general.py

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -861,14 +861,8 @@ def scale_segments(img1_shape, segments, img0_shape, ratio_pad=None, normalize=F
 
 def clip_boxes(boxes, shape):
     # Clip boxes (xyxy) to image shape (height, width)
-    if isinstance(boxes, torch.Tensor):  # faster individually
-        boxes[..., 0].clamp_(0, shape[1])  # x1
-        boxes[..., 1].clamp_(0, shape[0])  # y1
-        boxes[..., 2].clamp_(0, shape[1])  # x2
-        boxes[..., 3].clamp_(0, shape[0])  # y2
-    else:  # np.array (faster grouped)
-        boxes[..., [0, 2]] = boxes[..., [0, 2]].clip(0, shape[1])  # x1, x2
-        boxes[..., [1, 3]] = boxes[..., [1, 3]].clip(0, shape[0])  # y1, y2
+    boxes[..., [0, 2]] = boxes[..., [0, 2]].clip(0, shape[1])  # x1, x2
+    boxes[..., [1, 3]] = boxes[..., [1, 3]].clip(0, shape[0])  # y1, y2
 
 
 def clip_segments(segments, shape):


### PR DESCRIPTION
With torch >= 1.7, torch supports the `clip` API with the same signature as numpy. It is an alias for the `clamp`, see: https://pytorch.org/docs/1.7.0/generated/torch.clip.html?highlight=clip#torch.clip

I am proposing this change since with mac os metal implementation the `clamp_` functions does not work on the MPS device, while the standard `clip` or `clamp` does.

Signed-off-by: Marco Carosi <ercaronte@gmail.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimization of bounding box clipping in YOLOv5.

### 📊 Key Changes
- Removed condition that differentiated between clipping boxes for `torch.Tensor` and `np.array`.
- Unified clipping approach to only use `np.array.clip` method for both cases.

### 🎯 Purpose & Impact
- Simplifies the codebase by removing unnecessary conditional checks.
- Ensures bounding box coordinates are kept within image dimensions during preprocessing for both `torch.Tensor` and `np.array` formats.
- Potentially improves performance consistency across different data types.
- Users can expect cleaner code and potentially slight performance improvements in preprocessing. 🚀