### PR TITLE
Update selectable device Profile

### DIFF
--- a/classify/predict.py
+++ b/classify/predict.py
@@ -106,7 +106,7 @@ def run(
 
     # Run inference
     model.warmup(imgsz=(1 if pt else bs, 3, *imgsz))  # warmup
-    seen, windows, dt = 0, [], (Profile(), Profile(), Profile())
+    seen, windows, dt = 0, [], (Profile(device=device), Profile(device=device), Profile(device=device))
     for path, im, im0s, vid_cap, s in dataset:
         with dt[0]:
             im = torch.Tensor(im).to(model.device)

--- a/classify/val.py
+++ b/classify/val.py
@@ -97,7 +97,7 @@ def run(
                                                       workers=workers)
 
     model.eval()
-    pred, targets, loss, dt = [], [], 0, (Profile(), Profile(), Profile())
+    pred, targets, loss, dt = [], [], 0, (Profile(device=device), Profile(device=device), Profile(device=device))
     n = len(dataloader)  # number of batches
     action = 'validating' if dataloader.dataset.root.stem == 'val' else 'testing'
     desc = f'{pbar.desc[:-36]}{action:>36}' if pbar else f'{action}'

--- a/detect.py
+++ b/detect.py
@@ -116,7 +116,7 @@ def run(
 
     # Run inference
     model.warmup(imgsz=(1 if pt or model.triton else bs, 3, *imgsz))  # warmup
-    seen, windows, dt = 0, [], (Profile(), Profile(), Profile())
+    seen, windows, dt = 0, [], (Profile(device=device), Profile(device=device), Profile(device=device))
     for path, im, im0s, vid_cap, s in dataset:
         with dt[0]:
             im = torch.from_numpy(im).to(model.device)

--- a/segment/predict.py
+++ b/segment/predict.py
@@ -117,7 +117,7 @@ def run(
 
     # Run inference
     model.warmup(imgsz=(1 if pt else bs, 3, *imgsz))  # warmup
-    seen, windows, dt = 0, [], (Profile(), Profile(), Profile())
+    seen, windows, dt = 0, [], (Profile(device=device), Profile(device=device), Profile(device=device))
     for path, im, im0s, vid_cap, s in dataset:
         with dt[0]:
             im = torch.from_numpy(im).to(model.device)

--- a/segment/val.py
+++ b/segment/val.py
@@ -233,7 +233,7 @@ def run(
     class_map = coco80_to_coco91_class() if is_coco else list(range(1000))
     s = ('%22s' + '%11s' * 10) % ('Class', 'Images', 'Instances', 'Box(P', 'R', 'mAP50', 'mAP50-95)', 'Mask(P', 'R',
                                   'mAP50', 'mAP50-95)')
-    dt = Profile(), Profile(), Profile()
+    dt = Profile(device=device), Profile(device=device), Profile(device=device)
     metrics = Metrics()
     loss = torch.zeros(4, device=device)
     jdict, stats = [], []

--- a/utils/general.py
+++ b/utils/general.py
@@ -182,9 +182,10 @@ CONFIG_DIR = user_config_dir()  # Ultralytics settings dir
 
 class Profile(contextlib.ContextDecorator):
     # YOLOv5 Profile class. Usage: @Profile() decorator or 'with Profile():' context manager
-    def __init__(self, t=0.0):
+    def __init__(self, t=0.0, device: torch.device = None):
         self.t = t
-        self.cuda = torch.cuda.is_available()
+        self.device = device
+        self.cuda = True if (device and str(device)[:4] == "cuda") else False
 
     def __enter__(self):
         self.start = self.time()
@@ -196,7 +197,7 @@ class Profile(contextlib.ContextDecorator):
 
     def time(self):
         if self.cuda:
-            torch.cuda.synchronize()
+            torch.cuda.synchronize(self.device)
         return time.time()
 
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -185,7 +185,7 @@ class Profile(contextlib.ContextDecorator):
     def __init__(self, t=0.0, device: torch.device = None):
         self.t = t
         self.device = device
-        self.cuda = True if (device and str(device)[:4] == "cuda") else False
+        self.cuda = True if (device and str(device)[:4] == 'cuda') else False
 
     def __enter__(self):
         self.start = self.time()

--- a/val.py
+++ b/val.py
@@ -190,7 +190,7 @@ def run(
     class_map = coco80_to_coco91_class() if is_coco else list(range(1000))
     s = ('%22s' + '%11s' * 6) % ('Class', 'Images', 'Instances', 'P', 'R', 'mAP50', 'mAP50-95')
     tp, fp, p, r, f1, mp, mr, map50, ap50, map = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
-    dt = Profile(), Profile(), Profile()  # profiling times
+    dt = Profile(device=device), Profile(device=device), Profile(device=device)  # profiling times
     loss = torch.zeros(3, device=device)
     jdict, stats, ap, ap_class = [], [], [], []
     callbacks.run('on_val_start')


### PR DESCRIPTION
<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

When model using device ```cuda:1``` or ```cuda:2``` or whatever (Anyway, it's not ```cuda:0```) to inference model , ```Profile``` just occupy ```cuda:0``` GPU memory forever. Found Pytorch documentation that ```torch.cuda.synchronize``` can select device. So ```torch.cuda.synchronize``` maybe use ```cuda:0``` by default when the parameter is ```None```.

After experiment, GPU memory no longer just occupies ```cuda:0``` forever.

The code which using ```Profile``` has been changed, but there are still 2 places ( [export.py #L124](https://github.com/ultralytics/yolov5/blob/84ec8b586bd1c696f4bbf139e844a11d219f2711/export.py#L124), [models/common.py #L680](https://github.com/ultralytics/yolov5/blob/84ec8b586bd1c696f4bbf139e844a11d219f2711/models/common.py#L680) ) have not been modified due to my uncertainty. I guess it should also be possible to pass in parameters ```model.device```.


```python
class Profile(contextlib.ContextDecorator):
    # YOLOv5 Profile class. Usage: @Profile() decorator or 'with Profile():' context manager
    def __init__(self, t=0.0, device: torch.device = None):
        self.t = t
        self.device = device
        self.cuda = True if (device and str(device)[:4] == "cuda") else False

    def __enter__(self):
        self.start = self.time()
        return self

    def __exit__(self, type, value, traceback):
        self.dt = self.time() - self.start  # delta-time
        self.t += self.dt  # accumulate dt

    def time(self):
        if self.cuda:
            torch.cuda.synchronize(self.device)
        return time.time()
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR enhances profiling by incorporating device specificity in performance measurements.

### 📊 Key Changes
- `Profile` class now accepts an optional `device` argument to enable device-specific synchronization.
- All instances of the `Profile` class are now instantiated with the `device` parameter.

### 🎯 Purpose & Impact
- 🎯 **Purpose**: To provide more accurate performance profiling depending on whether the code runs on CPU or a specific GPU.
- 💡 **Impact**: Users can expect more precise measurement of code execution times, especially when using multiple GPUs, leading to better debugging and optimization of model inference and validation.