### PR TITLE
Update export.py

### DIFF
--- a/export.py
+++ b/export.py
@@ -638,7 +638,7 @@ def pipeline_coreml(model, im, file, names, y, prefix=colorstr('CoreML Pipeline:
         'confidence_threshold': str(nms.confidenceThreshold)})
 
     # Save the model
-    f = file.with_suffix('.mlmodel')  # filename
+    f = file.with_suffix('.mlpackage')  # filename
     model = ct.models.MLModel(pipeline.spec)
     model.input_description['image'] = 'Input image'
     model.input_description['iouThreshold'] = f'(optional) IOU Threshold override (default: {nms.iouThreshold})'


### PR DESCRIPTION
Changed coreml export extension to a working format. From ".mlmodel" to ".mlpackage".

reason:
If we leave it as .mlmodel, the following error message will appear because the pipeline model with nms added cannot be converted. "Exception: For an ML Program, extension must be .mlpackage (not .mlmodel)"

The .mlpackage format works fine.

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3833c4b</samp>

### Summary
📦🆕🛠️

<!--
1.  📦 - This emoji represents the new `.mlpackage` format, which is like a container or a package for the Core ML model and its associated files and metadata. It also suggests the idea of cross-platform and cross-device compatibility, as a package can be shipped or delivered to different destinations.
2.  🆕 - This emoji represents the novelty and improvement of the new format, which offers more features and flexibility than the previous one. It also implies that the change was made to keep up with the latest developments and standards in Core ML Tools and the machine learning field.
3.  🛠️ - This emoji represents the tool or the instrument that was used to make the change, which is Core ML Tools 5.0. It also suggests the idea of fixing, updating, or enhancing something, as a tool can be used to perform various tasks and operations.
-->
Updated `export.py` to save Core ML models in the new `.mlpackage` format for better compatibility and flexibility.

> _`mlpackage` format_
> _more flexible and compatible_
> _cutting edge for Core ML_

### Walkthrough
* Change the file extension for saving the Core ML model to `.mlpackage` to support the new format in Core ML Tools 5.0 ([link](https://github.com/ultralytics/yolov5/pull/11615/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2L641-R641))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Transition from CoreML `.mlmodel` file format to the new `.mlpackage` format.

### 📊 Key Changes
- Modified the file extension from `.mlmodel` to `.mlpackage` for the CoreML model export.

### 🎯 Purpose & Impact
- Ensures compatibility with the latest CoreML tools and practices by adopting the newer `.mlpackage` format.
- 📱 Users may experience smoother integration with iOS/macOS applications and benefit from enhancements in the CoreML framework.