### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@
 # Builds ultralytics/yolov5:latest images on DockerHub https://hub.docker.com/r/ultralytics/yolov5
 
 name: Publish Docker Images
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@
 # Builds ultralytics/yolov5:latest images on DockerHub https://hub.docker.com/r/ultralytics/yolov5
 
 name: Publish Docker Images
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/yolov5/security/code-scanning/4](https://github.com/ultralytics/yolov5/security/code-scanning/4)

To fix the problem, you should add a `permissions:` block at the root level (recommended) or at the job level. Given only one job is present, either approach is functionally equivalent. The minimal starting permission recommended by CodeQL is `contents: read`, which aligns with least privilege and is enough for `actions/checkout@v5` to function. This should be placed after the `name:` field, but before `on:` or `jobs:`, for best readability.

No imports or additional definitions are needed. Only the YAML structure changes in `.github/workflows/docker.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds explicit, least-privilege permissions to the Docker image publishing workflow to improve security with no functional changes to users. 🔒🐳

### 📊 Key Changes
- Set GitHub Actions workflow permissions to `contents: read` in `.github/workflows/docker.yml`.

### 🎯 Purpose & Impact
- Enhances security by enforcing least-privilege access for the workflow’s `GITHUB_TOKEN`. 🔐
- Reduces risk of unintended repository writes from the Docker publish pipeline. ✅
- No impact on model training, inference, or day-to-day usage; Docker builds/publishing should continue to work as before (assuming separate registry credentials are used). 🚀