### PR TITLE
Revert CI `pip install` retries to default

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip wheel
-          pip install --retries 3 -r requirements.txt coremltools openvino-dev "tensorflow-cpu<2.15.1" --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements.txt coremltools openvino-dev "tensorflow-cpu<2.15.1" --extra-index-url https://download.pytorch.org/whl/cpu
           yolo checks
           pip list
       - name: Benchmark DetectionModel
@@ -72,7 +72,7 @@ jobs:
           if [ "${{ matrix.torch }}" == "1.8.0" ]; then
             torch="torch==1.8.0 torchvision==0.9.0"
           fi
-          pip install --retries 3 -r requirements.txt $torch --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install -r requirements.txt $torch --extra-index-url https://download.pytorch.org/whl/cpu
         shell: bash # for Windows compatibility
       - name: Check environment
         run: |


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Simplification of installation commands in continuous integration testing.

### 📊 Key Changes
- Removed `--retries 3` from `pip install` commands in the GitHub Actions CI workflow file.

### 🎯 Purpose & Impact
- **Purpose:** To streamline the installation process during CI testing by removing unnecessary retry attempts during package installations.
- **Impact:** This change is likely to make the CI process slightly faster and cleaner, potentially reducing log clutter without significantly affecting reliability. For users and developers, this simplification may lead to easier troubleshooting and understanding of CI logs. It assumes network and server stability during package installation is sufficiently reliable without needing multiple retries. 🚀🔧