### PR TITLE
Add OpenVINO NNCF Support (Using --int8 flag)

### DIFF
--- a/export.py
+++ b/export.py
@@ -216,7 +216,6 @@ def export_openvino(file, metadata, half, int8, data, prefix=colorstr('OpenVINO:
     f_onnx = file.with_suffix('.onnx')
     f_ov = str(Path(f) / file.with_suffix('.xml').name)
     if int8:
-        check_requirements('openvino-dev>=2023.0')
         check_requirements('nncf')
         import nncf
         import numpy as np

--- a/export.py
+++ b/export.py
@@ -830,7 +830,7 @@ def parse_opt(known=False):
     parser.add_argument('--inplace', action='store_true', help='set YOLOv5 Detect() inplace=True')
     parser.add_argument('--keras', action='store_true', help='TF: use Keras')
     parser.add_argument('--optimize', action='store_true', help='TorchScript: optimize for mobile')
-    parser.add_argument('--int8', action='store_true', help='CoreML/TF INT8 quantization')
+    parser.add_argument('--int8', action='store_true', help='CoreML/TF/OpenVINO INT8 quantization')
     parser.add_argument('--dynamic', action='store_true', help='ONNX/TF/TensorRT: dynamic axes')
     parser.add_argument('--simplify', action='store_true', help='ONNX: simplify model')
     parser.add_argument('--opset', type=int, default=17, help='ONNX: opset version')

--- a/export.py
+++ b/export.py
@@ -205,7 +205,7 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr('ONNX
 
 
 @try_export
-def export_openvino(file, metadata, half, prefix=colorstr('OpenVINO:')):
+def export_openvino(file, metadata, half, int8,data,prefix=colorstr('OpenVINO:')):
     # YOLOv5 OpenVINO export
     check_requirements('openvino-dev>=2022.3')  # requires openvino-dev: https://pypi.org/project/openvino-dev/
     import openvino.runtime as ov  # noqa
@@ -215,8 +215,55 @@ def export_openvino(file, metadata, half, prefix=colorstr('OpenVINO:')):
     f = str(file).replace(file.suffix, f'_openvino_model{os.sep}')
     f_onnx = file.with_suffix('.onnx')
     f_ov = str(Path(f) / file.with_suffix('.xml').name)
+    if int8:
+        check_requirements('openvino-dev>=2023.0')
+        check_requirements('nncf')
+        from openvino.runtime import Core
+        from utils.dataloaders import create_dataloader, letterbox
+        import nncf
+        import numpy as np
+        core = Core()
+        onnx_model = core.read_model(f_onnx)  # export
+        def prepare_input_tensor(image: np.ndarray):
+            input_tensor = image.astype(np.float32)  # uint8 to fp16/32
+            input_tensor /= 255.0  # 0 - 255 to 0.0 - 1.0
 
-    ov_model = mo.convert_model(f_onnx, model_name=file.stem, framework='onnx', compress_to_fp16=half)  # export
+            if input_tensor.ndim == 3:
+                input_tensor = np.expand_dims(input_tensor, 0)
+            return input_tensor
+
+        def gen_dataloader(yaml_path, task='train', imgsz=640, workers=4):
+            data_yaml = check_yaml(yaml_path)
+            data = check_dataset(data_yaml)
+            dataloader = create_dataloader(data[task],
+                                           imgsz=imgsz,
+                                           batch_size=1,
+                                           stride=32,
+                                           pad=0.5,
+                                           single_cls=False,
+                                           rect=False,
+                                           workers=workers)[0]
+            return dataloader
+
+        # noqa: F811
+
+        def transform_fn(data_item):
+            """
+            Quantization transform function. Extracts and preprocess input data from dataloader item for quantization.
+            Parameters:
+               data_item: Tuple with data item produced by DataLoader during iteration
+            Returns:
+                input_tensor: Input data for quantization
+            """
+            img = data_item[0].numpy()
+            input_tensor = prepare_input_tensor(img)
+            return input_tensor
+
+        ds = gen_dataloader(data)
+        quantization_dataset = nncf.Dataset(ds, transform_fn)
+        ov_model = nncf.quantize(onnx_model, quantization_dataset, preset=nncf.QuantizationPreset.MIXED)
+    else:
+        ov_model = mo.convert_model(f_onnx, model_name=file.stem, framework='onnx', compress_to_fp16=half)  # export
 
     ov.serialize(ov_model, f_ov)  # save
     yaml_save(Path(f) / file.with_suffix('.yaml').name, metadata)  # add metadata.yaml
@@ -723,7 +770,7 @@ def run(
     if onnx or xml:  # OpenVINO requires ONNX
         f[2], _ = export_onnx(model, im, file, opset, dynamic, simplify)
     if xml:  # OpenVINO
-        f[3], _ = export_openvino(file, metadata, half)
+        f[3], _ = export_openvino(file, metadata, half,int8,data)
     if coreml:  # CoreML
         f[4], ct_model = export_coreml(model, im, file, int8, half, nms)
         if nms:

--- a/export.py
+++ b/export.py
@@ -205,7 +205,7 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr('ONNX
 
 
 @try_export
-def export_openvino(file, metadata, half, int8,data,prefix=colorstr('OpenVINO:')):
+def export_openvino(file, metadata, half, int8, data, prefix=colorstr('OpenVINO:')):
     # YOLOv5 OpenVINO export
     check_requirements('openvino-dev>=2022.3')  # requires openvino-dev: https://pypi.org/project/openvino-dev/
     import openvino.runtime as ov  # noqa
@@ -218,12 +218,14 @@ def export_openvino(file, metadata, half, int8,data,prefix=colorstr('OpenVINO:')
     if int8:
         check_requirements('openvino-dev>=2023.0')
         check_requirements('nncf')
-        from openvino.runtime import Core
-        from utils.dataloaders import create_dataloader, letterbox
         import nncf
         import numpy as np
+        from openvino.runtime import Core
+
+        from utils.dataloaders import create_dataloader, letterbox
         core = Core()
         onnx_model = core.read_model(f_onnx)  # export
+
         def prepare_input_tensor(image: np.ndarray):
             input_tensor = image.astype(np.float32)  # uint8 to fp16/32
             input_tensor /= 255.0  # 0 - 255 to 0.0 - 1.0
@@ -770,7 +772,7 @@ def run(
     if onnx or xml:  # OpenVINO requires ONNX
         f[2], _ = export_onnx(model, im, file, opset, dynamic, simplify)
     if xml:  # OpenVINO
-        f[3], _ = export_openvino(file, metadata, half,int8,data)
+        f[3], _ = export_openvino(file, metadata, half, int8, data)
     if coreml:  # CoreML
         f[4], ct_model = export_coreml(model, im, file, int8, half, nms)
         if nms:


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2925311</samp>

### Summary
🚀🔧📝

<!--
1.  🚀 This emoji conveys the idea of adding a new feature or enhancement, such as support for INT8 quantization, which can improve the performance and efficiency of the models.
2.  🔧 This emoji suggests the idea of modifying or adjusting something, such as the `export_openvino` function and the command line interface, to make it work with the new feature or option.
3.  📝 This emoji implies the idea of updating or documenting something, such as the help message, to reflect the changes and inform the users.
-->
Added INT8 quantization option for OpenVINO models in `export.py`. This allows users to reduce the model size and inference latency by quantizing the weights and activations to 8-bit integers.

> _Sing, O Muse, of the skillful coder who devised_
> _a way to make the models of OpenVINO more wise,_
> _by adding `int8` quantization, a noble feat,_
> _that shrinks the size and boosts the speed of `export.py`._

### Walkthrough
*  Add support for INT8 quantization for OpenVINO models ([link](https://github.com/ultralytics/yolov5/pull/11706/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2L208-R208), [link](https://github.com/ultralytics/yolov5/pull/11706/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2L218-R267), [link](https://github.com/ultralytics/yolov5/pull/11706/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2L726-R773), [link](https://github.com/ultralytics/yolov5/pull/11706/files?diff=unified&w=0#diff-74fc7d08922278c1afa6f5b36d1450c965185dbcbdb77a99e432b0f4edaaade2L786-R833))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added INT8 quantization support for OpenVINO exports in the YOLOv5 repository.

### 📊 Key Changes
- `export_openvino` function now takes additional parameters: `int8`, `data`.
- New quantization process for INT8, including a new dataset generator `gen_dataloader` and a transformer function `transform_fn` for preparing input tensors.
- Conditional logic to perform INT8 quantization if the `int8` flag is set; otherwise, proceed with the existing model conversion.
- New requirements checked for INT8 quantization: `nncf` library is now required for this process.

### 🎯 Purpose & Impact
- Purpose: To improve the performance of YOLOv5 models on devices compatible with OpenVINO by enabling INT8 quantization, which reduces the model size and inference time while maintaining accuracy.
- Impact: Users who rely on OpenVINO for deploying their models can now benefit from the reduced computational requirements of INT8 models, possibly allowing deployment on more resource-constrained devices. Enhanced flexibility and potentially better performance for AI models in production environments. 🚀🧠