### PR TITLE
Update downloads.py

### DIFF
--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -120,11 +120,10 @@ def attempt_download(file, repo='ultralytics/yolov5', release='v7.0'):
 
         file.parent.mkdir(parents=True, exist_ok=True)  # make parent dir (if required)
         if name in assets:
-            url3 = 'https://drive.google.com/drive/folders/1EFQTEUeXWSFww0luse2jB9M1QNZQGwNl'  # backup gdrive mirror
             safe_download(
                 file,
                 url=f'https://github.com/{repo}/releases/download/{tag}/{name}',
                 min_bytes=1E5,
-                error_msg=f'{file} missing, try downloading from https://github.com/{repo}/releases/{tag} or {url3}')
+                error_msg=f'{file} missing, try downloading from https://github.com/{repo}/releases/{tag}')
 
     return str(file)

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -120,10 +120,9 @@ def attempt_download(file, repo='ultralytics/yolov5', release='v7.0'):
 
         file.parent.mkdir(parents=True, exist_ok=True)  # make parent dir (if required)
         if name in assets:
-            safe_download(
-                file,
-                url=f'https://github.com/{repo}/releases/download/{tag}/{name}',
-                min_bytes=1E5,
-                error_msg=f'{file} missing, try downloading from https://github.com/{repo}/releases/{tag}')
+            safe_download(file,
+                          url=f'https://github.com/{repo}/releases/download/{tag}/{name}',
+                          min_bytes=1E5,
+                          error_msg=f'{file} missing, try downloading from https://github.com/{repo}/releases/{tag}')
 
     return str(file)


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvement to asset downloading process in Ultralytics YOLOv5.

### 📊 Key Changes
- Removed a backup Google Drive mirror URL for downloading assets.
- Simplified the `safe_download` call by removing the now unnecessary alternative download link.

### 🎯 Purpose & Impact
- **Purpose:** To clean up the downloading logic by eliminating the backup downloading option, focusing solely on GitHub as the primary source.
- **Impact:** Streamlines the user experience by simplifying the download steps. Removes potential confusion regarding alternative download sources but also takes away a fallback option in case of GitHub issues. Users now have a single, consistent source for downloads, enhancing reliability as long as GitHub remains available.