### PR TITLE
FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime

### DIFF
--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -2,9 +2,8 @@
 # Builds ultralytics/yolov5:latest image on DockerHub https://hub.docker.com/r/ultralytics/yolov5
 # Image is CUDA-optimized for YOLOv5 single/multi-GPU training and inference
 
-# Start FROM NVIDIA PyTorch image https://ngc.nvidia.com/catalog/containers/nvidia:pytorch
-# FROM docker.io/pytorch/pytorch:latest
-FROM pytorch/pytorch:latest
+# Start FROM PyTorch image https://hub.docker.com/r/pytorch/pytorch
+FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime
 
 # Downloads to user config dir
 ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated the YOLOv5 Dockerfile to use a specific PyTorch image with updated CUDA support.

### 📊 Key Changes
- Removed reference to NVIDIA's PyTorch image.
- Switched base Docker image to `pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime`.

### 🎯 Purpose & Impact
- **Consistency**: By specifying the PyTorch image version, the setup becomes more predictable and stable.
- **Latest Features and Fixes**: The update to PyTorch 2.0.0, CUDA 11.7, and cuDNN 8 ensures compatibility with the latest GPU acceleration features and optimizations.
- **Performance**: Users may experience improved performance due to better utilization of new GPU architectures.
- **Development Stability**: Fixed image version helps avoid potential issues with future breaking changes in the base image.