### PR TITLE
[needs a better fix] [segm] Fixed background images support with mixup augmentation

### DIFF
--- a/utils/segment/augmentations.py
+++ b/utils/segment/augmentations.py
@@ -17,6 +17,14 @@ def mixup(im, labels, segments, im2, labels2, segments2):
     # Applies MixUp augmentation https://arxiv.org/pdf/1710.09412.pdf
     r = np.random.beta(32.0, 32.0)  # mixup ratio, alpha=beta=32.0
     im = (im * r + im2 * (1 - r)).astype(np.uint8)
+
+    # on background images, one of the two segments might be empty and be an empty list
+    # which will lead to an incorrectly list casted to (0,) that cannot be concatenated
+    if len(labels) == 0:
+        return im, labels2, segments2
+    elif len(labels2) == 0:
+        return im, labels, segments
+
     labels = np.concatenate((labels, labels2), 0)
     segments = np.concatenate((segments, segments2), 0)
     return im, labels, segments


### PR DESCRIPTION
At the end of the day, mixup() function is expected to receive the labels and the segments of the two images.

The list of the segments are expected to be converted into a np array by going thru the `random_perspective` augmentation method.

But inside, if the label length is 0, it will just leave the function and return a list (an empty one) and in `mixup` function concatening an np array with an empty python list will auto cast the empty list to `(0,)` which cannot be concatened to the first image.

**This is a hotfix that fix a mixup between a non-background image and a background image, IT DOES NOT FIX background+background image mixup** 

I tried to apply the patch after the random_perspective call but I couldn't get my head on how it generated a shape of `(x,1000,2)` (x being number of classes I guess, not sure if  `1000` is constant.)


Error that happened before this hotfix:


```txt
Original Traceback (most recent call last):
  File "C:\Users\xxxxxxx\Desktop\yolov5\venv\lib\site-packages\torch\utils\data\_utils\worker.py", line 308, in _worker_loop
    data = fetcher.fetch(index)
  File "C:\Users\xxxxxxx\Desktop\yolov5\venv\lib\site-packages\torch\utils\data\_utils\fetch.py", line 51, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "C:\Users\xxxxxxx\Desktop\yolov5\venv\lib\site-packages\torch\utils\data\_utils\fetch.py", line 51, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "C:\Users\xxxxxxx\Desktop\yolov5\utils\segment\dataloaders.py", line 123, in __getitem__
    img, labels, segments = mixup(img, labels, segments, *self.load_mosaic(random.randint(0, self.n - 1)))
  File "C:\Users\xxxxxxx\Desktop\yolov5\utils\segment\augmentations.py", line 26, in mixup
    segments = np.concatenate((segments, segments2), 0)
  File "<__array_function__ internals>", line 200, in concatenate
ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 3 dimension(s) and the array at index 1 has 1 dimension(s)
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced MixUp augmentation in YOLOv5 with improved handling for empty segment cases.

### 📊 Key Changes
- Added checks for empty label/segment lists during MixUp augmentation.
- Ensured correct return value when one of the inputs has no labels or segments.

### 🎯 Purpose & Impact
- 🎨 Prevents errors during data augmentation, specifically when dealing with background images with no labels or segments.
- 👩‍💻 This ensures greater robustness and stability in models trained with MixUp augmentation, impacting user experience positively by reducing potential training errors.