### PR TITLE
Fixed creation of empty directories in path was entered mistaken

### DIFF
--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -118,8 +118,8 @@ def attempt_download(file, repo='ultralytics/yolov5', release='v7.0'):
                 except Exception:
                     tag = release
 
-        file.parent.mkdir(parents=True, exist_ok=True)  # make parent dir (if required)
         if name in assets:
+            file.parent.mkdir(parents=True, exist_ok=True)  # make parent dir (if required)
             safe_download(file,
                           url=f'https://github.com/{repo}/releases/download/{tag}/{name}',
                           min_bytes=1E5,


### PR DESCRIPTION
Hi,

Currently, when a mistaken weight path is entered, yolov5 tries to call the `attempt_download` function, which unconditionally creates the path's parent directory. This PR modify it to create the parent directory only after it has found the online assets.

```bash
python export.py --weights runs/abc/exp/weights/best.pt
```

The `runs/abc/exp/weights/` will be created even though the `best.pt` can not be downloaded.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved the file download process from GitHub in the `yolov5` project.

### 📊 Key Changes
- Moved the directory creation line, which ensures the parent directory exists before downloading a file from GitHub.

### 🎯 Purpose & Impact
- The change optimizes the process by ensuring that the parent directory is created only when it's confirmed that the desired asset is available for download. This may prevent unnecessary directory creation.
- Users can benefit from a more efficient download process, especially when downloading model assets or other files from the project’s GitHub releases. 📁✨