### PR TITLE
Pin `paddlepaddle<3.0.0` to avoid bug in latest release

### DIFF
--- a/export.py
+++ b/export.py
@@ -510,7 +510,7 @@ def export_paddle(model, im, file, metadata, prefix=colorstr("PaddlePaddle:")):
         $ pip install paddlepaddle x2paddle
         ```
     """
-    check_requirements(("paddlepaddle", "x2paddle"))
+    check_requirements(("paddlepaddle<3.0.0", "x2paddle"))
     import x2paddle
     from x2paddle.convert import pytorch2paddle
 

--- a/models/common.py
+++ b/models/common.py
@@ -646,7 +646,7 @@ class DetectMultiBackend(nn.Module):
             raise NotImplementedError("ERROR: YOLOv5 TF.js inference is not supported")
         elif paddle:  # PaddlePaddle
             LOGGER.info(f"Loading {w} for PaddlePaddle inference...")
-            check_requirements("paddlepaddle-gpu" if cuda else "paddlepaddle")
+            check_requirements("paddlepaddle-gpu" if cuda else "paddlepaddle<3.0.0")
             import paddle.inference as pdi
 
             if not Path(w).is_file():  # if not *.pdmodel


### PR DESCRIPTION
@glenn-jocher FYI.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated PaddlePaddle compatibility to ensure smooth operation with supported versions. 🚀  

### 📊 Key Changes  
- Restricted PaddlePaddle version to below 3.0.0 in `check_requirements` for both export and inference functionalities.  
- Adjusted dependency checks for PaddlePaddle and PaddlePaddle-GPU to align with this version constraint.  

### 🎯 Purpose & Impact  
- **Purpose**: Prevent compatibility issues with PaddlePaddle versions 3.0.0 and above, ensuring stable exports and inference workflows.  
- **Impact**: Users working with PaddlePaddle can avoid unexpected errors or crashes, improving reliability and user experience. 😊