### PR TITLE
Fix save_period inconsistent definition

### DIFF
--- a/train.py
+++ b/train.py
@@ -393,7 +393,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                 torch.save(ckpt, last)
                 if best_fitness == fi:
                     torch.save(ckpt, best)
-                if opt.save_period > 0 and epoch % opt.save_period == 0:
+                if opt.save-period > 0 and epoch % opt.save-period == 0:
                     torch.save(ckpt, w / f'epoch{epoch}.pt')
                 del ckpt
                 callbacks.run('on_model_save', last, epoch, final_epoch, best_fitness, fi)

--- a/train.py
+++ b/train.py
@@ -393,7 +393,7 @@ def train(hyp, opt, device, callbacks):  # hyp is path/to/hyp.yaml or hyp dictio
                 torch.save(ckpt, last)
                 if best_fitness == fi:
                     torch.save(ckpt, best)
-                if opt.save-period > 0 and epoch % opt.save-period == 0:
+                if opt.save - period > 0 and epoch % opt.save - period == 0:
                     torch.save(ckpt, w / f'epoch{epoch}.pt')
                 del ckpt
                 callbacks.run('on_model_save', last, epoch, final_epoch, best_fitness, fi)


### PR DESCRIPTION
Fixed inconsistency between variable name in train.py and argument in parser. The train.py code uses save_period as a variable, but the parser defined save-period. This has been corrected by changing save-period to save-period in the line 'if opt.save-period > 0 and epoch % opt.save-period == 0:'

copilot:all


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved model checkpoint saving customization in `train.py` script.

### 📊 Key Changes
- Modified the `train.py` conditional check related to the model saving period.

### 🎯 Purpose & Impact
- **Purpose**: To correct the syntax error in the checkpoint saving condition.
- **Impact**: Users can now set custom intervals for saving model checkpoints during training, enhancing model management and potentially saving disk space and time. This update should improve the reliability of the training process.