### PR TITLE
Fix bug when enable `--quad` training option

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -210,6 +210,7 @@ def create_dataloader(
         shuffle=shuffle and sampler is None,
         num_workers=nw,
         sampler=sampler,
+        drop_last=quad,
         pin_memory=PIN_MEMORY,
         collate_fn=LoadImagesAndLabels.collate_fn4 if quad else LoadImagesAndLabels.collate_fn,
         worker_init_fn=seed_worker,

--- a/utils/segment/dataloaders.py
+++ b/utils/segment/dataloaders.py
@@ -75,6 +75,7 @@ def create_dataloader(
         shuffle=shuffle and sampler is None,
         num_workers=nw,
         sampler=sampler,
+        drop_last=quad,
         pin_memory=True,
         collate_fn=LoadImagesAndLabelsAndMasks.collate_fn4 if quad else LoadImagesAndLabelsAndMasks.collate_fn,
         worker_init_fn=seed_worker,


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->

When enabling the `--quad` training option, the `collate_fn4` function assumes the batch size will be greater than 4, but without enabling `drop_last` in the dataloader, the size of the last batch is unpredictable. So in some cases, an Exception may be raised, depending on the size of the dataset.

```bash
Original Traceback (most recent call last):                                                                                                                                                                                                                                                 
  File "/home/user/envs/edge/lib/python3.8/site-packages/torch/utils/data/_utils/worker.py", line 302, in _worker_loop                                                                                                                                                                    
    data = fetcher.fetch(index)                                                                                                                                                                                                                                                             
  File "/home/user/envs/edge/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 61, in fetch                                                                                                                                                                             
    return self.collate_fn(data)                                                                                                                                                                                                                                                            
  File "/home/user/workspace/srcs/public/yolov5/utils/dataloaders.py", line 1070, in collate_fn4                                                                                                                                                                                          
    return torch.stack(im4, 0), torch.cat(label4, 0), path4, shapes4                                                                                                                                                                                                                        
RuntimeError: stack expects a non-empty TensorList      
```

`n` will be zero, if batch size per GPU is smaller than 4.
https://github.com/ultralytics/yolov5/blob/a3555241574a08e35b5f3b0138c09802ec4ed28a/utils/dataloaders.py#L1032

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Added `drop_last` parameter to data loaders for improved batch handling.

### 📊 Key Changes
- Added `drop_last` argument to `create_dataloader()` function in both `dataloaders.py` and `segment/dataloaders.py`.

### 🎯 Purpose & Impact
- **Purpose**: Ensures consistency in batch sizes during training when using the `quad` parameter.
- **Impact**: Improves training stability and performance by avoiding incomplete batches, leading to more efficient resource utilization. 📈

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This PR introduces an enhancement to the data loading process for YOLOv5 by incorporating the `drop_last` parameter to better handle batched data.

### 📊 Key Changes
- Added the `drop_last=quad` parameter in the data loader configurations within `utils/dataloaders.py` and `utils/segment/dataloaders.py`.

### 🎯 Purpose & Impact
- **Purpose**: The `drop_last` parameter helps manage batches more effectively, particularly when using "quad" mode, by dropping the last incomplete batch if it's smaller than the set batch size.
- **Impact**: This change ensures more consistent batch sizes during training, which can enhance stability and performance, especially when using data augmentations that require specific batch configurations.