### PR TITLE
PIL `.get_size()` deprecation fix

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -88,7 +88,7 @@ class Annotator:
         if self.pil or not is_ascii(label):
             self.draw.rectangle(box, width=self.lw, outline=color)  # box
             if label:
-                w, h = self.font.getsize(label)  # text width, height
+                _, _, w, h = self.font.getbbox(label)  # text width, height
                 outside = box[1] - h >= 0  # label fits outside box
                 self.draw.rectangle(
                     (box[0], box[1] - h if outside else box[1], box[0] + w + 1,


### PR DESCRIPTION
Signed-off-by: Glenn Jocher <glenn.jocher@ultralytics.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved label bounding box calculation in YOLOv5 visualizations. 🎨

### 📊 Key Changes
- Updated bounding box size calculation for labels using `font.getbbox()` instead of the older `font.getsize()` method.

### 🎯 Purpose & Impact
- **Enhanced Precision:** This change aims to provide more accurate text measurements, improving the positioning and appearance of text labels in images. 🎯
- **Visual Clarity:** Users will experience clearer and more precise label overlays on their images, which is particularly useful for accurately evaluating model performance visually. 🔍
- **Potential Impact:** The update could affect any visuals related to YOLOv5 model predictions, but should not impact the model's performance or accuracy. 🖼️