### PR TITLE
Add ndjson logging for training

### DIFF
--- a/train.py
+++ b/train.py
@@ -58,7 +58,7 @@ from utils.general import (LOGGER, TQDM_BAR_FORMAT, check_amp, check_dataset, ch
                            get_latest_run, increment_path, init_seeds, intersect_dicts, labels_to_class_weights,
                            labels_to_image_weights, methods, one_cycle, print_args, print_mutation, strip_optimizer,
                            yaml_save)
-from utils.loggers import Loggers, LOGGERS
+from utils.loggers import LOGGERS, Loggers
 from utils.loggers.comet.comet_utils import check_comet_resume
 from utils.loss import ComputeLoss
 from utils.metrics import fitness

--- a/train.py
+++ b/train.py
@@ -58,7 +58,7 @@ from utils.general import (LOGGER, TQDM_BAR_FORMAT, check_amp, check_dataset, ch
                            get_latest_run, increment_path, init_seeds, intersect_dicts, labels_to_class_weights,
                            labels_to_image_weights, methods, one_cycle, print_args, print_mutation, strip_optimizer,
                            yaml_save)
-from utils.loggers import Loggers
+from utils.loggers import Loggers, LOGGERS
 from utils.loggers.comet.comet_utils import check_comet_resume
 from utils.loss import ComputeLoss
 from utils.metrics import fitness
@@ -98,7 +98,20 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
     # Loggers
     data_dict = None
     if RANK in {-1, 0}:
-        loggers = Loggers(save_dir, weights, opt, hyp, LOGGER)  # loggers instance
+        include_loggers = list(LOGGERS)
+        if getattr(opt, 'ndjson_console', False):
+            include_loggers.append('ndjson_console')
+        if getattr(opt, 'ndjson_file', False):
+            include_loggers.append('ndjson_file')
+
+        loggers = Loggers(
+            save_dir=save_dir,
+            weights=weights,
+            opt=opt,
+            hyp=hyp,
+            logger=LOGGER,
+            include=tuple(include_loggers),
+        )
 
         # Register actions
         for k in methods(loggers):
@@ -481,6 +494,10 @@ def parse_opt(known=False):
     parser.add_argument('--upload_dataset', nargs='?', const=True, default=False, help='Upload data, "val" option')
     parser.add_argument('--bbox_interval', type=int, default=-1, help='Set bounding-box image logging interval')
     parser.add_argument('--artifact_alias', type=str, default='latest', help='Version of dataset artifact to use')
+
+    # NDJSON logging
+    parser.add_argument('--ndjson-console', action='store_true', help='Log ndjson to console')
+    parser.add_argument('--ndjson-file', action='store_true', help='Log ndjson to file')
 
     return parser.parse_known_args()[0] if known else parser.parse_args()
 


### PR DESCRIPTION
This adds support for NDJSON (newline-delimited JSON) metrics logging, for both console (stdout) output and a file (like the current CSV file).

NDJSON can be easily grepped from the output and/or parsed with e.g. `jq`.

An example JSON line is e.g.

```json
{"epoch": 0, "train/box_loss": 0.047209735, "train/obj_loss": 0.07622885704040527, "train/cls_loss": 0.03480850160121918, "metrics/precision": 0.7328301877186243, "metrics/recall": 0.6168343308792175, "metrics/mAP_0.5": 0.7002523536111919, "metrics/mAP_0.5:0.95": 0.45269375994535394, "val/box_loss": 0.03693515807390213, "val/obj_loss": 0.04277978464961052, "val/cls_loss": 0.009943380020558834, "x/lr0": 0.07046875, "x/lr1": 0.00328125 "x/lr2": 0.00328125}
```

The feature is enabled with the `--ndjson-console` and `--ndjson-file` switches to `train.py`.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced logging capabilities in YOLOv5 with support for NDJSON (Newline Delimited JSON).

### 📊 Key Changes
- Introduced NDJSON logging to the console and to files during training.
- Added new command-line arguments `--ndjson-console` and `--ndjson-file` for enabling NDJSON logging.
- Modified `Loggers` class to support NDJSON logging, with helper functions for JSON formatting.
- Altered training script (`train.py`) to initialize logging based on user preferences.

### 🎯 Purpose & Impact
- **Purpose**: To provide more structured and machine-readable logging options that facilitate easier integration with data processing pipelines.
- **Impact**: 
   - Developers can now receive logs in JSON format, supporting use cases requiring automated log analysis and monitoring 👩‍💻🔍.
   - Users have the flexibility to choose their preferred logging formats for improved development and debugging experiences 🛠️💡.