### PR TITLE
Uninstall `wandb` from notebook environments

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -61,6 +61,7 @@ def notebook_init(verbose=True):
 
     import psutil
 
+    os.system('pip uninstall -y wandb')
     if is_colab():
         shutil.rmtree('/content/sample_data', ignore_errors=True)  # remove colab /sample_data directory
 


### PR DESCRIPTION
Resolves unwanted W&B install issues in https://www.kaggle.com/code/ultralytics/yolov8/comments#2306977

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dcaa6db</samp>

### Summary
🗑️🚫🛠️

<!--
1.  🗑️ - This emoji represents the uninstallation or removal of something, in this case the wandb package. It can also convey the idea of cleaning up or simplifying the code.
2.  🚫 - This emoji represents the prevention or avoidance of something, in this case the conflicts with the Colab environment. It can also convey the idea of blocking or stopping a problem.
3.  🛠️ - This emoji represents the setup or configuration of something, in this case the dependencies and settings for running the YOLOv5 notebook. It can also convey the idea of fixing or improving something.
-->
Uninstall `wandb` package in `utils/__init__.py` to avoid conflicts with Colab. This affects the `notebook_init` function that prepares the YOLOv5 notebook.

> _`wandb` uninstalled_
> _Colab has it already_
> _notebook init changed_

### Walkthrough
*  Uninstall wandb package to avoid conflicts with Colab environment ([link](https://github.com/ultralytics/yolov5/pull/11729/files?diff=unified&w=0#diff-6e982446d45d5ffa23213eb0cb66991fb02283df19b49da3bc8057ce1ab5094aR64))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improvements to notebook initialization in YOLOv5 by ensuring the WandB is uninstalled in certain environments.

### 📊 Key Changes
- Added a command to uninstall the `wandb` Python package during the environment setup process.

### 🎯 Purpose & Impact
- 🎯 **Purpose:** The main goal seems to cater specifically to environments like Google Colab, where a clean slate is desired for certain dependencies when initializing notebooks. By explicitly uninstalling `wandb`, it may help avoid potential conflicts or bugs related to WandB that may already be installed in the environment.
- 🎯 **Impact:** This change will ensure that whenever a user starts up a new instance on platforms like Colab, they won't have `wandb` installed by default, potentially avoiding version mismatches and streamlining the setup process. Users looking to use `wandb` will need to reinstall it, which could add an extra step, but ensures that they have the latest and compatible version.