### PR TITLE
Fix iterrows unpacking in export_formats for benchmark export #IEEESOC

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -99,7 +99,13 @@ def run(
     y, t = [], time.time()
     device = select_device(device)
     model_type = type(attempt_load(weights, fuse=False))  # DetectionModel, SegmentationModel, etc.
-    for i, (name, f, suffix, cpu, gpu) in export.export_formats().iterrows():  # index, (name, file, suffix, CPU, GPU)
+    for i, row in export.export_formats().iterrows():
+        name = row['name']
+        f = row['file']
+        suffix = row['suffix']
+        cpu = row['cpu']
+        gpu = row['gpu']
+        # index, (name, file, suffix, CPU, GPU)
         try:
             assert i not in (9, 10), "inference not supported"  # Edge TPU and TF.js are unsupported
             assert i != 5 or platform.system() == "Darwin", "inference only supported on macOS>=10.13"  # CoreML

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -100,11 +100,11 @@ def run(
     device = select_device(device)
     model_type = type(attempt_load(weights, fuse=False))  # DetectionModel, SegmentationModel, etc.
     for i, row in export.export_formats().iterrows():
-        name = row['name']
-        f = row['file']
-        suffix = row['suffix']
-        cpu = row['cpu']
-        gpu = row['gpu']
+        name = row["name"]
+        f = row["file"]
+        suffix = row["suffix"]
+        cpu = row["cpu"]
+        gpu = row["gpu"]
         # index, (name, file, suffix, CPU, GPU)
         try:
             assert i not in (9, 10), "inference not supported"  # Edge TPU and TF.js are unsupported


### PR DESCRIPTION
What does this PR do?

Fixes a bug in benchmarks.py where `export.export_formats().iterrows()` was incorrectly unpacked as:

`for i, (name, f, suffix, cpu, gpu) in export.export_formats().iterrows():`
This caused a runtime error since iterrows() returns (index, Series), which is not directly unpackable like that.

✅ Replaced with:
```
for i, row in export.export_formats().iterrows():
    name = row['name']
    f = row['file']
    suffix = row['suffix']
    cpu = row['cpu']
    gpu = row['gpu']
```
This prevents unpacking errors during benchmark export.

I have read the CLA document and I sign the CLA.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved how export format details are accessed in the benchmarking script for better code clarity and reliability. 🛠️

### 📊 Key Changes  
- Updated the loop in `benchmarks.py` to access export format details by column name instead of by position.
- Enhanced code readability and maintainability by making variable assignments explicit.

### 🎯 Purpose & Impact  
- Reduces the risk of errors if the export formats table structure changes in the future.
- Makes the code easier to understand and modify for developers.
- No changes to user-facing features or results—this is a behind-the-scenes improvement.