### PR TITLE
Fix return value check for subprocess.run

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -631,8 +631,8 @@ def download(url, dir='.', unzip=True, delete=True, curl=False, threads=1, retry
             for i in range(retry + 1):
                 if curl:
                     s = 'sS' if threads > 1 else ''  # silent
-                    r = subprocess.run(f'curl -# -{s}L "{url}" -o "{f}" --retry 9 -C -'.split())
-                    success = r == 0
+                    proc = subprocess.run(f'curl -# -{s}L "{url}" -o "{f}" --retry 9 -C -'.split())
+                    success = proc.returncode == 0
                 else:
                     torch.hub.download_url_to_file(url, f, progress=threads == 1)  # torch download
                     success = f.is_file()


### PR DESCRIPTION
Subprocess.run does not return an integer.

Regressed in #10944


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancing file download reliability in the YOLOv5 codebase.

### 📊 Key Changes
- Modified the download script to use the process's return code for checking success.

### 🎯 Purpose & Impact
- **Purpose**: To ensure that the success of the file download is accurately determined by checking the return code of the curl process rather than the process object itself.
- **Impact**: Improves the reliability of file downloads within the utility scripts, potentially leading to fewer errors and more robust behavior for end-users when setting up YOLOv5 or downloading necessary files. 🛠️