### PR TITLE
add non-fixed path option to coco's instances_val2017.json

### DIFF
--- a/val.py
+++ b/val.py
@@ -304,6 +304,8 @@ def run(
     if save_json and len(jdict):
         w = Path(weights[0] if isinstance(weights, list) else weights).stem if weights is not None else ''  # weights
         anno_json = str(Path('../datasets/coco/annotations/instances_val2017.json'))  # annotations
+        if not os.path.exists(anno_json):
+            anno_json = os.path.join(data['path'], 'annotations', 'instances_val2017.json')
         pred_json = str(save_dir / f'{w}_predictions.json')  # predictions
         LOGGER.info(f'\nEvaluating pycocotools mAP... saving {pred_json}...')
         with open(pred_json, 'w') as f:


### PR DESCRIPTION
Very small fix without which I have an error at the end of each training session
`[Errno 2] No such file or directory: '../datasets/coco/annotations/instances_val2017.json`


<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 123b23d</samp>

### Summary
🛠️🗂️🐛

<!--
1.  🛠️ - This emoji represents a tool or a fix, and it can be used to indicate that the change improves the functionality or reliability of the code.
2.  🗂️ - This emoji represents a file folder or an archive, and it can be used to indicate that the change involves the organization or location of files or data.
3.  🐛 - This emoji represents a bug or an error, and it can be used to indicate that the change fixes a problem or a mistake in the code.
-->
The pull request improves the annotation file handling for the COCO validation dataset in `val.py`. It adds a fallback option to look for the file in the `annotations` subfolder if it is not found in the image folder.

> _`annotation` path_
> _not always where expected_
> _try `annotations`_

### Walkthrough
* Add a fallback option for the COCO annotation file path ([link](https://github.com/ultralytics/yolov5/pull/11860/files?diff=unified&w=0#diff-9d519d95d7e57936997ef1b72f9cb5ade1003df487f612dfaf5427bda532830fR307-R308) in `val.py`)




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced flexibility in locating annotation files for COCO dataset evaluation.

### 📊 Key Changes
- Added a check to determine if the default COCO annotation file path exists.
- If the default path is not found, the code now looks for the annotation file within a directory specified in the dataset configuration.

### 🎯 Purpose & Impact
- **Purpose:** The change ensures that the evaluation script can adapt to different file structures, making it easier for users to use custom paths for their datasets without manual code modifications.
- **Impact:** Users with non-standard dataset installations can now run evaluations without encountering file not found errors, streamlining the validation process of object detection models trained with YOLOv5. 🔄💡