### PR TITLE
Add OpenVINO_NNCF (int8 export)  export support

### DIFF
--- a/export.py
+++ b/export.py
@@ -111,8 +111,7 @@ def export_formats():
         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False, False],
         ['TensorFlow.js', 'tfjs', '_web_model', False, False],
         ['PaddlePaddle', 'paddle', '_paddle_model', True, True],
-        ['OpenVINO_nncf', 'openvino_nncf', '_openvino_model_int8', True, False],
-    ]
+        ['OpenVINO_nncf', 'openvino_nncf', '_openvino_model_int8', True, False],]
     return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'CPU', 'GPU'])
 
 
@@ -226,16 +225,23 @@ def export_openvino(file, metadata, half, prefix=colorstr('OpenVINO:')):
 
 
 @try_export
-def export_nncf(file, metadata, half, data, prefix=colorstr('OpenVINO_NNCF:'), ):
+def export_nncf(
+        file,
+        metadata,
+        half,
+        data,
+        prefix=colorstr('OpenVINO_NNCF:'),
+):
     # YOLOv5 OpenVINO_NNCF export
     check_requirements('openvino-dev>=2023.0')  # requires openvino-dev: https://pypi.org/project/openvino-dev/
     check_requirements('nncf')
     import nncf
-    from utils.dataloaders import letterbox, create_dataloader
-    from utils.general import check_dataset, check_yaml
+    import numpy as np
     import openvino.runtime as ov  # noqa
     from openvino.runtime import Core
-    import numpy as np
+
+    from utils.dataloaders import create_dataloader, letterbox
+    from utils.general import check_dataset, check_yaml
 
     LOGGER.info(f'\n{prefix} starting export with openvino_nncf {ov.__version__}...')
     core = Core()
@@ -264,10 +270,14 @@ def export_nncf(file, metadata, half, data, prefix=colorstr('OpenVINO_NNCF:'), )
     def gen_dataloader(yaml_path, task='train', imgsz=640, workers=4):
         data_yaml = check_yaml(yaml_path)
         data = check_dataset(data_yaml)
-        dataloader = create_dataloader(
-            data[task], imgsz=imgsz, batch_size=1, stride=32, pad=0.5, single_cls=False,
-            rect=False, workers=workers
-        )[0]
+        dataloader = create_dataloader(data[task],
+                                       imgsz=imgsz,
+                                       batch_size=1,
+                                       stride=32,
+                                       pad=0.5,
+                                       single_cls=False,
+                                       rect=False,
+                                       workers=workers)[0]
         return dataloader
 
     # noqa: F811
@@ -523,7 +533,7 @@ def export_edgetpu(file, prefix=colorstr('Edge TPU:')):
         '10',
         '--out_dir',
         str(file.parent),
-        f_tfl, ], check=True)
+        f_tfl,], check=True)
     return f, None
 
 
@@ -544,7 +554,7 @@ def export_tfjs(file, int8, prefix=colorstr('TensorFlow.js:')):
         '--quantize_uint8' if int8 else '',
         '--output_node_names=Identity,Identity_1,Identity_2,Identity_3',
         str(f_pb),
-        str(f), ]
+        str(f),]
     subprocess.run([arg for arg in args if arg], check=True)
 
     json = Path(f_json).read_text()
@@ -554,9 +564,9 @@ def export_tfjs(file, int8, prefix=colorstr('TensorFlow.js:')):
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}, '
             r'"Identity.?.?": {"name": "Identity.?.?"}}}', r'{"outputs": {"Identity": {"name": "Identity"}, '
-                                                           r'"Identity_1": {"name": "Identity_1"}, '
-                                                           r'"Identity_2": {"name": "Identity_2"}, '
-                                                           r'"Identity_3": {"name": "Identity_3"}}}', json)
+            r'"Identity_1": {"name": "Identity_1"}, '
+            r'"Identity_2": {"name": "Identity_2"}, '
+            r'"Identity_3": {"name": "Identity_3"}}}', json)
         j.write(subst)
     return f, None
 
@@ -871,7 +881,8 @@ def parse_opt(known=False):
         '--include',
         nargs='+',
         default=['torchscript'],
-        help='torchscript, onnx, openvino, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle, openvino_nncf')
+        help='torchscript, onnx, openvino, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle, openvino_nncf'
+    )
     opt = parser.parse_known_args()[0] if known else parser.parse_args()
     print_args(vars(opt))
     return opt

--- a/export.py
+++ b/export.py
@@ -824,7 +824,7 @@ def run(
     if paddle:  # PaddlePaddle
         f[10], _ = export_paddle(model, im, file, metadata)
     if openvino_nncf:
-        f[11], _ = export_openvino(file, metadata, half, data=data)
+        f[11], _ = export_nncf(file, metadata, half, data=data)
 
     # Finish
     f = [str(x) for x in f if x]  # filter out '' and None


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a96ef50</samp>

### Summary
🚀🔧📝

<!--
1.  🚀 This emoji represents the new feature of exporting to OpenVINO_NNCF, which can improve the performance and efficiency of the YOLOv5 model on Intel devices.
2.  🔧 This emoji represents the minor formatting changes in other export functions, which are done to improve the code readability and consistency.
3.  📝 This emoji represents the documentation update in the `export_formats` DataFrame, which explains the new format and its requirements.
-->
This pull request enables exporting YOLOv5 models to the OpenVINO_NNCF format for better performance on Intel devices. It adds a new function `export_nncf` and a new flag `openvino_nncf` in `export.py`. It also improves the code style of other export functions.

> _Sing, O Muse, of the skillful coder who devised_
> _A way to export the swift and keen-eyed YOLOv5_
> _To the OpenVINO_NNCF format, that wondrous art_
> _Of Intel, which makes the models swift as Hermes' dart._

### Walkthrough
*  Add support for exporting YOLOv5 model to OpenVINO_NNCF format, a quantized and optimized model for Intel hardware ([link](https://github.com/ultralytics/yolov5/pull/11699/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2L113-R115), [link](https://github.com/ultralytics/yolov5/pull/11699/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2R229-R296), [link](https://github.com/ultralytics/yolov5/pull/11699/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2L680-R750), [link](https://github.com/ultralytics/yolov5/pull/11699/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2L723-R793), [link](https://github.com/ultralytics/yolov5/pull/11699/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2R826-R827), [link](https://github.com/ultralytics/yolov5/pull/11699/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2L802-R874))
*  Format the arguments and indentation of `subprocess.run` calls and regular expression substitution in `export_edgetpu` and `export_tfjs` functions for consistency and readability ([link](https://github.com/ultralytics/yolov5/pull/11699/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2L456-R526), [link](https://github.com/ultralytics/yolov5/pull/11699/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2L477-R547), [link](https://github.com/ultralytics/yolov5/pull/11699/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2L487-R559))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added export support for OpenVINO Neural Network Compression Framework (NNCF) models in the YOLOv5 repository.

### 📊 Key Changes
- Introduced a new export format for OpenVINO NNCF, enabling Int8 quantization during the model export process.
- Implemented `export_nncf` function, which handles the export and quantization steps required for NNCF.
- Required dependencies (`openvino-dev` and `nncf`) are checked and imported within the `export_nncf` function.
- Extended the command-line interface to include the `openvino_nncf` option in the `--include` argument.
- Modified the main export `run` function to accommodate the new OpenVINO NNCF export option.

### 🎯 Purpose & Impact
- This change allows users to export YOLOv5 models with NNCF quantization, which can lead to optimized model performance on certain Intel hardware.
- Enabling Int8 quantization can significantly improve inference speed while maintaining accuracy, which is important for edge computing and devices with limited computational power.
- Users can now choose OpenVINO NNCF as part of the model export pipeline, making it easier to deploy models on various platforms that support OpenVINO.