### PR TITLE
Add timing cache to accelerate consequent `.engine` export

### DIFF
--- a/export.py
+++ b/export.py
@@ -593,8 +593,9 @@ def export_coreml(model, im, file, int8, half, nms, mlmodel, prefix=colorstr("Co
 
 
 @try_export
-def export_engine(model, im, file, half, dynamic, simplify, workspace=4, verbose=False, cache="",
-                  prefix=colorstr("TensorRT:")):
+def export_engine(
+    model, im, file, half, dynamic, simplify, workspace=4, verbose=False, cache="", prefix=colorstr("TensorRT:")
+):
     """
     Export a YOLOv5 model to TensorRT engine format, requiring GPU and TensorRT>=7.0.0.
 

--- a/export.py
+++ b/export.py
@@ -593,7 +593,8 @@ def export_coreml(model, im, file, int8, half, nms, mlmodel, prefix=colorstr("Co
 
 
 @try_export
-def export_engine(model, im, file, half, dynamic, simplify, workspace=4, verbose=False, prefix=colorstr("TensorRT:")):
+def export_engine(model, im, file, half, dynamic, simplify, workspace=4, verbose=False, cache="",
+                  prefix=colorstr("TensorRT:")):
     """
     Export a YOLOv5 model to TensorRT engine format, requiring GPU and TensorRT>=7.0.0.
 
@@ -606,6 +607,7 @@ def export_engine(model, im, file, half, dynamic, simplify, workspace=4, verbose
         simplify (bool): Set to True to simplify the model during export.
         workspace (int): Workspace size in GB (default is 4).
         verbose (bool): Set to True for verbose logging output.
+        cache (str): Path to save the TensorRT timing cache.
         prefix (str): Log message prefix.
 
     Returns:
@@ -660,6 +662,11 @@ def export_engine(model, im, file, half, dynamic, simplify, workspace=4, verbose
         config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace << 30)
     else:  # TensorRT versions 7, 8
         config.max_workspace_size = workspace * 1 << 30
+    if cache:  # enable timing cache
+        Path(cache).parent.mkdir(parents=True, exist_ok=True)
+        buf = Path(cache).read_bytes() if Path(cache).exists() else b""
+        timing_cache = config.create_timing_cache(buf)
+        config.set_timing_cache(timing_cache, ignore_mismatch=True)
     flag = 1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
     network = builder.create_network(flag)
     parser = trt.OnnxParser(network, logger)
@@ -688,6 +695,9 @@ def export_engine(model, im, file, half, dynamic, simplify, workspace=4, verbose
     build = builder.build_serialized_network if is_trt10 else builder.build_engine
     with build(network, config) as engine, open(f, "wb") as t:
         t.write(engine if is_trt10 else engine.serialize())
+    if cache:  # save timing cache
+        with open(cache, "wb") as c:
+            c.write(config.get_timing_cache().serialize())
     return f, None
 
 
@@ -1277,6 +1287,7 @@ def run(
     int8=False,  # CoreML/TF INT8 quantization
     per_tensor=False,  # TF per tensor quantization
     dynamic=False,  # ONNX/TF/TensorRT: dynamic axes
+    cache="",  # TensorRT: timing cache path
     simplify=False,  # ONNX: simplify model
     mlmodel=False,  # CoreML: Export in *.mlmodel format
     opset=12,  # ONNX: opset version
@@ -1306,6 +1317,7 @@ def run(
         int8 (bool): Apply INT8 quantization for CoreML or TensorFlow models. Default is False.
         per_tensor (bool): Apply per tensor quantization for TensorFlow models. Default is False.
         dynamic (bool): Enable dynamic axes for ONNX, TensorFlow, or TensorRT exports. Default is False.
+        cache (str): TensorRT timing cache path. Default is an empty string.
         simplify (bool): Simplify the ONNX model during export. Default is False.
         opset (int): ONNX opset version. Default is 12.
         verbose (bool): Enable verbose logging for TensorRT export. Default is False.
@@ -1341,6 +1353,7 @@ def run(
             int8=False,
             per_tensor=False,
             dynamic=False,
+            cache="",
             simplify=False,
             opset=12,
             verbose=False,
@@ -1378,7 +1391,8 @@ def run(
     # Input
     gs = int(max(model.stride))  # grid size (max stride)
     imgsz = [check_img_size(x, gs) for x in imgsz]  # verify img_size are gs-multiples
-    im = torch.zeros(batch_size, 3, *imgsz).to(device)  # image size(1,3,320,192) BCHW iDetection
+    ch = next(model.parameters()).size(1)  # require input image channels
+    im = torch.zeros(batch_size, ch, *imgsz).to(device)  # image size(1,3,320,192) BCHW iDetection
 
     # Update model
     model.eval()
@@ -1402,7 +1416,7 @@ def run(
     if jit:  # TorchScript
         f[0], _ = export_torchscript(model, im, file, optimize)
     if engine:  # TensorRT required before ONNX
-        f[1], _ = export_engine(model, im, file, half, dynamic, simplify, workspace, verbose)
+        f[1], _ = export_engine(model, im, file, half, dynamic, simplify, workspace, verbose, cache)
     if onnx or xml:  # OpenVINO requires ONNX
         f[2], _ = export_onnx(model, im, file, opset, dynamic, simplify)
     if xml:  # OpenVINO
@@ -1497,6 +1511,7 @@ def parse_opt(known=False):
     parser.add_argument("--int8", action="store_true", help="CoreML/TF/OpenVINO INT8 quantization")
     parser.add_argument("--per-tensor", action="store_true", help="TF per-tensor quantization")
     parser.add_argument("--dynamic", action="store_true", help="ONNX/TF/TensorRT: dynamic axes")
+    parser.add_argument("--cache", type=str, default="", help="TensorRT: timing cache file path")
     parser.add_argument("--simplify", action="store_true", help="ONNX: simplify model")
     parser.add_argument("--mlmodel", action="store_true", help="CoreML: Export in *.mlmodel format")
     parser.add_argument("--opset", type=int, default=17, help="ONNX: opset version")

--- a/train.py
+++ b/train.py
@@ -717,10 +717,10 @@ def main(opt, callbacks=Callbacks()):
             "perspective": (True, 0.0, 0.001),  # image perspective (+/- fraction), range 0-0.001
             "flipud": (True, 0.0, 1.0),  # image flip up-down (probability)
             "fliplr": (True, 0.0, 1.0),  # image flip left-right (probability)
-            "mosaic": (True, 0.0, 1.0),  # image mixup (probability)
+            "mosaic": (True, 0.0, 1.0),  # image mosaic (probability)
             "mixup": (True, 0.0, 1.0),  # image mixup (probability)
-            "copy_paste": (True, 0.0, 1.0),
-        }  # segment copy-paste (probability)
+            "copy_paste": (True, 0.0, 1.0),  # segment copy-paste (probability)
+        }
 
         # GA configs
         pop_size = 50


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->
It's time consuming to export `.engine` format model with `--half` option. TensorRT provides an option to use timing cache to accelerate the consequent export process. This PR add this option to the `export.py`.

Export `yolov5m.pt` without timing cache take 565.4s:

```bash
python export.py --weights weights/yolov5m.pt --include engine --opset 17 --half --device 0
```

```bash
[10/25/2024-14:58:27] [TRT] [I] [MemUsageStats] Peak memory usage of TRT CPU/GPU memory allocators: CPU 5 MiB, GPU 213 MiB
[10/25/2024-14:58:27] [TRT] [I] [MemUsageStats] Peak memory usage during Engine building and serialization: CPU: 3283 MiB
TensorRT: export success ✅ 565.4s, saved as weights/yolov5m.engine (42.3 MB)

Export complete (566.4s)
```

And shrink to 11.5s with timing cache (the second run):

```bash
python export.py --weights weights/yolov5m.pt --include engine --opset 17 --half --device 0 --cache runs/timing.cache
```

```bash
[10/25/2024-15:08:19] [TRT] [I] [MemUsageStats] Peak memory usage of TRT CPU/GPU memory allocators: CPU 5 MiB, GPU 44 MiB
[10/25/2024-15:08:19] [TRT] [I] [MemUsageStats] Peak memory usage during Engine building and serialization: CPU: 4374 MiB
[10/25/2024-15:08:19] [TRT] [I] Serialized 27 bytes of code generator cache.
[10/25/2024-15:08:19] [TRT] [I] Serialized 14672 timing cache entries
TensorRT: export success ✅ 11.5s, saved as weights/yolov5m.engine (42.3 MB)

Export complete (12.3s)
```

Reference for [`timing cache`](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#timing-cache)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements to YOLOv5's TensorRT export functionality include adding a timing cache feature, improving export efficiency and performance.

### 📊 Key Changes
- Introduced a `cache` parameter to the `export_engine` function, allowing users to specify a file path for storing the TensorRT timing cache.
- Adjusted the `run` function to pass the cache parameter during TensorRT export.
- Updated the CLI to include a `--cache` argument that specifies the timing cache file path.
- Minor code formatting improvements in train configuration comments.

### 🎯 Purpose & Impact
- **Efficiency Boost**: The timing cache provides performance improvements during TensorRT export by reusing kernel choice decisions, which can result in faster export times and potential runtime optimization.
- **User Control**: Users gain more control over the export process by storing and utilizing timing data, particularly beneficial for model deployment scenarios requiring multiple runs.
- **Improved Documentation**: Clearer code comments enhance understanding for developers and maintainers, fostering better configuration management.