### PR TITLE
Apply SIoU on Bounding Box IoU metrics as default

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -138,7 +138,7 @@ class ComputeLoss:
                 pxy = pxy.sigmoid() * 2 - 0.5
                 pwh = (pwh.sigmoid() * 2) ** 2 * anchors[i]
                 pbox = torch.cat((pxy, pwh), 1)  # predicted box
-                iou = bbox_iou(pbox, tbox[i], CIoU=True).squeeze()  # iou(prediction, target)
+                iou = bbox_iou(pbox, tbox[i], SIoU=True).squeeze()  # iou(prediction, target)
                 lbox += (1.0 - iou).mean()  # iou loss
 
                 # Objectness

--- a/utils/segment/loss.py
+++ b/utils/segment/loss.py
@@ -62,7 +62,7 @@ class ComputeLoss:
                 pxy = pxy.sigmoid() * 2 - 0.5
                 pwh = (pwh.sigmoid() * 2) ** 2 * anchors[i]
                 pbox = torch.cat((pxy, pwh), 1)  # predicted box
-                iou = bbox_iou(pbox, tbox[i], CIoU=True).squeeze()  # iou(prediction, target)
+                iou = bbox_iou(pbox, tbox[i], SIoU=True).squeeze()  # iou(prediction, target)
                 lbox += (1.0 - iou).mean()  # iou loss
 
                 # Objectness


### PR DESCRIPTION
- SIoU method on metrics/bbox_iou
- applying SIoU as default metric on bounding box loss

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Incorporating SIoU (Scaled IoU) Loss into YOLOv5 prediction and bounding box calculations.

### 📊 Key Changes
- Replaced CIoU (Complete IoU) with SIoU (Scaled IoU) in IoU loss calculations for object detection.
- Extended the `bbox_iou` function to support SIoU loss computation.
- Implemented the SIoU loss mathematical formula according to the referenced research paper.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To improve the performance of YOLOv5 by integrating a more advanced IoU loss computation that could better differentiate between bounding boxes and address scale invariance.
- 🚀 **Impact**: Users may experience improved object detection accuracy, especially in cases where scaling differences are significant, potentially leading to more precise and scalable object detection models.