### PR TITLE
Update CoreML exports to support newer *.mlpackage outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ VOC/
 *.onnx
 *.engine
 *.mlmodel
+*.mlpackage
 *.torchscript
 *.tflite
 *.h5

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -9,7 +9,7 @@ TorchScript                 | `torchscript`                 | yolov5s.torchscrip
 ONNX                        | `onnx`                        | yolov5s.onnx
 OpenVINO                    | `openvino`                    | yolov5s_openvino_model/
 TensorRT                    | `engine`                      | yolov5s.engine
-CoreML                      | `coreml`                      | yolov5s.mlmodel
+CoreML                      | `coreml`                      | yolov5s.mlpackage
 TensorFlow SavedModel       | `saved_model`                 | yolov5s_saved_model/
 TensorFlow GraphDef         | `pb`                          | yolov5s.pb
 TensorFlow Lite             | `tflite`                      | yolov5s.tflite

--- a/detect.py
+++ b/detect.py
@@ -20,7 +20,7 @@ Usage - formats:
                                  yolov5s.onnx               # ONNX Runtime or OpenCV DNN with --dnn
                                  yolov5s_openvino_model     # OpenVINO
                                  yolov5s.engine             # TensorRT
-                                 yolov5s.mlmodel            # CoreML (macOS-only)
+                                 yolov5s.mlpackage          # CoreML (macOS-only)
                                  yolov5s_saved_model        # TensorFlow SavedModel
                                  yolov5s.pb                 # TensorFlow GraphDef
                                  yolov5s.tflite             # TensorFlow Lite

--- a/export.py
+++ b/export.py
@@ -575,10 +575,7 @@ def export_coreml(model, im, file, int8, half, nms, mlmodel, prefix=colorstr("Co
     bits, mode = (8, "kmeans") if int8 else (16, "linear") if half else (32, None)
     if bits < 32:
         if mlmodel:
-            if MACOS:
-                ct_model = ct.models.neural_network.quantization_utils.quantize_weights(ct_model, bits, mode)
-            else:
-                print(f"{prefix} quantization only supported on macOS, skipping...")
+            ct_model = ct.models.neural_network.quantization_utils.quantize_weights(ct_model, bits, mode)
         elif bits == 8:
             op_config=ct.optimize.coreml.OpPalettizerConfig(mode=mode, nbits=bits, weight_threshold=512)
             config = ct.optimize.coreml.OptimizationConfig(global_config=op_config)

--- a/export.py
+++ b/export.py
@@ -575,7 +575,9 @@ def export_coreml(model, im, file, int8, half, nms, mlmodel, prefix=colorstr("Co
     bits, mode = (8, "kmeans") if int8 else (16, "linear") if half else (32, None)
     if bits < 32:
         if mlmodel:
-            ct_model = ct.models.neural_network.quantization_utils.quantize_weights(ct_model, bits, mode)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=DeprecationWarning)  # suppress numpy==1.20 float warning, fixed in coremltools==7.0
+                ct_model = ct.models.neural_network.quantization_utils.quantize_weights(ct_model, bits, mode)
         elif bits == 8:
             op_config=ct.optimize.coreml.OpPalettizerConfig(mode=mode, nbits=bits, weight_threshold=512)
             config = ct.optimize.coreml.OptimizationConfig(global_config=op_config)

--- a/models/common.py
+++ b/models/common.py
@@ -444,7 +444,7 @@ class DetectMultiBackend(nn.Module):
         #   ONNX Runtime:                   *.onnx
         #   ONNX OpenCV DNN:                *.onnx --dnn
         #   OpenVINO:                       *_openvino_model
-        #   CoreML:                         *.mlmodel
+        #   CoreML:                         *.mlpackage
         #   TensorRT:                       *.engine
         #   TensorFlow SavedModel:          *_saved_model
         #   TensorFlow GraphDef:            *.pb

--- a/val.py
+++ b/val.py
@@ -11,7 +11,7 @@ Usage - formats:
                               yolov5s.onnx               # ONNX Runtime or OpenCV DNN with --dnn
                               yolov5s_openvino_model     # OpenVINO
                               yolov5s.engine             # TensorRT
-                              yolov5s.mlmodel            # CoreML (macOS-only)
+                              yolov5s.mlpackage          # CoreML (macOS-only)
                               yolov5s_saved_model        # TensorFlow SavedModel
                               yolov5s.pb                 # TensorFlow GraphDef
                               yolov5s.tflite             # TensorFlow Lite


### PR DESCRIPTION
Change 1: This PR changes the default behavior for CoreML exports to generate `*.mlpackage` files. This is the preferred output for CoreML models since it allows for more efficient on-device compilation (see https://apple.github.io/coremltools/docs-guides/source/comparing-ml-programs-and-neural-networks.html). This change in particular closes #13076

Change 2: As to preserve compatibility with users wanting `*.mlmodel` files, I have added a flag `--mlmodel` that will use the previously existing export tooling. I am unsure if this is the ideal way of expressing intent for `*.mlmodel` files, since it will break users wanting to use `*.mlmodel` models with detect.py, val.py, and benchmarks.py

Change 3: Since the minimum required coremltools is 6.0 or newer, the macOS check when quantizing `*.mlmodel` files was removed. In the 6.0 release, Apple removed the requirement for macOS when quantizing models.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR updates the CoreML export format from `.mlmodel` to `.mlpackage`, adding flexibility and future-proofing the YOLOv5 repository.

### 📊 Key Changes
- Updated the CoreML export format from `.mlmodel` to `.mlpackage` in multiple scripts (detect.py, export.py, val.py, benchmarks.py).
- Added an option to still export in the older `.mlmodel` format if needed.
- Adjusted the export methods to accommodate the new format and added necessary flags in command-line arguments.

### 🎯 Purpose & Impact
- **Modernization**: Shifts to `.mlpackage`, CoreML's more contemporary and scalable format.
- **Flexibility**: Allows users to choose between the new `.mlpackage` and the older `.mlmodel` formats.
- **Compatibility**: Ensures better future support and potentially enhanced performance on Apple devices.

This update ensures that the models exported for use with CoreML are ready for modern application demands, maintaining compatibility with future versions of CoreML. Additionally, the explicit option to use `.mlmodel` provides users with the flexibility to stick with the familiar format if they haven't transitioned yet.