### PR TITLE
Fix the bug that multi webcam detection failed with OpenVINO

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -134,8 +134,7 @@ def run(
                     if pred is None:
                         pred = model(image, augment=augment, visualize=visualize).unsqueeze(0)
                     else:
-                        pred = torch.cat((pred, model(
-                            image, augment=augment, visualize=visualize).unsqueeze(0)), dim=0)
+                        pred = torch.cat((pred, model(image, augment=augment, visualize=visualize).unsqueeze(0)), dim=0)
                 pred = [pred, None]
             else:
                 pred = model(im, augment=augment, visualize=visualize)

--- a/detect.py
+++ b/detect.py
@@ -122,12 +122,23 @@ def run(
             im /= 255  # 0 - 255 to 0.0 - 1.0
             if len(im.shape) == 3:
                 im = im[None]  # expand for batch dim
+            if model.xml and im.shape[0] > 1:
+                ims = torch.chunk(im, im.shape[0], 0)
 
         # Inference
         with dt[1]:
             visualize = increment_path(save_dir / Path(path).stem, mkdir=True) if visualize else False
-            pred = model(im, augment=augment, visualize=visualize)
-
+            if model.xml and im.shape[0] > 1:
+                pred = None
+                for image in ims:
+                    if pred is None:
+                        pred = model(image, augment=augment, visualize=visualize).unsqueeze(0)
+                    else:
+                        pred = torch.cat((pred, model(
+                            image, augment=augment, visualize=visualize).unsqueeze(0)), dim=0)
+                pred = [pred, None]
+            else:
+                pred = model(im, augment=augment, visualize=visualize)
         # NMS
         with dt[2]:
             pred = non_max_suppression(pred, conf_thres, iou_thres, classes, agnostic_nms, max_det=max_det)


### PR DESCRIPTION
It would failed with the following error when detect multi webcam. 
"Input blob size is not equal network input size (2457600!=1228800)"

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f03d467</samp>

### Summary
📄🖼️🔮

<!--
1.  📄 - This emoji represents XML files or documents, which are the format of the models that this change supports.
2.  🖼️ - This emoji represents images, which are the input and output of the inference process. The change affects how images are processed depending on their batch dimension and model type.
3.  🔮 - This emoji represents prediction or inference, which is the main function of the `run` function. The change modifies how prediction is performed for different models and inputs.
-->
Add support for XML models in `detect.py`. Split and merge input images if needed for single-image inference.

> _`run` can handle XML_
> _split and infer single-image_
> _autumn leaves fall fast_

### Walkthrough
*  Add support for XML models that require single-image inference ([link](https://github.com/ultralytics/yolov5/pull/11935/files?diff=unified&w=0#diff-278fcc604176ae58c274067af877efa53ef921d4d410de5e8cd8e5a019286e39L125-R141))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced support for batch processing in YOLOv5 inference when using specific model formats.

### 📊 Key Changes
- Added condition to check if the input model format is `.xml` and the input image batch size is greater than 1.
- Implemented chunking of the input image tensor into individual images for sequential processing.
- Changed the model prediction step to handle each image separately for `.xml` model formats when batch size is greater than 1.
- Assembled individual predictions into a single batch after processing.

### 🎯 Purpose & Impact
- 🎨 Improves compatibility with `.xml` model formats that may not support batch inference.
- 🚀 Enables correct inference by processing each image in a sequence rather than as a batch for specific models.
- 🔍 Ensures users can still leverage batch-processing benefits for other formats, while providing a workaround for `.xml` formatted models.
- 🛠 Potentially increases inference time for `.xml` models with batches but ensures functional and accurate predictions.