### PR TITLE
Improve Slack notification

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -45,14 +45,6 @@ jobs:
           python detect.py --weights ${{ matrix.model }}.onnx --img 320
           python segment/predict.py --weights ${{ matrix.model }}-seg.onnx --img 320
           python classify/predict.py --weights ${{ matrix.model }}-cls.onnx --img 224
-      - name: Notify on failure
-        if: failure() && github.repository == 'ultralytics/yolov5' && (github.event_name == 'schedule' || github.event_name == 'push')
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {"text": "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n*Job Status:* ${{ job.status }}\n"}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
 
   Tests:
     timeout-minutes: 60
@@ -159,11 +151,17 @@ jobs:
           for path in '$m', '$b':
               model = torch.hub.load('.', 'custom', path=path, source='local')
           EOF
-      - name: Notify on failure
-        if: failure() && github.repository == 'ultralytics/yolov5' && (github.event_name == 'schedule' || github.event_name == 'push')
+
+  NotifyFailure:
+    runs-on: ubuntu-latest
+    needs: [Benchmarks, Tests] # Add job names that you want to check for failure
+    if: always() # This ensures the job runs even if previous jobs fail
+    steps:
+      - name: Check for failure and notify
+        if: ${{ needs.Benchmarks.result == 'failure' || needs.Tests.result == 'failure' }} # Check if any of the jobs failed
         uses: slackapi/slack-github-action@v1.23.0
         with:
           payload: |
-            {"text": "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n*Job Status:* ${{ job.status }}\n"}
+            {"text": "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -152,7 +152,7 @@ jobs:
               model = torch.hub.load('.', 'custom', path=path, source='local')
           EOF
 
-  NotifyFailure:
+  Summary:
     runs-on: ubuntu-latest
     needs: [Benchmarks, Tests] # Add job names that you want to check for failure
     if: always() # This ensures the job runs even if previous jobs fail

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,7 @@ name: "CodeQL"
 on:
   schedule:
     - cron: '0 0 1 * *'  # Runs at 00:00 UTC on the 1st of every month
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ name: Publish Docker Images
 on:
   push:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   docker:


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b5c041c</samp>

### Summary
:recycle::speech_balloon::negative_squared_cross_mark:

<!--
1.  :recycle: - This emoji represents the refactoring of the existing code to improve its structure and readability.
2.  :speech_balloon: - This emoji represents the slack notification feature that communicates the status of the workflow to the team.
3.  :negative_squared_cross_mark: - This emoji represents the failure condition that triggers the notification and alerts the team of any issues.
-->
Refactor slack notification logic in `ci-testing.yml` workflow. Add a new job to send one message on failure instead of multiple messages from each job.

> _Sing, O Muse, of the cunning refactorer_
> _Who tamed the slack notification logic_
> _In the `ci-testing.yml` workflow of code_
> _And made it simpler and more efficient._

### Walkthrough
*  Consolidate slack notification logic into one job called NotifyFailure ([link](https://github.com/ultralytics/yolov5/pull/11458/files?diff=unified&w=0#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aL162-R165)). This job runs after all the other jobs in the workflow and checks their status using the `needs` and `if` keywords. If any of the previous jobs failed, it sends a single message to the slack channel with the workflow name, run number, and commit SHA. This avoids duplicate notifications for the same workflow failure, which could be noisy and confusing.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refinement of CI notifications and enhancing workflow triggers for user-initiated actions.

### 📊 Key Changes
- 🔄 Updated GitHub Actions workflows for more targeted failure notifications.
- 🔧 Removed direct Slack notifications on every failure.
- 📬 Replaced with a conditional notification mechanism that checks for failures in specific jobs ('Benchmarks' and 'Tests').
- 🚀 Added "workflow_dispatch" to manually trigger workflows for code analysis and Docker image publication.

### 🎯 Purpose & Impact
- 🎯 Aim to declutter unnecessary notifications and only alert when crucial jobs fail, increasing attention to significant issues.
- 💡 Impact is more streamlined and user-controlled CI processes, giving developers and maintainers better oversight and control over the codebase and deployment pipelines.
- 👥 Non-expert users benefit from a more stable and monitored system, as critical errors are promptly and efficiently managed.