### PR TITLE
Fix possible image drawing issues

### DIFF
--- a/utils/plots.py
+++ b/utils/plots.py
@@ -183,7 +183,7 @@ def plot_images(images, targets, paths=None, fname="images.jpg", names=None):
     # Annotate
     fs = int((h + w) * ns * 0.01)  # font size
     annotator = Annotator(mosaic, line_width=round(fs / 10), font_size=fs, pil=True, example=names)
-    for i in range(i + 1):
+    for i in range(bs):
         x, y = int(w * (i // ns)), int(h * (i % ns))  # block origin
         annotator.rectangle([x, y, x + w, y + h], None, (255, 255, 255), width=2)  # borders
         if paths:

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -183,7 +183,7 @@ def plot_images(images, targets, paths=None, fname="images.jpg", names=None):
     # Annotate
     fs = int((h + w) * ns * 0.01)  # font size
     annotator = Annotator(mosaic, line_width=round(fs / 10), font_size=fs, pil=True, example=names)
-    for i in range(min(bs, i+1)):
+    for i in range(min(bs, i + 1)):
         x, y = int(w * (i // ns)), int(h * (i % ns))  # block origin
         annotator.rectangle([x, y, x + w, y + h], None, (255, 255, 255), width=2)  # borders
         if paths:

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -183,7 +183,7 @@ def plot_images(images, targets, paths=None, fname="images.jpg", names=None):
     # Annotate
     fs = int((h + w) * ns * 0.01)  # font size
     annotator = Annotator(mosaic, line_width=round(fs / 10), font_size=fs, pil=True, example=names)
-    for i in range(bs):
+    for i in range(min(bs, i+1)):
         x, y = int(w * (i // ns)), int(h * (i % ns))  # block origin
         annotator.rectangle([x, y, x + w, y + h], None, (255, 255, 255), width=2)  # borders
         if paths:


### PR DESCRIPTION
Fixed non-meaningful labels in the top right (row 1, column 4) plots when batch size is larger than max_subplots.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->

Fixed non-meaningful labels in the top right (row 1, column 4) plots when batch size is larger than max_subplots.
The reason is that when the batch size is larger than max_subplots, the pre-repair plots will be looped one more time, and the unnecessary looping may accidentally draw the labels of the images indexed as max_subplots in the batch to the top-right corner of the image.
I fix the situation in this PR by using bs instead of i+1, plus I is not suitable for handling other logic as part of the for loop above.

I have read the CLA Document and I sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved the loop control in the image annotation function to prevent out-of-bounds errors.

### 📊 Key Changes
- Adjusted the loop iteration condition in the `plot_images()` function to use `min(bs, i + 1)` instead of `i + 1`.

### 🎯 Purpose & Impact
- **Purpose**: To ensure the loop does not exceed the number of available images, preventing potential errors during image annotation.
- **Impact**: Enhances the robustness of the image plotting utility, reducing crashes and improving usability for large batches of images. 🖼️✨