### PR TITLE
Limit tensorflow version and add checks

### DIFF
--- a/export.py
+++ b/export.py
@@ -397,6 +397,11 @@ def export_saved_model(model,
     from models.tf import TFModel
 
     LOGGER.info(f'\n{prefix} starting export with tensorflow {tf.__version__}...')
+    check_version(tf.__version__,
+                   '<=2.13.1',
+                    name='tensorflow',
+                    verbose=True,
+                    msg='https://github.com/ultralytics/yolov5/issues/12489')
     f = str(file).replace('.pt', '_saved_model')
     batch_size, ch, *imgsz = list(im.shape)  # BCHW
 

--- a/export.py
+++ b/export.py
@@ -398,10 +398,10 @@ def export_saved_model(model,
 
     LOGGER.info(f'\n{prefix} starting export with tensorflow {tf.__version__}...')
     check_version(tf.__version__,
-                   '<=2.13.1',
-                    name='tensorflow',
-                    verbose=True,
-                    msg='https://github.com/ultralytics/yolov5/issues/12489')
+                  '<=2.13.1',
+                  name='tensorflow',
+                  verbose=True,
+                  msg='https://github.com/ultralytics/yolov5/issues/12489')
     f = str(file).replace('.pt', '_saved_model')
     batch_size, ch, *imgsz = list(im.shape)  # BCHW
 

--- a/export.py
+++ b/export.py
@@ -397,9 +397,11 @@ def export_saved_model(model,
     from models.tf import TFModel
 
     LOGGER.info(f'\n{prefix} starting export with tensorflow {tf.__version__}...')
-    if tf.__version__>'2.13.1':
-        helper_url = "https://github.com/ultralytics/yolov5/issues/12489"
-        LOGGER.info(f'WARNING ⚠️ using Tensorflow {tf.__version__} > 2.13.1 might cause issue when exporting the model to tflite {helper_url}') #handling issue https://github.com/ultralytics/yolov5/issues/12489
+    if tf.__version__ > '2.13.1':
+        helper_url = 'https://github.com/ultralytics/yolov5/issues/12489'
+        LOGGER.info(
+            f'WARNING ⚠️ using Tensorflow {tf.__version__} > 2.13.1 might cause issue when exporting the model to tflite {helper_url}'
+        )  #handling issue https://github.com/ultralytics/yolov5/issues/12489
     f = str(file).replace('.pt', '_saved_model')
     batch_size, ch, *imgsz = list(im.shape)  # BCHW
 

--- a/export.py
+++ b/export.py
@@ -397,11 +397,9 @@ def export_saved_model(model,
     from models.tf import TFModel
 
     LOGGER.info(f'\n{prefix} starting export with tensorflow {tf.__version__}...')
-    check_version(tf.__version__,
-                   '<=2.13.1',
-                    name='tensorflow',
-                    verbose=True,
-                    msg='https://github.com/ultralytics/yolov5/issues/12489')
+    if tf.__version__>'2.13.1':
+        helper_url = "https://github.com/ultralytics/yolov5/issues/12489"
+        LOGGER.info(f'WARNING ⚠️ using Tensorflow {tf.__version__} > 2.13.1 might cause issue when exporting the model to tflite {helper_url}') #handling issue https://github.com/ultralytics/yolov5/issues/12489
     f = str(file).replace('.pt', '_saved_model')
     batch_size, ch, *imgsz = list(im.shape)  # BCHW
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ seaborn>=0.11.0
 # nvidia-pyindex  # TensorRT export
 # nvidia-tensorrt  # TensorRT export
 # scikit-learn<=1.1.2  # CoreML quantization
-# tensorflow>=2.4.0  # TF exports (-cpu, -aarch64, -macos)
+# tensorflow>=2.4.0,<=2.13.1  # TF exports (-cpu, -aarch64, -macos)
 # tensorflowjs>=3.9.0  # TF.js export
 # openvino-dev>=2023.0  # OpenVINO export
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -386,11 +386,11 @@ def check_python(minimum='3.8.0'):
     check_version(platform.python_version(), minimum, name='Python ', hard=True)
 
 
-def check_version(current='0.0.0', minimum='0.0.0', name='version ', pinned=False, hard=False, verbose=False):
+def check_version(current='0.0.0', minimum='0.0.0', name='version ', pinned=False, hard=False, verbose=False, msg=''):
     # Check version vs. required version
     current, minimum = (pkg.parse_version(x) for x in (current, minimum))
     result = (current == minimum) if pinned else (current >= minimum)  # bool
-    s = f'WARNING ⚠️ {name}{minimum} is required by YOLOv5, but {name}{current} is currently installed'  # string
+    s = f'WARNING ⚠️ {name}{minimum} is required by YOLOv5, but {name}{current} is currently installed {msg}'  # string
     if hard:
         assert result, emojis(s)  # assert min requirements met
     if verbose and not result:

--- a/utils/general.py
+++ b/utils/general.py
@@ -386,11 +386,11 @@ def check_python(minimum='3.8.0'):
     check_version(platform.python_version(), minimum, name='Python ', hard=True)
 
 
-def check_version(current='0.0.0', minimum='0.0.0', name='version ', pinned=False, hard=False, verbose=False, msg=''):
+def check_version(current='0.0.0', minimum='0.0.0', name='version ', pinned=False, hard=False, verbose=False):
     # Check version vs. required version
     current, minimum = (pkg.parse_version(x) for x in (current, minimum))
     result = (current == minimum) if pinned else (current >= minimum)  # bool
-    s = f'WARNING ⚠️ {name}{minimum} is required by YOLOv5, but {name}{current} is currently installed {msg}'  # string
+    s = f'WARNING ⚠️ {name}{minimum} is required by YOLOv5, but {name}{current} is currently installed'  # string
     if hard:
         assert result, emojis(s)  # assert min requirements met
     if verbose and not result:


### PR DESCRIPTION
Exporting to tflite format fails when the activation function is a leakyReLU / ReLU.

The bug was reported here: https://github.com/ultralytics/yolov5/issues/12489
The problem seems to be with the tensorflow version, that has to be <=2.13.1
The other repository (https://github.com/ultralytics/ultralytics) have had a similar patch https://github.com/ultralytics/ultralytics/pull/6466 
I am applying the same here to constraint tensorflow version.


copilot:all


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adjustment to TensorFlow compatibility in YOLOv5 export functionality.

### 📊 Key Changes
- Added a version check in `export.py` to advise on a known issue for TensorFlow versions greater than 2.13.1.
- Updated the `requirements.txt` file to restrict TensorFlow version to 2.4.0 or above and up to 2.13.1.

### 🎯 Purpose & Impact
- Ensures users are aware of potential problems when exporting models with TensorFlow versions newer than 2.13.1. 🛠️
- Prevents installation of incompatible TensorFlow versions that could cause export issues, enhancing stability and user experience. 🧰
- Users running `yolov5` exports with TensorFlow will have a smoother experience with controlled version compatibility. ✅