### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -4,6 +4,9 @@
 
 name: YOLOv5 CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/yolov5/security/code-scanning/11](https://github.com/ultralytics/yolov5/security/code-scanning/11)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the tasks performed in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- Additional permissions (e.g., `issues: write`, `pull-requests: write`) should only be added if explicitly required by the workflow.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved security settings for YOLOv5's continuous integration (CI) workflow. 🔒

### 📊 Key Changes  
- Added explicit permissions (`contents: read`) to the CI workflow configuration.

### 🎯 Purpose & Impact  
- Enhances security by limiting workflow permissions to read-only access.
- Reduces potential risks from unauthorized changes during automated testing.
- No impact on user-facing features or day-to-day usage.