### PR TITLE
fix 'NotImplementedError: cannot instantiate 'PosixPath' on your system' error for windows

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -34,10 +34,11 @@ import os
 import platform
 import sys
 from pathlib import Path
-import pathlib # added for Windows compatibility
-pathlib.PosixPath = pathlib.WindowsPath # and fix "NotImplementedError: cannot instantiate 'PosixPath' on your system" error
-import torch
+# import pathlib # # uncomment if you are using windows
+# fix "NotImplementedError: cannot instantiate 'PosixPath' on your system" error for windows
 
+# pathlib.PosixPath = pathlib.WindowsPath # uncomment if you are using windows
+import torch
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:

--- a/detect.py
+++ b/detect.py
@@ -34,7 +34,8 @@ import os
 import platform
 import sys
 from pathlib import Path
-
+import pathlib # added for Windows compatibility
+pathlib.PosixPath = pathlib.WindowsPath # and fix "NotImplementedError: cannot instantiate 'PosixPath' on your system" error
 import torch
 
 FILE = Path(__file__).resolve()

--- a/detect.py
+++ b/detect.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 # pathlib.PosixPath = pathlib.WindowsPath # uncomment if you are using windows
 import torch
+
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:


### PR DESCRIPTION
There is an error for windows users that states "NotImplementedError: cannot instantiate 'PosixPath' on your system" in the detect.py file. so for windows users just uncomment the section 
# pathlib.PosixPath = pathlib.WindowsPath # uncomment if you are using windows
and 
# import pathlib # # uncomment if you are using windows

then run