### PR TITLE
dataloaders: fix class filtering for segmentation

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -538,7 +538,7 @@ class LoadImagesAndLabels(Dataset):
                 j = (label[:, 0:1] == include_class_array).any(1)
                 self.labels[i] = label[j]
                 if segment:
-                    self.segments[i] = [segment[idx] for idx,elem in enumerate(j) if elem]
+                    self.segments[i] = [segment[idx] for idx, elem in enumerate(j) if elem]
             if single_cls:  # single-class training, merge all classes into 0
                 self.labels[i][:, 0] = 0
 

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -531,13 +531,14 @@ class LoadImagesAndLabels(Dataset):
 
         # Update labels
         include_class = []  # filter labels to include only these classes (optional)
+        self.segments = list(self.segments)
         include_class_array = np.array(include_class).reshape(1, -1)
         for i, (label, segment) in enumerate(zip(self.labels, self.segments)):
             if include_class:
                 j = (label[:, 0:1] == include_class_array).any(1)
                 self.labels[i] = label[j]
                 if segment:
-                    self.segments[i] = segment[j]
+                    self.segments[i] = [segment[idx] for idx,elem in enumerate(j) if elem]
             if single_cls:  # single-class training, merge all classes into 0
                 self.labels[i][:, 0] = 0
 


### PR DESCRIPTION
Issue: https://github.com/ultralytics/yolov5/issues/11170

- `self.segments[i]` and `segment[j]` are lists so they cannot be indexed with booleans
- `self.segments` is a tuple so it has to be converted into a list first

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced filtering logic in data loading for class-specific segmentation.

### 📊 Key Changes
- `self.segments` is now explicitly converted to a list to ensure it's mutable.
- Updated the segmentation filter section to comprehensively handle the inclusion of specified classes.

### 🎯 Purpose & Impact
- This change ensures that when a user wants to train a model on a subset of classes, the data loader correctly filters both the labels and the associated segments.
- By properly indexing the segments according to the filtered labels, the integrity of the data is maintained, leading to possibly more accurate model training outcomes.
- Users will benefit from more flexible and error-free data preparation, especially when working with complex datasets with multiple classes. 🎨📈