### PR TITLE
Update general.py

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -517,9 +517,9 @@ def check_dataset(data, autodownload=True):
     if isinstance(data, (str, Path)):
         data = yaml_load(data)  # dictionary
 
-    data['train'] = os.path.join(os.environ['DATASET_DIRECTORY'] + 'image/train/')
-    data['test'] = os.path.join(os.environ['DATASET_DIRECTORY'] + 'image/test/')
-    data['val'] = os.path.join(os.environ['DATASET_DIRECTORY'] + 'image/val/')
+    data['train'] = os.path.join(os.environ['DATASET_DIRECTORY'] + 'images/train/')
+    data['test'] = os.path.join(os.environ['DATASET_DIRECTORY'] + 'images/test/')
+    data['val'] = os.path.join(os.environ['DATASET_DIRECTORY'] + 'images/val/')
 
     # Checks
     for k in 'train', 'val', 'names':

--- a/utils/general.py
+++ b/utils/general.py
@@ -517,9 +517,9 @@ def check_dataset(data, autodownload=True):
     if isinstance(data, (str, Path)):
         data = yaml_load(data)  # dictionary
 
-    data['train'] = str(DATASETS_DIR.joinpath('image/train/'))
-    data['test'] = str(DATASETS_DIR.joinpath('image/test/'))
-    data['val'] = str(DATASETS_DIR.joinpath('image/val/'))
+    data['train'] = os.path.join(os.environ["DATASET_DIRECTORY"] + 'image/train/')
+    data['test'] =os.path.join(os.environ["DATASET_DIRECTORY"] + 'image/test/')
+    data['val'] =os.path.join(os.environ["DATASET_DIRECTORY"] + 'image/val/')
 
     # Checks
     for k in 'train', 'val', 'names':

--- a/utils/general.py
+++ b/utils/general.py
@@ -517,9 +517,9 @@ def check_dataset(data, autodownload=True):
     if isinstance(data, (str, Path)):
         data = yaml_load(data)  # dictionary
 
-    data['train'] = os.path.join(os.environ["DATASET_DIRECTORY"] + 'image/train/')
-    data['test'] =os.path.join(os.environ["DATASET_DIRECTORY"] + 'image/test/')
-    data['val'] =os.path.join(os.environ["DATASET_DIRECTORY"] + 'image/val/')
+    data['train'] = os.path.join(os.environ['DATASET_DIRECTORY'] + 'image/train/')
+    data['test'] = os.path.join(os.environ['DATASET_DIRECTORY'] + 'image/test/')
+    data['val'] = os.path.join(os.environ['DATASET_DIRECTORY'] + 'image/val/')
 
     # Checks
     for k in 'train', 'val', 'names':

--- a/utils/general.py
+++ b/utils/general.py
@@ -517,6 +517,10 @@ def check_dataset(data, autodownload=True):
     if isinstance(data, (str, Path)):
         data = yaml_load(data)  # dictionary
 
+    data['train'] = str(DATASETS_DIR.joinpath('image/train/'))
+    data['test'] =str(DATASETS_DIR.joinpath('image/test/'))
+    data['val'] =str(DATASETS_DIR.joinpath('image/val/'))
+    
     # Checks
     for k in 'train', 'val', 'names':
         assert k in data, emojis(f"data.yaml '{k}:' field missing ❌")

--- a/utils/general.py
+++ b/utils/general.py
@@ -518,9 +518,9 @@ def check_dataset(data, autodownload=True):
         data = yaml_load(data)  # dictionary
 
     data['train'] = str(DATASETS_DIR.joinpath('image/train/'))
-    data['test'] =str(DATASETS_DIR.joinpath('image/test/'))
-    data['val'] =str(DATASETS_DIR.joinpath('image/val/'))
-    
+    data['test'] = str(DATASETS_DIR.joinpath('image/test/'))
+    data['val'] = str(DATASETS_DIR.joinpath('image/val/'))
+
     # Checks
     for k in 'train', 'val', 'names':
         assert k in data, emojis(f"data.yaml '{k}:' field missing ❌")

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -21,6 +21,8 @@ LOGGERS = ('csv', 'tb', 'wandb', 'clearml', 'comet')  # *.csv, TensorBoard, Weig
 RANK = int(os.getenv('RANK', -1))
 
 try:
+    wandb = None
+    '''
     import wandb
 
     assert hasattr(wandb, '__version__')  # verify package import not local dir
@@ -31,6 +33,7 @@ try:
             wandb_login_success = False
         if not wandb_login_success:
             wandb = None
+    '''
 except (ImportError, AssertionError):
     wandb = None
 


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced dataset directory handling and temporarily disabled Weights & Biases integration.

### 📊 Key Changes
- The dataset paths for 'train', 'test', and 'val' are now automatically constructed using an environment variable `DATASET_DIRECTORY`.
- Commented out the Weights & Biases (wandb) import and initialization code block.

### 🎯 Purpose & Impact
- By using an environment variable for dataset directories, users can more easily customize dataset locations, increasing flexibility. 📍
- Temporarily disabling wandb could be for debugging or because of issues with current integration; users won't be able to log their training runs to wandb until it's re-enabled. 🔧
- These changes could affect automated workflows and scripts if they rely on wandb or hard-coded dataset paths. 🔄