### PR TITLE
remove objects with iscrowd=True in Objects365

### DIFF
--- a/data/Objects365.yaml
+++ b/data/Objects365.yaml
@@ -428,7 +428,7 @@ download: |
               path = Path(im["file_name"])  # image filename
               try:
                   with open(labels / path.with_suffix('.txt').name, 'a') as file:
-                      annIds = coco.getAnnIds(imgIds=im["id"], catIds=catIds, iscrowd=None)
+                      annIds = coco.getAnnIds(imgIds=im["id"], catIds=catIds, iscrowd=False)
                       for a in coco.loadAnns(annIds):
                           x, y, w, h = a['bbox']  # bounding box in xywh (xy top-left corner)
                           xyxy = np.array([x, y, x + w, y + h])[None]  # pixels(1,4)


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ff08404</samp>

### Summary
🚫📈🎯

<!--
1.  🚫 - This emoji means "no" or "prohibited", and it can be used to indicate that the `iscrowd` parameter was changed to exclude crowd annotations.
2.  📈 - This emoji means "increase" or "improve", and it can be used to indicate that the change improves the quality of the labels for the object detection task.
3.  🎯 - This emoji means "target" or "goal", and it can be used to indicate that the change was made in the context of a specific dataset and format conversion.
-->
Filter out crowd annotations from Objects365 dataset. This improves label quality and model performance for object detection with `coco.getAnnIds(iscrowd=False)` in `data/Objects365.yaml`.

> _`iscrowd` is false_
> _Filter out crowd annotations_
> _Winter of objects_

### Walkthrough
*  Filter out crowd annotations from Objects365 dataset (`[link](https://github.com/ultralytics/yolov5/pull/11788/files?diff=unified&w=0#diff-a54e9eb40255f0afce61a0d2d0b7c39d90296c11a3bb30c17241dc339fc31742L431-R431)`). This improves the label quality for object detection models and avoids counting crowd regions as false positives.



according to coco.py in pycocotools:
```
        if not iscrowd == None:
            ids = [ann['id'] for ann in anns if ann['iscrowd'] == iscrowd]
        else:
            ids = [ann['id'] for ann in anns]
```

here we should set iscrowd=False to remove the crowd annotations as stated in
https://github.com/ultralytics/yolov5/issues/3392#issuecomment-873578434

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved annotation filtering in Objects365 dataset configuration.

### 📊 Key Changes
- Changed the parameter `iscrowd` from `None` to `False` in `getAnnIds` function call within Objects365 dataset YAML file.

### 🎯 Purpose & Impact
- 🎨 **Purpose**: To refine the selection of annotations by excluding 'crowd' annotations when creating label files.
- 🌐 **Impact**: This ensures that models trained using the Objects365 dataset will no longer use crowded bounding boxes, potentially improving detection quality by focusing on more distinct object instances. Users should experience performance boosts and more accurate training results.