### PR TITLE
Error in docstring with tensor shape

### DIFF
--- a/utils/segment/general.py
+++ b/utils/segment/general.py
@@ -10,7 +10,7 @@ def crop_mask(masks, boxes):
     Vectorized by Chong (thanks Chong).
 
     Args:
-        - masks should be a size [h, w, n] tensor of masks
+        - masks should be a size [n, h, w] tensor of masks
         - boxes should be a size [n, 4] tensor of bbox coords in relative point form
     """
 


### PR DESCRIPTION
When calling crop_mask(masks, boxes) the incoming masks are stacked in dim=0  NOT as stated in the docs in dim=2. 

Cheers!

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced mask tensor dimension order in segmentation utility.

### 📊 Key Changes
- Modified the expected dimension order for the `masks` input in `crop_mask` function.

### 🎯 Purpose & Impact
- This change aims to standardize the input format, likely aligning with other parts of the code or conventions in the data processing pipeline.
- Users dealing with segmentation tasks will need to adjust their input `masks` tensor shape to comply with the new [n, h, w] format, leading to potential changes in their data preparation scripts.