### PR TITLE
Print hyperparameters to evolve yaml file correctly

### DIFF
--- a/segment/train.py
+++ b/segment/train.py
@@ -642,7 +642,7 @@ def main(opt, callbacks=Callbacks()):
             results = train(hyp.copy(), opt, device, callbacks)
             callbacks = Callbacks()
             # Write mutation results
-            keys = (  # Source: https://github.com/ultralytics/yolov5/pull/9742#issuecomment-1277490480
+            keys = (
                 'metrics/precision(B)',
                 'metrics/recall(B)',
                 'metrics/mAP_0.5(B)',

--- a/segment/train.py
+++ b/segment/train.py
@@ -51,10 +51,10 @@ from utils.general import (LOGGER, TQDM_BAR_FORMAT, check_amp, check_dataset, ch
                            check_git_status, check_img_size, check_requirements, check_suffix, check_yaml, colorstr,
                            get_latest_run, increment_path, init_seeds, intersect_dicts, labels_to_class_weights,
                            labels_to_image_weights, one_cycle, print_args, strip_optimizer, yaml_save)
-from utils.segment.general import print_mutation
 from utils.loggers import GenericLogger
 from utils.plots import plot_evolve, plot_labels
 from utils.segment.dataloaders import create_dataloader
+from utils.segment.general import print_mutation
 from utils.segment.loss import ComputeLoss
 from utils.segment.metrics import KEYS, fitness
 from utils.segment.plots import plot_images_and_masks, plot_results_with_masks

--- a/utils/segment/general.py
+++ b/utils/segment/general.py
@@ -1,14 +1,13 @@
+import logging
+import os
+import platform
+import subprocess
+
 import cv2
 import numpy as np
+import pandas as pd
 import torch
 import torch.nn.functional as F
-
-import subprocess
-import os
-import logging
-import platform
-
-import pandas as pd
 import yaml
 
 from utils import emojis
@@ -32,12 +31,12 @@ def set_logging(name=LOGGING_NAME, verbose=True):
             name: {
                 'class': 'logging.StreamHandler',
                 'formatter': name,
-                'level': level, }},
+                'level': level,}},
         'loggers': {
             name: {
                 'level': level,
                 'handlers': [name],
-                'propagate': False, }}})
+                'propagate': False,}}})
 
 
 set_logging(LOGGING_NAME)  # run before defining LOGGER
@@ -255,14 +254,14 @@ def print_mutation(keys, results, hyp, save_dir, bucket, prefix=colorstr('evolve
         i = np.argmax(fitness(data.values[:, :12]))  #
         generations = len(data)
         f.write('# YOLOv5 Hyperparameter Evolution Results\n' + f'# Best generation: {i}\n' +
-                f'# Last generation: {generations - 1}\n'
-                + '# ' + ', '.join(f'{x.strip():>20s}' for x in keys[:4]) + '\n'
-                + '# ' + ', '.join(f'{x:>20.5g}' for x in data.values[i, :4]) + '\n'
-                + '# ' + ', '.join(f'{x.strip():>20s}' for x in keys[4:8]) + '\n'
-                + '# ' + ', '.join(f'{x:>20.5g}' for x in data.values[i, 4:8]) + '\n'
-                + '# ' + ', '.join(f'{x.strip():>20s}' for x in keys[8:12]) + '\n'
-                + '# ' + ', '.join(f'{x:>20.5g}' for x in data.values[i, 8:12]) + '\n'
-                + '\n')
+                f'# Last generation: {generations - 1}\n' + '# ' + ', '.join(f'{x.strip():>20s}' for x in keys[:4]) +
+                '\n' + '# ' + ', '.join(f'{x:>20.5g}' for x in data.values[i, :4]) + '\n' + '# ' +
+                ', '.join(f'{x.strip():>20s}'
+                          for x in keys[4:8]) + '\n' + '# ' + ', '.join(f'{x:>20.5g}'
+                                                                        for x in data.values[i, 4:8]) + '\n' + '# ' +
+                ', '.join(f'{x.strip():>20s}'
+                          for x in keys[8:12]) + '\n' + '# ' + ', '.join(f'{x:>20.5g}'
+                                                                         for x in data.values[i, 8:12]) + '\n' + '\n')
         yaml.safe_dump(data.loc[i][12:].to_dict(), f, sort_keys=False)
 
     # Print to screen

--- a/utils/segment/general.py
+++ b/utils/segment/general.py
@@ -12,31 +12,10 @@ import yaml
 
 from utils import emojis
 from utils.downloads import gsutil_getsize
+from utils.general import set_logging, colorstr
 from utils.segment.metrics import fitness
 
 LOGGING_NAME = 'yolov5'
-
-
-def set_logging(name=LOGGING_NAME, verbose=True):
-    # sets up logging for the given name
-    rank = int(os.getenv('RANK', -1))  # rank in world for Multi-GPU trainings
-    level = logging.INFO if verbose and rank in {-1, 0} else logging.ERROR
-    logging.config.dictConfig({
-        'version': 1,
-        'disable_existing_loggers': False,
-        'formatters': {
-            name: {
-                'format': '%(message)s'}},
-        'handlers': {
-            name: {
-                'class': 'logging.StreamHandler',
-                'formatter': name,
-                'level': level,}},
-        'loggers': {
-            name: {
-                'level': level,
-                'handlers': [name],
-                'propagate': False,}}})
 
 
 set_logging(LOGGING_NAME)  # run before defining LOGGER
@@ -200,32 +179,6 @@ def masks2segments(masks, strategy='largest'):
             c = np.zeros((0, 2))  # no segments found
         segments.append(c.astype('float32'))
     return segments
-
-
-def colorstr(*input):
-    # Colors a string https://en.wikipedia.org/wiki/ANSI_escape_code, i.e.  colorstr('blue', 'hello world')
-    *args, string = input if len(input) > 1 else ('blue', 'bold', input[0])  # color arguments, string
-    colors = {
-        'black': '\033[30m',  # basic colors
-        'red': '\033[31m',
-        'green': '\033[32m',
-        'yellow': '\033[33m',
-        'blue': '\033[34m',
-        'magenta': '\033[35m',
-        'cyan': '\033[36m',
-        'white': '\033[37m',
-        'bright_black': '\033[90m',  # bright colors
-        'bright_red': '\033[91m',
-        'bright_green': '\033[92m',
-        'bright_yellow': '\033[93m',
-        'bright_blue': '\033[94m',
-        'bright_magenta': '\033[95m',
-        'bright_cyan': '\033[96m',
-        'bright_white': '\033[97m',
-        'end': '\033[0m',  # misc
-        'bold': '\033[1m',
-        'underline': '\033[4m'}
-    return ''.join(colors[x] for x in args) + f'{string}' + colors['end']
 
 
 def print_mutation(keys, results, hyp, save_dir, bucket, prefix=colorstr('evolve: ')):

--- a/utils/segment/general.py
+++ b/utils/segment/general.py
@@ -12,11 +12,10 @@ import yaml
 
 from utils import emojis
 from utils.downloads import gsutil_getsize
-from utils.general import set_logging, colorstr
+from utils.general import colorstr, set_logging
 from utils.segment.metrics import fitness
 
 LOGGING_NAME = 'yolov5'
-
 
 set_logging(LOGGING_NAME)  # run before defining LOGGER
 LOGGER = logging.getLogger(LOGGING_NAME)  # define globally (used in train.py, val.py, detect.py, etc.)


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->

When training segmentation with evolve, the corresponding hyperparameters yaml file is created without considering the correct number of metrics. Thus the data is stored in the following way:
```
# YOLOv5 Hyperparameter Evolution Results
# Best generation: 1
# Last generation: 4
# metrics/precision(B),    metrics/recall(B),   metrics/mAP_0.5(B), metrics/mAP_0.5:0.95(B), metrics/precision(M),    metrics/recall(M),   metrics/mAP_0.5(M)
#             0.063966,              0.44075,             0.055458,             0.012713,             0.030348,              0.22661,             0.019414

metrics/mAP_0.5:0.95(M): 0.003792
val/box_loss: 0.12199
val/obj_loss: 0.15555
val/cls_loss: 0.63032
val/seg_loss: 0.0
lr0: 0.00935
lrf: 0.01246
...
```

This PR fixes this error, storing the data in the following format:
```
# YOLOv5 Hyperparameter Evolution Results
# Best generation: 1
# Last generation: 1
# metrics/precision(B),    metrics/recall(B),   metrics/mAP_0.5(B), metrics/mAP_0.5:0.95(B)
#             0.066667,              0.54054,             0.062136,             0.014717
# metrics/precision(M),    metrics/recall(M),   metrics/mAP_0.5(M), metrics/mAP_0.5:0.95(M)
#             0.035128,              0.28482,             0.024308,            0.0048832
#         val/box_loss,         val/obj_loss,         val/cls_loss,         val/seg_loss
#              0.11127,              0.13789,              0.59428,                    0

lr0: 0.01
lrf: 0.01021
...
```



## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to YOLOv5's segmentation and hyperparameter evolution logging.

### 📊 Key Changes
- Removed `print_mutation` from `segment/train.py` and added it to `utils/segment/general.py`.
- Introduced a new `LOGGING_NAME` variable and emoji compatible logging for Windows.
- `print_mutation` function expanded with additional features for evolution results handling.
- Evolve results now save to both CSV and YAML formats, supporting better data management and readability.

### 🎯 Purpose & Impact
- 🚀 By shifting `print_mutation`, segmentation training code gets cleaner, promoting better codebase maintenance.
- 💻 Windows users will now see emoji-safe messages for an enhanced user experience.
- 📈 Enhanced evolution results logging provides a more comprehensive overview of model performance over generations, helping users to better track and understand hyperparameter evolution outcomes.
- 🗂️ The dual-format saving of evolve results in both CSV and YAML formats offers versatility in data analysis and sharing, potentially benefiting users who perform many evolutions to fine-tune their models.