### PR TITLE
Rename evolve folder if default project name

### DIFF
--- a/segment/train.py
+++ b/segment/train.py
@@ -530,8 +530,8 @@ def main(opt, callbacks=Callbacks()):
             check_file(opt.data), check_yaml(opt.cfg), check_yaml(opt.hyp), str(opt.weights), str(opt.project)  # checks
         assert len(opt.cfg) or len(opt.weights), 'either --cfg or --weights must be specified'
         if opt.evolve:
-            if opt.project == str(ROOT / 'runs/train'):  # if default project name, rename to runs/evolve
-                opt.project = str(ROOT / 'runs/evolve')
+            if opt.project == str(ROOT / 'runs/train-seg'):  # if default project name, rename to runs/evolve-seg
+                opt.project = str(ROOT / 'runs/evolve-seg')
             opt.exist_ok, opt.resume = opt.resume, False  # pass resume to exist_ok and disable resume
         if opt.name == 'cfg':
             opt.name = Path(opt.cfg).stem  # use model.yaml as name


### PR DESCRIPTION
Save logs to 'runs/evolve-seg' if default project name, 'runs/train-seg'

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to project directory naming for evolving segmentation models.

### 📊 Key Changes
- Changed the default project directory from `runs/train` to `runs/train-seg` for segmentation models.
- Adjusted the evolution directory from `runs/evolve` to `runs/evolve-seg`.

### 🎯 Purpose & Impact
- Prevents confusion between the directories used for training standard models and segmentation models.
- Helps users quickly identify the correct project directories for segmentation model training and evolution.
- No direct impact on model performance, but improves user experience when organizing and locating model files.