### PR TITLE
Add option to quantize per-tensor

### DIFF
--- a/export.py
+++ b/export.py
@@ -443,7 +443,7 @@ def export_pb(keras_model, file, prefix=colorstr('TensorFlow GraphDef:')):
 
 
 @try_export
-def export_tflite(keras_model, im, file, int8, data, nms, agnostic_nms, prefix=colorstr('TensorFlow Lite:')):
+def export_tflite(keras_model, im, file, int8, per_tensor, data, nms, agnostic_nms, prefix=colorstr('TensorFlow Lite:')):
     # YOLOv5 TensorFlow Lite export
     import tensorflow as tf
 
@@ -464,6 +464,8 @@ def export_tflite(keras_model, im, file, int8, data, nms, agnostic_nms, prefix=c
         converter.inference_input_type = tf.uint8  # or tf.int8
         converter.inference_output_type = tf.uint8  # or tf.int8
         converter.experimental_new_quantizer = True
+        if per_tensor:
+            converter._experimental_disable_per_channel = True
         f = str(file).replace('.pt', '-int8.tflite')
     if nms or agnostic_nms:
         converter.target_spec.supported_ops.append(tf.lite.OpsSet.SELECT_TF_OPS)
@@ -708,6 +710,7 @@ def run(
         keras=False,  # use Keras
         optimize=False,  # TorchScript: optimize for mobile
         int8=False,  # CoreML/TF INT8 quantization
+        per_tensor=False, # TF per tensor quantization
         dynamic=False,  # ONNX/TF/TensorRT: dynamic axes
         simplify=False,  # ONNX: simplify model
         opset=12,  # ONNX: opset version
@@ -793,7 +796,7 @@ def run(
         if pb or tfjs:  # pb prerequisite to tfjs
             f[6], _ = export_pb(s_model, file)
         if tflite or edgetpu:
-            f[7], _ = export_tflite(s_model, im, file, int8 or edgetpu, data=data, nms=nms, agnostic_nms=agnostic_nms)
+            f[7], _ = export_tflite(s_model, im, file, int8 or edgetpu, per_tensor, data=data, nms=nms, agnostic_nms=agnostic_nms)
             if edgetpu:
                 f[8], _ = export_edgetpu(file)
             add_tflite_metadata(f[8] or f[7], metadata, num_outputs=len(s_model.outputs))
@@ -832,6 +835,7 @@ def parse_opt(known=False):
     parser.add_argument('--keras', action='store_true', help='TF: use Keras')
     parser.add_argument('--optimize', action='store_true', help='TorchScript: optimize for mobile')
     parser.add_argument('--int8', action='store_true', help='CoreML/TF/OpenVINO INT8 quantization')
+    parser.add_argument('--per-tensor', action='store_true', help='TF per-tensor quantization')
     parser.add_argument('--dynamic', action='store_true', help='ONNX/TF/TensorRT: dynamic axes')
     parser.add_argument('--simplify', action='store_true', help='ONNX: simplify model')
     parser.add_argument('--opset', type=int, default=17, help='ONNX: opset version')

--- a/export.py
+++ b/export.py
@@ -443,7 +443,8 @@ def export_pb(keras_model, file, prefix=colorstr('TensorFlow GraphDef:')):
 
 
 @try_export
-def export_tflite(keras_model, im, file, int8, per_tensor, data, nms, agnostic_nms, prefix=colorstr('TensorFlow Lite:')):
+def export_tflite(keras_model, im, file, int8, per_tensor, data, nms, agnostic_nms,
+                  prefix=colorstr('TensorFlow Lite:')):
     # YOLOv5 TensorFlow Lite export
     import tensorflow as tf
 
@@ -710,7 +711,7 @@ def run(
         keras=False,  # use Keras
         optimize=False,  # TorchScript: optimize for mobile
         int8=False,  # CoreML/TF INT8 quantization
-        per_tensor=False, # TF per tensor quantization
+        per_tensor=False,  # TF per tensor quantization
         dynamic=False,  # ONNX/TF/TensorRT: dynamic axes
         simplify=False,  # ONNX: simplify model
         opset=12,  # ONNX: opset version
@@ -796,7 +797,14 @@ def run(
         if pb or tfjs:  # pb prerequisite to tfjs
             f[6], _ = export_pb(s_model, file)
         if tflite or edgetpu:
-            f[7], _ = export_tflite(s_model, im, file, int8 or edgetpu, per_tensor, data=data, nms=nms, agnostic_nms=agnostic_nms)
+            f[7], _ = export_tflite(s_model,
+                                    im,
+                                    file,
+                                    int8 or edgetpu,
+                                    per_tensor,
+                                    data=data,
+                                    nms=nms,
+                                    agnostic_nms=agnostic_nms)
             if edgetpu:
                 f[8], _ = export_edgetpu(file)
             add_tflite_metadata(f[8] or f[7], metadata, num_outputs=len(s_model.outputs))


### PR DESCRIPTION
## Changes

Add a `--per-tensor` flag that allows quantizing the model when exporting per tensor instead of per channel.

## Motivation

The quantization type done by TensorFlow Lite Converter is called "Quantization by channels" (also sometimes called "Quantization by Axis"). With this type of quantization, each channel of a convolutional layer has its own quantization parameters.
This type of quantization is the standard in TensorFlow 2.x

Before that, in TF 1.x the standard was "Quantization by tensor" where all the channels of a layer were sharing the same quantization parameters.

Some ASICs (Deep Learning accelerators) are optimized for the quantization by tensor scheme. It would be nice to have a flag in the exporter to quantize by tensors instead of channels.

Solves: https://github.com/ultralytics/yolov5/issues/12515


copilot:all


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced TensorFlow Lite (TFLite) model quantization options in YOLOv5 export script.

### 📊 Key Changes
- Added a new `per_tensor` parameter to `export_tflite` function signature.
- Injected conditional logic to enable or disable per-channel quantization in TFLite conversion based on the `per_tensor` flag.
- Introduced the `--per-tensor` command line argument in the script to allow users to specify per-tensor quantization preference.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: This change gives users more control over the quantization process of TFLite models, particularly allowing a choice between per-tensor and per-channel quantization strategies.
- ✨ **Impact**: Users will have the flexibility to optimize their model's size and performance even further, which could be critical for deployment on resource-constrained devices that rely on TFLite models.