### PR TITLE
Update VOC.yaml

### DIFF
--- a/data/VOC.yaml
+++ b/data/VOC.yaml
@@ -21,7 +21,7 @@ test: # test images (optional)
 
 # Classes
 names:
-  0: aeroplane
+  0: drone
   1: bicycle
   2: bird
   3: boat


### PR DESCRIPTION
Signed-off-by: Adil Inthiyaz Shaik <94380371+Inthiyaz184@users.noreply.github.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Changed the label for class 0 from 'aeroplane' to 'drone' in the VOC dataset.

### 📊 Key Changes
- Updated the `VOC.yaml` file by modifying the class name associated with index 0.
- Previously labeled 'aeroplane', it is now labeled as 'drone'.

### 🎯 Purpose & Impact
- **Purpose:** To accurately reflect the content in images where 'drones' are present instead of 'aeroplanes'. It may be part of an effort to focus on a more specific type of flying object for certain machine learning tasks.
- **Impact:** Will affect the training of machine learning models using this dataset by changing how they recognize and classify objects labeled with index 0. This could lead to better specialization for tasks involving drone detection or differentiation from other aircraft.
  
🔍 Users should note that the models trained on this modified dataset will no longer recognize 'aeroplanes' with label 0, and retraining or updating existing models might be necessary to align with this change.