### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -9,6 +9,7 @@
 #   - 999(LinkedIn, 'unknown status code')
 
 name: Check Broken links
+
 permissions:
   contents: read
 

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -9,6 +9,8 @@
 #   - 999(LinkedIn, 'unknown status code')
 
 name: Check Broken links
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/yolov5/security/code-scanning/13](https://github.com/ultralytics/yolov5/security/code-scanning/13)

To resolve the issue, add a `permissions:` block specifying the minimum required permissions for the workflow/jobs. For this workflow, it's likely only `contents: read` is needed as the jobs only check out code and run link-checking tools—they do not update repository contents, issues, or pull requests. The `permissions:` block should be added either at the workflow root (line 12, just before `on:`) to apply to all jobs, or at the job level (inside the `Links:` job definition, e.g., after line 19). The best practice is to set it at the workflow root for global effect. No new imports or dependencies are needed, just an addition of the YAML permissions stanza.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds explicit, read-only permissions to the “Check Broken links” GitHub Actions workflow to improve security and reliability 🔒✅

### 📊 Key Changes
- Configures workflow permissions with `permissions: contents: read` in `.github/workflows/links.yml`.
- No code or model logic changes; CI-only update affecting the link-checking workflow.

### 🎯 Purpose & Impact
- Enhances security by using least-privilege permissions for the workflow 🔐.
- Aligns with GitHub best practices and prevents accidental write access from the workflow.
- Improves reliability in orgs that enforce restricted default permissions, reducing permission-related CI failures.
- No impact on YOLOv5 users or training/inference behavior—purely CI infrastructure.