### PR TITLE
Remove Python 3.7 from tests

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -57,10 +57,7 @@ jobs:
         model: [ yolov5n ]
         include:
           - os: ubuntu-latest
-            python-version: '3.7'  # '3.6.8' min
-            model: yolov5n
-          - os: ubuntu-latest
-            python-version: '3.8'
+            python-version: '3.8'  # '3.6.8' min
             model: yolov5n
           - os: ubuntu-latest
             python-version: '3.9'


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 91d3476</samp>

### Summary
:wrench::zap::snake:

<!--
1.  :wrench: This emoji can be used to indicate a configuration or settings change, such as modifying the CI testing matrix. It can also imply fixing or improving something, which is the goal of the pull request.
2.  :zap: This emoji can be used to indicate a performance improvement or a speed boost, which is one of the benefits of reducing the number of tests. It can also imply something dynamic or exciting, which could reflect the simplification and optimization of the CI testing process.
3.  :snake: This emoji can be used to indicate a python-related change, as it is the official logo of the language. It can also imply something clever or cunning, which could reflect the skill or creativity involved in the pull request.
-->
Removed python 3.7 from CI testing matrix in `.github/workflows/ci-testing.yml` to improve workflow efficiency. The change was part of a pull request to simplify and optimize CI testing.

> _`python-version` gone_
> _CI tests run faster now_
> _Autumn leaves fall swift_

### Walkthrough
* Remove python 3.7 from CI testing matrix ([link](https://github.com/ultralytics/yolov5/pull/11708/files?diff=unified&w=0#diff-82af06888290ef31d154541fdc86514e682a9b9c656353a226e1d3eed32fef0aL60-R62)). This reduces the number of tests and speeds up the workflow, as python 3.7 is not required for the project. The minimum supported version is 3.6.8, which is still tested in another workflow. This change is part of a pull request that simplifies and optimizes the CI testing process in `.github/workflows/ci-testing.yml`.




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated Python versions for continuous integration testing in GitHub Actions.

### 📊 Key Changes
- Python `3.7` testing has been removed.
- Only Python versions `3.8` and `3.9` are now explicitly tested for the Ubuntu latest OS.

### 🎯 Purpose & Impact
- 🧹 Simplifies testing by dropping an older Python version, potentially reducing maintenance overhead.
- 🔄 Ensures compatibility with newer Python versions commonly in use, benefiting developers and users who are on more recent Python environments.
- 🚀 Users can be more confident that the codebase works on modern versions of Python, emphasizing current best practices in Python development.