### PR TITLE
Passing input channels to Model constructor instead of hardcoding the value

### DIFF
--- a/models/yolov5l.yaml
+++ b/models/yolov5l.yaml
@@ -1,6 +1,7 @@
 # YOLOv5 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
+input_channels: 3  # number of input channels, RGB is 3
 nc: 80  # number of classes
 depth_multiple: 1.0  # model depth multiple
 width_multiple: 1.0  # layer channel multiple

--- a/models/yolov5m.yaml
+++ b/models/yolov5m.yaml
@@ -1,6 +1,7 @@
 # YOLOv5 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
+input_channels: 3  # number of input channels, RGB is 3
 nc: 80  # number of classes
 depth_multiple: 0.67  # model depth multiple
 width_multiple: 0.75  # layer channel multiple

--- a/models/yolov5n.yaml
+++ b/models/yolov5n.yaml
@@ -1,6 +1,7 @@
 # YOLOv5 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
+input_channels: 3  # number of input channels, RGB is 3
 nc: 80  # number of classes
 depth_multiple: 0.33  # model depth multiple
 width_multiple: 0.25  # layer channel multiple

--- a/models/yolov5s.yaml
+++ b/models/yolov5s.yaml
@@ -1,6 +1,7 @@
 # YOLOv5 🚀 by Ultralytics, AGPL-3.0 license
 
 # Parameters
+input_channels: 3  # number of input channels, RGB is 3
 nc: 80  # number of classes
 depth_multiple: 0.33  # model depth multiple
 width_multiple: 0.50  # layer channel multiple

--- a/train.py
+++ b/train.py
@@ -127,14 +127,14 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
         with torch_distributed_zero_first(LOCAL_RANK):
             weights = attempt_download(weights)  # download if not found locally
         ckpt = torch.load(weights, map_location='cpu')  # load checkpoint to CPU to avoid CUDA memory leak
-        model = Model(cfg or ckpt['model'].yaml, ch=hyp.get('ch', 3), nc=nc, anchors=hyp.get('anchors')).to(device)  # create
+        model = Model(cfg or ckpt['model'].yaml, ch=hyp.get('input_channels', 3), nc=nc, anchors=hyp.get('anchors')).to(device)  # create
         exclude = ['anchor'] if (cfg or hyp.get('anchors')) and not resume else []  # exclude keys
         csd = ckpt['model'].float().state_dict()  # checkpoint state_dict as FP32
         csd = intersect_dicts(csd, model.state_dict(), exclude=exclude)  # intersect
         model.load_state_dict(csd, strict=False)  # load
         LOGGER.info(f'Transferred {len(csd)}/{len(model.state_dict())} items from {weights}')  # report
     else:
-        model = Model(cfg, ch=hyp.get('ch', 3), nc=nc, anchors=hyp.get('anchors')).to(device)  # create
+        model = Model(cfg, ch=hyp.get('input_channels', 3), nc=nc, anchors=hyp.get('anchors')).to(device)  # create
     amp = check_amp(model)  # check AMP
 
     # Freeze

--- a/train.py
+++ b/train.py
@@ -127,14 +127,14 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
         with torch_distributed_zero_first(LOCAL_RANK):
             weights = attempt_download(weights)  # download if not found locally
         ckpt = torch.load(weights, map_location='cpu')  # load checkpoint to CPU to avoid CUDA memory leak
-        model = Model(cfg or ckpt['model'].yaml, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
+        model = Model(cfg or ckpt['model'].yaml, ch=hyp.get('ch', 3), nc=nc, anchors=hyp.get('anchors')).to(device)  # create
         exclude = ['anchor'] if (cfg or hyp.get('anchors')) and not resume else []  # exclude keys
         csd = ckpt['model'].float().state_dict()  # checkpoint state_dict as FP32
         csd = intersect_dicts(csd, model.state_dict(), exclude=exclude)  # intersect
         model.load_state_dict(csd, strict=False)  # load
         LOGGER.info(f'Transferred {len(csd)}/{len(model.state_dict())} items from {weights}')  # report
     else:
-        model = Model(cfg, ch=3, nc=nc, anchors=hyp.get('anchors')).to(device)  # create
+        model = Model(cfg, ch=hyp.get('ch', 3), nc=nc, anchors=hyp.get('anchors')).to(device)  # create
     amp = check_amp(model)  # check AMP
 
     # Freeze

--- a/train.py
+++ b/train.py
@@ -127,7 +127,8 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
         with torch_distributed_zero_first(LOCAL_RANK):
             weights = attempt_download(weights)  # download if not found locally
         ckpt = torch.load(weights, map_location='cpu')  # load checkpoint to CPU to avoid CUDA memory leak
-        model = Model(cfg or ckpt['model'].yaml, ch=hyp.get('input_channels', 3), nc=nc, anchors=hyp.get('anchors')).to(device)  # create
+        model = Model(cfg or ckpt['model'].yaml, ch=hyp.get('input_channels', 3), nc=nc,
+                      anchors=hyp.get('anchors')).to(device)  # create
         exclude = ['anchor'] if (cfg or hyp.get('anchors')) and not resume else []  # exclude keys
         csd = ckpt['model'].float().state_dict()  # checkpoint state_dict as FP32
         csd = intersect_dicts(csd, model.state_dict(), exclude=exclude)  # intersect


### PR DESCRIPTION
Passing number of channels in input as a part of the config (defaults back to 3) when creating the Model object in train.py
I was working on a yolo model that will take as input images that are not necessarily RGB - and while coding around i noticed that you hardcode the value of number of input channels.
I think it is better practice/prettier code if you define the number of input channels in a .yaml file and then load that value while creating the model. The way i do it in this PR is that i define input_channels: 3 in the hyperparameter file.

An alternative method could be that you detect the number of channels in the dataset, but i think that might be a bit overkill/inconsistent.

I am interested in hearing your opinions/suggestions about improving this method of defining the numbers of channels in a .yaml

thanks to @akx for suggesting defaulting number of channels to 3 for backwards compatibility in the [first PR ](https://github.com/ultralytics/yolov5/pull/10976)

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0acac83</samp>

### Summary
🎛️🌈🚀

<!--
1.  🎛️ - This emoji represents the addition of a new parameter that can be adjusted by the user, such as input_channels. It can also imply customization and flexibility of the model.
2.  🌈 - This emoji represents the support for different types of input data, such as RGB, grayscale, or multispectral images. It can also imply diversity and variety of the model.
3.  🚀 - This emoji represents the improvement of the model performance and speed, as the user can choose the optimal number of input channels for their data. It can also imply innovation and advancement of the model.
-->
This pull request adds a new parameter `input_channels` to the YAML files of the YOLOv5 models, which allows the user to customize the number of input channels for different types of data. It also modifies the `train` function in `train.py` to use the value of `input_channels` from the YAML files instead of a hard-coded value.

> _Sing, O Muse, of the skillful code review_
> _That added a new parameter to the YAML files_
> _Of the swift and powerful YOLOv5 models_
> _That detect objects with keen eyes and many channels_

### Walkthrough
*  Add `input_channels` parameter to YAML files of YOLOv5 models, which allows the user to customize the number of input channels for different types of data ([link](https://github.com/ultralytics/yolov5/pull/12382/files?diff=unified&w=0#diff-d67e269730c91c93c44b5316b26346fb0b835e61f1ac52b587edcc05e519abc7R4), [link](https://github.com/ultralytics/yolov5/pull/12382/files?diff=unified&w=0#diff-fab8bc462352ed71b5229100f799629e05a8990b19a4bc4eca2c0570167fe46fR4), [link](https://github.com/ultralytics/yolov5/pull/12382/files?diff=unified&w=0#diff-16dd0f10664a75cc5fb6fc01a014b64b023f1bf90a5b8f9abbce6c1bfe7fafeeR4), [link](https://github.com/ultralytics/yolov5/pull/12382/files?diff=unified&w=0#diff-7b31b326c81479708e6ca5235d213a565cd8e3ea8cfe1e70b78e488aa529f491R4))
*  Modify `train` function in `train.py` to use `input_channels` value from `hyp` dictionary instead of hard-coded 3, and add default value of 3 in case the key is not present. This makes the function compatible with the new parameter and enables training with different input channels ([link](https://github.com/ultralytics/yolov5/pull/12382/files?diff=unified&w=0#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L130-R130), [link](https://github.com/ultralytics/yolov5/pull/12382/files?diff=unified&w=0#diff-ed183d67207df065a11e1289f19d34cc2abbc5448dea952683cfe9728c342b95L137-R137))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 📊 Key Changes
- Added a new configuration parameter `input_channels` in various YOLOv5 model configuration files (yolov5s.yaml, yolov5m.yaml, yolov5l.yaml, yolov5n.yaml).
- Updated the `train.py` script to use the `input_channels` parameter from hyperparameters (`hyp`) instead of hardcoding it to 3.

### 🎯 Purpose & Impact
- The purpose is to make the number of input channels configurable, allowing the model to support different types of input (e.g., grayscale images, which have only 1 channel, or multispectral images with more than 3 channels). 🛠️
- This change increases flexibility and makes YOLOv5 more adaptable to various computer vision tasks with inputs beyond the standard RGB images. 🌈

### 🌟 Summary
Enabled dynamic configuration of input channels in YOLOv5 for greater flexibility in handling images with different numbers of channels. 🔄