### PR TITLE
Parametrize multiple of number of channels in Conv

### DIFF
--- a/models/tf.py
+++ b/models/tf.py
@@ -380,9 +380,11 @@ class TFConcat(keras.layers.Layer):
 
 def parse_model(d, ch, model, imgsz):  # model_dict, input_channels(3)
     LOGGER.info(f"\n{'':>3}{'from':>18}{'n':>3}{'params':>10}  {'module':<40}{'arguments':<30}")
-    anchors, nc, gd, gw = d['anchors'], d['nc'], d['depth_multiple'], d['width_multiple']
+    anchors, nc, gd, gw, ch_mul = d['anchors'], d['nc'], d['depth_multiple'], d['width_multiple'], d['channel_multiple']
     na = (len(anchors[0]) // 2) if isinstance(anchors, list) else anchors  # number of anchors
     no = na * (nc + 5)  # number of outputs = anchors * (classes + 5)
+    if not ch_mul:
+        ch_mul = 8
 
     layers, save, c2 = [], [], ch[-1]  # layers, savelist, ch out
     for i, (f, n, m, args) in enumerate(d['backbone'] + d['head']):  # from, number, module, args
@@ -399,7 +401,7 @@ def parse_model(d, ch, model, imgsz):  # model_dict, input_channels(3)
                 nn.Conv2d, Conv, DWConv, DWConvTranspose2d, Bottleneck, SPP, SPPF, MixConv2d, Focus, CrossConv,
                 BottleneckCSP, C3, C3x]:
             c1, c2 = ch[f], args[0]
-            c2 = make_divisible(c2 * gw, 8) if c2 != no else c2
+            c2 = make_divisible(c2 * gw, ch_mul) if c2 != no else c2
 
             args = [c1, c2, *args[1:]]
             if m in [BottleneckCSP, C3, C3x]:
@@ -414,7 +416,7 @@ def parse_model(d, ch, model, imgsz):  # model_dict, input_channels(3)
             if isinstance(args[1], int):  # number of anchors
                 args[1] = [list(range(args[1] * 2))] * len(f)
             if m is Segment:
-                args[3] = make_divisible(args[3] * gw, 8)
+                args[3] = make_divisible(args[3] * gw, ch_mul)
             args.append(imgsz)
         else:
             c2 = ch[f]

--- a/models/tf.py
+++ b/models/tf.py
@@ -380,7 +380,8 @@ class TFConcat(keras.layers.Layer):
 
 def parse_model(d, ch, model, imgsz):  # model_dict, input_channels(3)
     LOGGER.info(f"\n{'':>3}{'from':>18}{'n':>3}{'params':>10}  {'module':<40}{'arguments':<30}")
-    anchors, nc, gd, gw, ch_mul = d['anchors'], d['nc'], d['depth_multiple'], d['width_multiple'], d.get('channel_multiple')
+    anchors, nc, gd, gw, ch_mul = d['anchors'], d['nc'], d['depth_multiple'], d['width_multiple'], d.get(
+        'channel_multiple')
     na = (len(anchors[0]) // 2) if isinstance(anchors, list) else anchors  # number of anchors
     no = na * (nc + 5)  # number of outputs = anchors * (classes + 5)
     if not ch_mul:

--- a/models/tf.py
+++ b/models/tf.py
@@ -380,7 +380,7 @@ class TFConcat(keras.layers.Layer):
 
 def parse_model(d, ch, model, imgsz):  # model_dict, input_channels(3)
     LOGGER.info(f"\n{'':>3}{'from':>18}{'n':>3}{'params':>10}  {'module':<40}{'arguments':<30}")
-    anchors, nc, gd, gw, ch_mul = d['anchors'], d['nc'], d['depth_multiple'], d['width_multiple'], d['channel_multiple']
+    anchors, nc, gd, gw, ch_mul = d['anchors'], d['nc'], d['depth_multiple'], d['width_multiple'], d.get('channel_multiple')
     na = (len(anchors[0]) // 2) if isinstance(anchors, list) else anchors  # number of anchors
     no = na * (nc + 5)  # number of outputs = anchors * (classes + 5)
     if not ch_mul:

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -299,7 +299,8 @@ class ClassificationModel(BaseModel):
 def parse_model(d, ch):  # model_dict, input_channels(3)
     # Parse a YOLOv5 model.yaml dictionary
     LOGGER.info(f"\n{'':>3}{'from':>18}{'n':>3}{'params':>10}  {'module':<40}{'arguments':<30}")
-    anchors, nc, gd, gw, act, ch_mul = d['anchors'], d['nc'], d['depth_multiple'], d['width_multiple'], d.get('activation'), d.get('channel_multiple')
+    anchors, nc, gd, gw, act, ch_mul = d['anchors'], d['nc'], d['depth_multiple'], d['width_multiple'], d.get(
+        'activation'), d.get('channel_multiple')
     if act:
         Conv.default_act = eval(act)  # redefine default activation, i.e. Conv.default_act = nn.SiLU()
         LOGGER.info(f"{colorstr('activation:')} {act}")  # print

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -299,10 +299,12 @@ class ClassificationModel(BaseModel):
 def parse_model(d, ch):  # model_dict, input_channels(3)
     # Parse a YOLOv5 model.yaml dictionary
     LOGGER.info(f"\n{'':>3}{'from':>18}{'n':>3}{'params':>10}  {'module':<40}{'arguments':<30}")
-    anchors, nc, gd, gw, act = d['anchors'], d['nc'], d['depth_multiple'], d['width_multiple'], d.get('activation')
+    anchors, nc, gd, gw, act, ch_mul = d['anchors'], d['nc'], d['depth_multiple'], d['width_multiple'], d.get('activation'), d.get('channel_multiple')
     if act:
         Conv.default_act = eval(act)  # redefine default activation, i.e. Conv.default_act = nn.SiLU()
         LOGGER.info(f"{colorstr('activation:')} {act}")  # print
+    if not ch_mul:
+        ch_mul = 8
     na = (len(anchors[0]) // 2) if isinstance(anchors, list) else anchors  # number of anchors
     no = na * (nc + 5)  # number of outputs = anchors * (classes + 5)
 
@@ -319,7 +321,7 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
                 BottleneckCSP, C3, C3TR, C3SPP, C3Ghost, nn.ConvTranspose2d, DWConvTranspose2d, C3x}:
             c1, c2 = ch[f], args[0]
             if c2 != no:  # if not output
-                c2 = make_divisible(c2 * gw, 8)
+                c2 = make_divisible(c2 * gw, ch_mul)
 
             args = [c1, c2, *args[1:]]
             if m in {BottleneckCSP, C3, C3TR, C3Ghost, C3x}:
@@ -335,7 +337,7 @@ def parse_model(d, ch):  # model_dict, input_channels(3)
             if isinstance(args[1], int):  # number of anchors
                 args[1] = [list(range(args[1] * 2))] * len(f)
             if m is Segment:
-                args[3] = make_divisible(args[3] * gw, 8)
+                args[3] = make_divisible(args[3] * gw, ch_mul)
         elif m is Contract:
             c2 = ch[f] * args[0] ** 2
         elif m is Expand:


### PR DESCRIPTION
These minimal changes make it possible to parametrize what number the channels of convolutions should be divisible for.
It allows easier optimization of the model for hardware optimized for convolutions having channels non-multiple of 8.
The parameters can be configured in the .yaml file, and if not, they 8 is going to used as default.

Solves GitHub issue: https://github.com/ultralytics/yolov5/issues/12506

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cfa78b6</samp>

### Summary
🧮🔄🎛️

<!--
1.  🧮 - This emoji represents the introduction of a new parameter that affects the model calculations and dimensions.
2.  🔄 - This emoji represents the adaptation of an existing function from one framework to another, implying some modifications and adjustments.
3.  🎛️ - This emoji represents the support for variable channel multipliers, which allows for more flexibility and control over the model configuration.
-->
Add a new `ch_mul` parameter to the TensorFlow model in `models/tf.py` to allow customizing the channel size of the convolutional layers. Refactor the `parse_model` function to work with TensorFlow and variable channel multipliers.

> _Oh we're the TensorFlow crew and we've got a job to do_
> _We'll parse the model with `ch_mul` and make it run like new_
> _Heave away, me hearties, heave away with all your might_
> _We'll tune the convolutions till we get the best results tonight_

### Walkthrough
*  Add `ch_mul` parameter to control channel multiple for convolutional layers in TensorFlow-compatible YOLOv5 model ([link](https://github.com/ultralytics/yolov5/pull/12508/files?diff=unified&w=0#diff-8e25d6265fbd96f107ef99cdbbdef2848f4e700aecf9c2e7767d82838c9b2e52L383-R387), [link](https://github.com/ultralytics/yolov5/pull/12508/files?diff=unified&w=0#diff-2cd118cbb69c9ca7b5544f4187b11335fc3addbaf2c3c5bb45435cac648c957bL302-R307))
*  Use `ch_mul` parameter instead of hard-coded value of 8 in `make_divisible` function for rounding up channel numbers in `models/tf.py` ([link](https://github.com/ultralytics/yolov5/pull/12508/files?diff=unified&w=0#diff-8e25d6265fbd96f107ef99cdbbdef2848f4e700aecf9c2e7767d82838c9b2e52L402-R404), [link](https://github.com/ultralytics/yolov5/pull/12508/files?diff=unified&w=0#diff-8e25d6265fbd96f107ef99cdbbdef2848f4e700aecf9c2e7767d82838c9b2e52L417-R419), [link](https://github.com/ultralytics/yolov5/pull/12508/files?diff=unified&w=0#diff-2cd118cbb69c9ca7b5544f4187b11335fc3addbaf2c3c5bb45435cac648c957bL322-R324), [link](https://github.com/ultralytics/yolov5/pull/12508/files?diff=unified&w=0#diff-2cd118cbb69c9ca7b5544f4187b11335fc3addbaf2c3c5bb45435cac648c957bL338-R340))
*  Allow customization of channel multiple for semantic segmentation output in `Segment` module in `models/tf.py` ([link](https://github.com/ultralytics/yolov5/pull/12508/files?diff=unified&w=0#diff-8e25d6265fbd96f107ef99cdbbdef2848f4e700aecf9c2e7767d82838c9b2e52L417-R419), [link](https://github.com/ultralytics/yolov5/pull/12508/files?diff=unified&w=0#diff-2cd118cbb69c9ca7b5544f4187b11335fc3addbaf2c3c5bb45435cac648c957bL338-R340))




## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced flexibility in the channel width multiplier setting for YOLOv5 models.

### 📊 Key Changes
- 🛠 Introduced a new configuration parameter `channel_multiple` within the model configuration dictionaries.
- 🔄 Defaulted `channel_multiple` to 8 when it's not explicitly set in the configuration.

### 🎯 Purpose & Impact
- 👌 Allows for more granular control over channel width, which can lead to optimizations in model size and computational efficiency.
- 🤝 Non-specified `channel_multiple` will not break existing configurations, preserving backwards compatibility.
- 🏎 Potentially enhances model performance for different hardware constraints by fine-tuning channel widths.