### PR TITLE
请问怎么转onnx到rv1106，类似例子中给的1-3-85-80-80的输出

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+#### Get model optimized for RKNN
+Exporting detect/segment model with optimization for RKNN, please refer here [README_rkopt.md](./README_rkopt.md)
+
+导出适配 RKNPU 的检测/分割模型, 请参考 [README_rkopt.md](./README_rkopt.md) 的说明
+
+---
+<br>
+
 <div align="center">
   <p>
     <a align="center" href="https://ultralytics.com/yolov5" target="_blank">

--- a/README_rkopt.md
+++ b/README_rkopt.md
@@ -1,0 +1,43 @@
+# YOLOv5 - RKNN optimize
+
+## Source
+
+  Base on https://github.com/ultralytics/yolov5 (v7.0) with commit id as 915bbf294bb74c859f0b41f1c23bc395014ea679
+
+
+
+## What different
+
+With inference result values unchanged, the following optimizations were applied:
+
+- Optimize focus/SPPF block, getting better performance with same result
+- Change output node, remove post_process from the model. (post process block in model is unfriendly for quantization)
+
+
+
+With inference result got changed, the following optimization was applied:
+
+- Using ReLU as activation layer instead of SiLU（Only valid when training new model）
+
+
+
+## How to use
+
+```
+# for detection model
+python export.py --rknpu --weight yolov5s.pt
+
+# for segmentation model
+python export.py --rknpu --weight yolov5s-seg.pt
+```
+
+- 'yolov5s.pt'/ 'yolov5s-seg.pt' could be replaced with your model path
+- A file name "RK_anchors.txt" would be generated and it would be used for the post_process stage. 
+- **NOTICE: Please call with --rknpu, do not changing the default rknpu value in export.py.** 
+
+
+
+## Deploy demo
+
+Please refer https://github.com/airockchip/rknn_model_zoo
+

--- a/export.py
+++ b/export.py
@@ -56,6 +56,11 @@ import time
 import warnings
 from pathlib import Path
 
+
+# activate rknn hack
+if '--rknpu' in sys.argv:
+    os.environ['RKNN_model_hack'] = "1"
+
 import pandas as pd
 import torch
 from torch.utils.mobile_optimizer import optimize_for_mobile
@@ -68,7 +73,7 @@ if platform.system() != 'Windows':
     ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
 from models.experimental import attempt_load
-from models.yolo import ClassificationModel, Detect, DetectionModel, SegmentationModel
+from models.yolo import ClassificationModel, Detect, DetectionModel, SegmentationModel, Segment
 from utils.dataloaders import LoadImages
 from utils.general import (LOGGER, Profile, check_dataset, check_img_size, check_requirements, check_version,
                            check_yaml, colorstr, file_size, get_default_args, print_args, url2file, yaml_save)
@@ -545,11 +550,76 @@ def run(
             m.dynamic = dynamic
             m.export = True
 
+        if os.getenv('RKNN_model_hack', '0') in ['1']:
+            from models.common import Focus
+            from models.common import Conv
+            from models.common_rk_plug_in import surrogate_focus
+            if isinstance(model.model[0], Focus):
+                # For yolo v5 version
+                surrogate_focous = surrogate_focus(int(model.model[0].conv.conv.weight.shape[1]/4),
+                                                model.model[0].conv.conv.weight.shape[0],
+                                                k=tuple(model.model[0].conv.conv.weight.shape[2:4]),
+                                                s=model.model[0].conv.conv.stride,
+                                                p=model.model[0].conv.conv.padding,
+                                                g=model.model[0].conv.conv.groups,
+                                                act=True)
+                surrogate_focous.conv.conv.weight = model.model[0].conv.conv.weight
+                surrogate_focous.conv.conv.bias = model.model[0].conv.conv.bias
+                surrogate_focous.conv.act = model.model[0].conv.act
+                temp_i = model.model[0].i
+                temp_f = model.model[0].f
+
+                model.model[0] = surrogate_focous
+                model.model[0].i = temp_i
+                model.model[0].f = temp_f
+                model.model[0].eval()
+            elif isinstance(model.model[0], Conv) and model.model[0].conv.kernel_size == (6, 6):
+                # For yolo v6 version
+                surrogate_focous = surrogate_focus(model.model[0].conv.weight.shape[1],
+                                                model.model[0].conv.weight.shape[0],
+                                                k=(3,3), # 6/2, 6/2
+                                                s=1,
+                                                p=(1,1), # 2/2, 2/2
+                                                g=model.model[0].conv.groups,
+                                                act=hasattr(model.model[0], 'act'))
+                surrogate_focous.conv.conv.weight[:,:3,:,:] = model.model[0].conv.weight[:,:,::2,::2]
+                surrogate_focous.conv.conv.weight[:,3:6,:,:] = model.model[0].conv.weight[:,:,1::2,::2]
+                surrogate_focous.conv.conv.weight[:,6:9,:,:] = model.model[0].conv.weight[:,:,::2,1::2]
+                surrogate_focous.conv.conv.weight[:,9:,:,:] = model.model[0].conv.weight[:,:,1::2,1::2]
+                surrogate_focous.conv.conv.bias = model.model[0].conv.bias
+                surrogate_focous.conv.act = model.model[0].act
+                temp_i = model.model[0].i
+                temp_f = model.model[0].f
+
+                model.model[0] = surrogate_focous
+                model.model[0].i = temp_i
+                model.model[0].f = temp_f
+                model.model[0].eval()
+
+    if os.getenv('RKNN_model_hack', '0') in ['1']:
+        if isinstance(model.model[-1], Detect):
+            # save anchors
+            print('---> save anchors for RKNN')
+            RK_anchors = model.model[-1].stride.reshape(3,1).repeat(1,3).reshape(-1,1)* model.model[-1].anchors.reshape(9,2)
+            with open('RK_anchors.txt', 'w') as anf:
+                # anf.write(str(model.model[-1].na)+'\n')
+                for _v in RK_anchors.numpy().flatten():
+                    anf.write(str(_v)+'\n')
+            RK_anchors = RK_anchors.tolist()
+            print(RK_anchors)
+
+        if isinstance(model.model[-1], Segment):
+            print("export segment model for RKNPU")
+            model.model[-1]._register_seg_seperate(True)
+        else:
+            print("export detect model for RKNPU")
+            model.model[-1]._register_detect_seperate(True)
+
     for _ in range(2):
         y = model(im)  # dry runs
     if half and not coreml:
         im, model = im.half(), model.half()  # to FP16
-    shape = tuple((y[0] if isinstance(y, tuple) else y).shape)  # model output shape
+    shape = tuple((y[0] if (isinstance(y, tuple) or (isinstance(y, list))) else y).shape)  # model output shape
     metadata = {'stride': int(max(model.stride)), 'names': model.names}  # model metadata
     LOGGER.info(f"\n{colorstr('PyTorch:')} starting from {file} with output shape {shape} ({file_size(file):.1f} MB)")
 
@@ -632,11 +702,11 @@ def parse_opt():
     parser.add_argument('--topk-all', type=int, default=100, help='TF.js NMS: topk for all classes to keep')
     parser.add_argument('--iou-thres', type=float, default=0.45, help='TF.js NMS: IoU threshold')
     parser.add_argument('--conf-thres', type=float, default=0.25, help='TF.js NMS: confidence threshold')
-    parser.add_argument(
-        '--include',
-        nargs='+',
-        default=['torchscript'],
-        help='torchscript, onnx, openvino, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle')
+    parser.add_argument('--include',
+                        nargs='+',
+                        default=['onnx'],
+                        help='torchscript, onnx, openvino, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs')
+    parser.add_argument('--rknpu', action='store_true', help='RKNN npu platform')
     opt = parser.parse_args()
     print_args(vars(opt))
     return opt
@@ -649,4 +719,5 @@ def main(opt):
 
 if __name__ == "__main__":
     opt = parse_opt()
+    del opt.rknpu
     main(opt)

--- a/models/common_rk_plug_in.py
+++ b/models/common_rk_plug_in.py
@@ -1,0 +1,30 @@
+# This file contains modules common to various models
+
+import torch
+import torch.nn as nn
+from models.common import Conv
+
+
+class surrogate_focus(nn.Module):
+    # surrogate_focus wh information into c-space
+    def __init__(self, c1, c2, k=1, s=1, p=None, g=1, act=True):  # ch_in, ch_out, kernel, stride, padding, groups
+        super(surrogate_focus, self).__init__()
+        self.conv = Conv(c1 * 4, c2, k, s, p, g, act=act)
+
+        with torch.no_grad():
+            self.convsp = nn.Conv2d(3, 12, (2, 2), groups=1, bias=False, stride=(2, 2))
+            self.convsp.weight.data = torch.zeros(self.convsp.weight.shape).float()
+            for i in range(4):
+                for j in range(3):
+                    ch = i*3 + j
+                    if ch>=0 and ch<3:
+                        self.convsp.weight[ch:ch+1, j:j+1, 0, 0] = 1
+                    elif ch>=3 and ch<6:
+                        self.convsp.weight[ch:ch+1, j:j+1, 1, 0] = 1
+                    elif ch>=6 and ch<9:
+                        self.convsp.weight[ch:ch+1, j:j+1, 0, 1] = 1
+                    elif ch>=9 and ch<12:
+                        self.convsp.weight[ch:ch+1, j:j+1, 1, 1] = 1
+
+    def forward(self, x):  # x(b,c,w,h) -> y(b,4c,w/2,h/2)
+        return self.conv(self.convsp(x))

--- a/models/experimental.py
+++ b/models/experimental.py
@@ -51,7 +51,8 @@ class MixConv2d(nn.Module):
         self.m = nn.ModuleList([
             nn.Conv2d(c1, int(c_), k, s, k // 2, groups=math.gcd(c1, int(c_)), bias=False) for k, c_ in zip(k, c_)])
         self.bn = nn.BatchNorm2d(c2)
-        self.act = nn.SiLU()
+        # self.act = nn.SiLU()
+        self.act = nn.ReLU()
 
     def forward(self, x):
         return self.act(self.bn(torch.cat([m(x) for m in self.m], 1)))

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -35,6 +35,24 @@ except ImportError:
     thop = None
 
 
+# define block, seperate conv channel. 
+# For eacn anchor, frist 85 need sigmoid, the last 32 needn't. Seperate them to get better accuracy.
+class Segment_head_seperate_block(nn.Module):
+    def __init__(self, cls, seg, na, src_conv) -> None:
+        super().__init__()
+        self.conv_cls = nn.Conv2d(src_conv.in_channels, cls*na, 1)
+        self.conv_seg = nn.Conv2d(src_conv.in_channels, seg*na, 1)
+        per_na = cls+seg
+        for i in range(na):
+            self.conv_cls.weight.data[cls*i:cls*(i+1),:,:,:] = src_conv.weight.data[per_na*i:per_na*i+cls,:,:,:]
+            self.conv_cls.bias.data[cls*i:cls*(i+1)] = src_conv.bias.data[per_na*i:per_na*i+cls]
+            self.conv_seg.weight.data[seg*i:seg*(i+1),:,:,:] = src_conv.weight.data[per_na*(i) + cls:per_na*(i+1),:,:,:]
+            self.conv_seg.bias.data[seg*i:seg*(i+1)] = src_conv.bias.data[per_na*(i) + cls:per_na*(i+1)]
+    
+    def forward(self, x):
+        return [self.conv_cls(x).sigmoid(), self.conv_seg(x)]
+        # return [self.conv_cls(x), self.conv_seg(x)]
+
 class Detect(nn.Module):
     # YOLOv5 Detect head for detection models
     stride = None  # strides computed during build
@@ -53,12 +71,41 @@ class Detect(nn.Module):
         self.m = nn.ModuleList(nn.Conv2d(x, self.no * self.na, 1) for x in ch)  # output conv
         self.inplace = inplace  # use inplace ops (e.g. slice assignment)
 
+    def _register_seg_seperate(self, export=False):
+        self.seg_seperate = True
+        self.m_replace = nn.ModuleList()
+        self.export = export
+
+        for _mc in self.m:
+            out_channels = _mc.out_channels
+            cls_channel = 5 + self.nc
+            seg_channel = int(out_channels/self.na) - 5 - self.nc
+            self.m_replace.append(Segment_head_seperate_block(cls_channel, seg_channel, self.na, _mc))
+
+    def _register_detect_seperate(self, export=False):
+        self.detect_seperate = True
+        
+
     def forward(self, x):
         z = []  # inference output
         for i in range(self.nl):
-            x[i] = self.m[i](x[i])  # conv
-            bs, _, ny, nx = x[i].shape  # x(bs,255,20,20) to x(bs,3,20,20,85)
-            x[i] = x[i].view(bs, self.na, self.no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
+            if getattr(self, 'seg_seperate', False):
+                c, s = self.m_replace[i](x[i])
+                if getattr(self, 'export', False):
+                    z.append(c)
+                    z.append(s)
+                    continue
+                bs, _, ny, nx = c.shape
+                c = c.reshape(bs, self.na, -1, ny, nx)
+                s = s.reshape(bs, self.na, -1, ny, nx)
+                x[i] = torch.cat([c, s], 2).permute(0, 1, 3, 4, 2).contiguous()
+            elif getattr(self, 'detect_seperate', False):
+                z.append(torch.sigmoid(self.m[i](x[i])))
+                continue
+            else:
+                x[i] = self.m[i](x[i])  # conv
+                bs, _, ny, nx = x[i].shape  # x(bs,255,20,20) to x(bs,3,20,20,85)
+                x[i] = x[i].view(bs, self.na, self.no, ny, nx).permute(0, 1, 3, 4, 2).contiguous()
 
             if not self.training:  # inference
                 if self.dynamic or self.grid[i].shape[2:4] != x[i].shape[2:4]:
@@ -76,6 +123,8 @@ class Detect(nn.Module):
                     y = torch.cat((xy, wh, conf), 4)
                 z.append(y.view(bs, self.na * nx * ny, self.no))
 
+        if getattr(self, 'export', False):
+            return z
         return x if self.training else (torch.cat(z, 1),) if self.export else (torch.cat(z, 1), x)
 
     def _make_grid(self, nx=20, ny=20, i=0, torch_1_10=check_version(torch.__version__, '1.10.0')):
@@ -103,8 +152,8 @@ class Segment(Detect):
     def forward(self, x):
         p = self.proto(x[0])
         x = self.detect(self, x)
-        return (x, p) if self.training else (x[0], p) if self.export else (x[0], p, x[1])
 
+        return (x, p) if self.training else (*x, p) if self.export else (x[0], p, x[1])
 
 class BaseModel(nn.Module):
     # YOLOv5 base model


### PR DESCRIPTION
官方给的例子，转出来是1-255-80-80，但是rv1106不支持ncwh的输出，我讲1-255-80-80 reshape到1-3-85-80-80，但是结果不对

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 📊 Key Changes
- Optimization guidance for exporting YOLOv5 models to the RKNN format, with a focus on the RKNN toolkit for Rockchip NPU acceleration support.
- Introduction of several environment variable checks and condition-based initializations to enable or disable RKNN-specific model tweaks during the model export process.
- Modifications in `export.py` to support RKNN-targeted exports by inserting RKNN-specific layers and adjustments to the YOLOv5 focus/SPPF blocks and final layer outputs.
- Addition of a new file, `README_rkopt.md`, providing instructions and details on the optimizations for RKNN.
- Adjustments in `models/common.py` and other related files to the Focus, SPP, and SPPF blocks including changes to underlying operations and activation functions for RKNN compatibility.
- Environment variable `RKNN_model_hack` is introduced to activate RKNN-specific changes.

### 🎯 Purpose & Impact
- The changes enable YOLOv5's neural network models to be exported and optimized for deployment on Rockchip NPU hardware, which is valuable for developers aiming to deploy AI models on embedded devices or IoT applications powered by Rockchip NPUs.
- The optimizations are designed to maintain the quality of inference results while improving performance on targeted hardware.
- The documentation provided in the new `README_rkopt.md` helps users understand how to properly export and optimize their models using the provided scripts and underlying code changes.

### 🌟 Summary
This PR adds support and optimization for exporting YOLOv5 models to RKNN, aimed at boosting performance on Rockchip NPU accelerated devices. 🚀📲