### PR TITLE
Fixed randrange warnings in Python>=3.10

### DIFF
--- a/segment/train.py
+++ b/segment/train.py
@@ -299,7 +299,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
 
             # Multi-scale
             if opt.multi_scale:
-                sz = random.randrange(imgsz * 0.5, imgsz * 1.5 + gs) // gs * gs  # size
+                sz = random.randrange(int(imgsz * 0.5), int(imgsz * 1.5) + gs) // gs * gs  # size
                 sf = sz / max(imgs.shape[2:])  # scale factor
                 if sf != 1:
                     ns = [math.ceil(x * sf / gs) * gs for x in imgs.shape[2:]]  # new shape (stretched to gs-multiple)

--- a/train.py
+++ b/train.py
@@ -299,7 +299,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
 
             # Multi-scale
             if opt.multi_scale:
-                sz = random.randrange(imgsz * 0.5, imgsz * 1.5 + gs) // gs * gs  # size
+                sz = random.randrange(int(imgsz * 0.5), int(imgsz * 1.5) + gs) // gs * gs  # size
                 sf = sz / max(imgs.shape[2:])  # scale factor
                 if sf != 1:
                     ns = [math.ceil(x * sf / gs) * gs for x in imgs.shape[2:]]  # new shape (stretched to gs-multiple)


### PR DESCRIPTION
Hi, jocher

When training with `--multi-scale` option in python 3.10, there is some warnings about `randrange()`

```bash
DeprecationWarning: non-integer arguments to randrange() have been deprecated since Python 3.10 and will be removed in a subsequent version
```


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced multi-scale training stability in YOLOv5.

### 📊 Key Changes
- Modified the calculation of image sizes for multi-scale training to ensure integer values.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: The update ensures that random image sizes generated during multi-scale training are integers, preventing potential errors in the training process that can occur with non-integer sizes.
- 💥 **Impact**: This change will lead to more stable training runs when using the multi-scale option, and users should experience fewer interruptions due to size-related errors.