### PR TITLE
Error in tensor shape of docstring

### DIFF
--- a/utils/segment/general.py
+++ b/utils/segment/general.py
@@ -10,7 +10,7 @@ def crop_mask(masks, boxes):
     Vectorized by Chong (thanks Chong).
 
     Args:
-        - masks should be a size [h, w, n] tensor of masks
+        - masks should be a size [n, h, w] tensor of masks
         - boxes should be a size [n, 4] tensor of bbox coords in relative point form
     """
 


### PR DESCRIPTION
Corrected the tensor shape in the doc string.
The incoming masks are stacked in dim=0 therefore the doc is wrong

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved tensor dimension order for mask cropping functionality. 🚀

### 📊 Key Changes
- Modified the expected input tensor dimension order for `masks` from `[h, w, n]` to `[n, h, w]` in the `crop_mask` function.

### 🎯 Purpose & Impact
- 🎨 **Enhanced Consistency**: This change aligns the `masks` tensor dimension order with common conventions, improving code readability and maintenance.
- 🧩 **Better Integration**: Adjusting the tensor dimensions could facilitate easier integration with other parts of the system where the `[n, h, w]` format is standard.
- 🔁 **Potential Refactor Impact**: Users utilizing this function will need to ensure their mask tensors conform to the new format to prevent runtime errors.