### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   stale:
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/yolov5/security/code-scanning/14](https://github.com/ultralytics/yolov5/security/code-scanning/14)

To fix the problem, an explicit `permissions` block should be added to ensure the `GITHUB_TOKEN` only receives the rights necessary for the stale workflow to work. The `actions/stale` action requires `write` access to issues and pull requests (to comment on and close them), and at least `read` access to contents; `contents: read` is the minimum needed for internal GitHub operations. 

The best, least privileged set (per the action's [documentation](https://github.com/actions/stale#required-permissions)) is:

```yaml
permissions:
  issues: write
  pull-requests: write
  contents: read
```

Add this block at the job level (line 10), just above or below `runs-on: ubuntu-latest`, for clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds explicit GitHub Actions permissions to the stale-issue workflow so the bot can reliably manage stale issues and PRs. 🤖✅

### 📊 Key Changes
- Introduces a `permissions` block in `.github/workflows/stale.yml`:
  - `issues: write`
  - `pull-requests: write`
  - `contents: read`
- Ensures compatibility with `actions/stale@v10`.
- No changes to the codebase, models, or user-facing features—workflow-only update. 🔧

### 🎯 Purpose & Impact
- Ensures the Stale bot can label, comment, and close issues/PRs without permission errors. 🚀
- Applies least-privilege access for better security. 🛡️
- Improves maintenance automation and repository hygiene. 🧹
- Zero impact on training, inference, or performance for users.