### PR TITLE
Add hide_conf argument to model common.py

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -738,7 +738,7 @@ class Detections:
         self.t = tuple(x.t / self.n * 1E3 for x in times)  # timestamps (ms)
         self.s = tuple(shape)  # inference BCHW shape
 
-    def _run(self, pprint=False, show=False, save=False, crop=False, render=False, labels=True, save_dir=Path('')):
+    def _run(self, pprint=False, show=False, save=False, crop=False, render=False, labels=True, hide_conf = False, save_dir=Path('')):
         s, crops = '', []
         for i, (im, pred) in enumerate(zip(self.ims, self.pred)):
             s += f'\nimage {i + 1}/{len(self.pred)}: {im.shape[0]}x{im.shape[1]} '  # string
@@ -750,7 +750,9 @@ class Detections:
                 if show or save or render or crop:
                     annotator = Annotator(im, example=str(self.names))
                     for *box, conf, cls in reversed(pred):  # xyxy, confidence, class
-                        label = f'{self.names[int(cls)]} {conf:.2f}'
+                        label = f'{self.names[int(cls)]}'
+                        if not hide_conf:
+                            label += f' {conf:.2f}'
                         if crop:
                             file = save_dir / 'crops' / self.names[int(cls)] / self.files[i] if save else None
                             crops.append({
@@ -784,19 +786,19 @@ class Detections:
             return crops
 
     @TryExcept('Showing images is not supported in this environment')
-    def show(self, labels=True):
-        self._run(show=True, labels=labels)  # show results
+    def show(self, labels=True, hide_conf=False):
+        self._run(show=True, labels=labels, hide_conf=hide_conf)  # show results
 
-    def save(self, labels=True, save_dir='runs/detect/exp', exist_ok=False):
+    def save(self, labels=True, save_dir='runs/detect/exp', exist_ok=False, hide_conf=False):
         save_dir = increment_path(save_dir, exist_ok, mkdir=True)  # increment save_dir
-        self._run(save=True, labels=labels, save_dir=save_dir)  # save results
+        self._run(save=True, labels=labels, save_dir=save_dir, hide_conf=hide_conf)  # save results
 
     def crop(self, save=True, save_dir='runs/detect/exp', exist_ok=False):
         save_dir = increment_path(save_dir, exist_ok, mkdir=True) if save else None
         return self._run(crop=True, save=save, save_dir=save_dir)  # crop results
 
-    def render(self, labels=True):
-        self._run(render=True, labels=labels)  # render results
+    def render(self, labels=True, hide_conf=False):
+        self._run(render=True, labels=labels, hide_conf=hide_conf)  # render results
         return self.ims
 
     def pandas(self):

--- a/models/common.py
+++ b/models/common.py
@@ -738,7 +738,15 @@ class Detections:
         self.t = tuple(x.t / self.n * 1E3 for x in times)  # timestamps (ms)
         self.s = tuple(shape)  # inference BCHW shape
 
-    def _run(self, pprint=False, show=False, save=False, crop=False, render=False, labels=True, hide_conf = False, save_dir=Path('')):
+    def _run(self,
+             pprint=False,
+             show=False,
+             save=False,
+             crop=False,
+             render=False,
+             labels=True,
+             hide_conf=False,
+             save_dir=Path('')):
         s, crops = '', []
         for i, (im, pred) in enumerate(zip(self.ims, self.pred)):
             s += f'\nimage {i + 1}/{len(self.pred)}: {im.shape[0]}x{im.shape[1]} '  # string


### PR DESCRIPTION
Added parameter for hiding confindence on image.
Using: results.render(hide_conf = True) / results.show(hide_conf = True) / results.save(hide_conf = True)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced display options for YOLOv5 detection results.

### 📊 Key Changes
- Added a `hide_conf` parameter to various functions in `models/common.py`.
- Updated `_run`, `show`, `save`, and `render` methods to accept the new `hide_conf` parameter.
- Adjusted label display logic to conditionally include confidence scores based on `hide_conf`.

### 🎯 Purpose & Impact
- **Purpose**: The changes provide users the option to hide confidence scores in the output labels of their detection results if desired.
- **Impact**: This can lead to more flexible and cleaner visual results for presentations or cases where showing confidence scores isn't necessary or preferred. It offers users more control over the visual aspects of their detection outputs.