### PR TITLE
Fixed access 'names' from a DistributedDataParallel module

### DIFF
--- a/classify/train.py
+++ b/classify/train.py
@@ -44,7 +44,7 @@ from utils.general import (DATASETS_DIR, LOGGER, TQDM_BAR_FORMAT, WorkingDirecto
                            check_requirements, colorstr, download, increment_path, init_seeds, print_args, yaml_save)
 from utils.loggers import GenericLogger
 from utils.plots import imshow_cls
-from utils.torch_utils import (ModelEMA, model_info, reshape_classifier_output, select_device, smart_DDP,
+from utils.torch_utils import (ModelEMA, de_parallel, model_info, reshape_classifier_output, select_device, smart_DDP,
                                smart_optimizer, smartCrossEntropyLoss, torch_distributed_zero_first)
 
 LOCAL_RANK = int(os.getenv('LOCAL_RANK', -1))  # https://pytorch.org/docs/stable/elastic/run.html
@@ -260,7 +260,7 @@ def train(opt, device):
         # Plot examples
         images, labels = (x[:25] for x in next(iter(testloader)))  # first 25 images and labels
         pred = torch.max(ema.ema(images.to(device)), 1)[1]
-        file = imshow_cls(images, labels, pred, model.names, verbose=False, f=save_dir / 'test_images.jpg')
+        file = imshow_cls(images, labels, pred, de_parallel(model).names, verbose=False, f=save_dir / 'test_images.jpg')
 
         # Log results
         meta = {'epochs': epochs, 'top1_acc': best_fitness, 'date': datetime.now().isoformat()}


### PR DESCRIPTION
Hi,

The `classify/train.py` is trying to access the `names` property from the model in the last epoch, but the `names` was attach to the model before calling the `smart_DDP(model)`. So, if someone trains the model with DDP enabled, it will end up some exceptions in the last epoch. E.g.:
```bash
Traceback (most recent call last):                                                                                                                                                                                                                                                                                             
  File "/home/user/data/newWorkspace/algorithm/yolov5/classify/train.py", line 337, in <module>                                                                                                                                                                                                                              
    main(opt)                                                                                                                                                                                                                                                                                                                  
  File "/home/user/data/newWorkspace/algorithm/yolov5/classify/train.py", line 323, in main                                                                                                                                                                                                                                  
    train(opt, device)                                                                                                                                                                                                                                                                                                         
  File "/home/user/data/newWorkspace/algorithm/yolov5/classify/train.py", line 266, in train                                                                                                                                                                                                                                 
    file = imshow_cls(images, labels, pred, model.names, verbose=False, f=save_dir / 'test_images.jpg')                                                                                                                                                                                                                        
  File "/home/user/miniconda3/envs/edge/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1269, in __getattr__                                                                                                                                                                                                  
    raise AttributeError("'{}' object has no attribute '{}'".format(                                                                                                                                                                                                                                                           
AttributeError: 'DistributedDataParallel' object has no attribute 'names' 
```


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced classifier training script with model parallelism improvements.

### 📊 Key Changes
- Imported `de_parallel` utility function to `train.py`.
- Utilized `de_parallel` when accessing model names for plotting test images.

### 🎯 Purpose & Impact
- 🚀 The purpose of these changes is to ensure that when the trained model gets saved or processed further, it is no longer wrapped by DataParallel or DistributedDataParallel, which can cause issues when accessing model attributes.
- 📈 This change could improve model handling during training and simplify accessing model attributes like `names`, which can be crucial for visualization and logging purposes.
- ✅ The impact of this change should be strictly positive for users, resulting in a more reliable and straightforward training process, particularly for those who are working in distributed environments or using parallel execution.