### PR TITLE
Fix deprecation warning for `pkg_resources` dependency by changing to `packaging`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ dependencies = [
     "thop>=0.1.1", # FLOPs computation
     "pandas>=1.1.4",
     "seaborn>=0.11.0", # plotting
+    "packaging", # general utilities
     "ultralytics>=8.2.64"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ seaborn>=0.11.0
 # openvino-dev>=2023.0  # OpenVINO export
 
 # Deploy ----------------------------------------------------------------------
+packaging  # Migration of deprecated pkg_resources packages
 setuptools>=70.0.0 # Snyk vulnerability fix
 # tritonclient[all]~=2.24.0
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -29,7 +29,7 @@ from zipfile import ZipFile, is_zipfile
 import cv2
 import numpy as np
 import pandas as pd
-import pkg_resources as pkg
+import packaging
 import torch
 import torchvision
 import yaml
@@ -425,7 +425,7 @@ def check_python(minimum="3.8.0"):
 
 def check_version(current="0.0.0", minimum="0.0.0", name="version ", pinned=False, hard=False, verbose=False):
     """Checks if the current version meets the minimum required version, exits or warns based on parameters."""
-    current, minimum = (pkg.parse_version(x) for x in (current, minimum))
+    current, minimum = (packaging.version.parse(x) for x in (current, minimum))
     result = (current == minimum) if pinned else (current >= minimum)  # bool
     s = f"WARNING ⚠️ {name}{minimum} is required by YOLOv5, but {name}{current} is currently installed"  # string
     if hard:

--- a/utils/general.py
+++ b/utils/general.py
@@ -28,8 +28,8 @@ from zipfile import ZipFile, is_zipfile
 
 import cv2
 import numpy as np
-import pandas as pd
 import packaging
+import pandas as pd
 import torch
 import torchvision
 import yaml


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

Resolves #13642.

Replaces the `pkg_resources` dependency usage with the `packaging` dependency as recommended by the `setuptools` package.

I did not see any unit tests for the `check_version` function, nor a good place to add such tests, so I did not include in the PR but I did create some to test changes and avoid regression.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Replaces deprecated pkg_resources with the modern packaging library and updates dependencies to improve reliability and security 🔧🛡️

### 📊 Key Changes
- Added packaging to pyproject.toml and requirements.txt.
- Replaced pkg_resources usage with packaging.version.parse in utils/general.py.
- Kept/setuptools>=70.0.0 for security (Snyk) and clarified comment.
- Minor import cleanup (removed pkg_resources import).

### 🎯 Purpose & Impact
- Improves compatibility with newer Python environments by removing deprecated pkg_resources usage ✅
- Enhances version checking accuracy and maintainability via packaging.version 📦
- Reduces potential security and supply-chain risks by updating dependencies 🛡️
- Minimizes runtime warnings and future breakage, leading to smoother installs and usage for users 🚀