### PR TITLE
Remove duplicate assignment code

### DIFF
--- a/utils/segment/loss.py
+++ b/utils/segment/loss.py
@@ -16,7 +16,6 @@ class ComputeLoss:
         self.overlap = overlap
         device = next(model.parameters()).device  # get model device
         h = model.hyp  # hyperparameters
-        self.device = device
 
         # Define criteria
         BCEcls = nn.BCEWithLogitsLoss(pos_weight=torch.tensor([h['cls_pw']], device=device))


### PR DESCRIPTION
Hi, these two lines of assignment codes are duplicate. 
https://github.com/ultralytics/yolov5/blob/3e55763d45f9c5f8217e4dad5ba1e6c1f42e3bf8/utils/segment/loss.py#L19 https://github.com/ultralytics/yolov5/blob/3e55763d45f9c5f8217e4dad5ba1e6c1f42e3bf8/utils/segment/loss.py#L42
I remove L19 and keep L42 according to the codes here:
https://github.com/ultralytics/yolov5/blob/3e55763d45f9c5f8217e4dad5ba1e6c1f42e3bf8/utils/loss.py#L94-L119


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancement of loss computation efficiency in segmentation utilities.

### 📊 Key Changes
- Removed redundant `device` attribute assignment in the segmentation loss class.

### 🎯 Purpose & Impact
- 👍 The purpose is to streamline the loss computation by eliminating unnecessary code, which can potentially lead to reduced memory usage and faster execution.
- 🚀 Impact on users will likely be minimal on the surface but improves the underlying code quality and efficiency.