### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-main-into-prs.yml
+++ b/.github/workflows/merge-main-into-prs.yml
@@ -4,6 +4,9 @@
 # Action runs on updates to main branch so when one PR merges to main all others update
 
 name: Merge main into PRs
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/merge-main-into-prs.yml
+++ b/.github/workflows/merge-main-into-prs.yml
@@ -4,6 +4,7 @@
 # Action runs on updates to main branch so when one PR merges to main all others update
 
 name: Merge main into PRs
+
 permissions:
   contents: read
   pull-requests: write


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/yolov5/security/code-scanning/8](https://github.com/ultralytics/yolov5/security/code-scanning/8)

To fix this problem, explicitly declare the `permissions` for the workflow, following the least-privilege principle. Determine which permissions are strictly required for the workflow to function. In this case, since the workflow updates PR branches (`pr.update_branch()`) and thus needs to modify pull requests, a minimal set would be `permissions: { contents: read, pull-requests: write }`.  
Add a `permissions` block at the top (root) of the workflow, just after the `name:` line and before `on:`, so all jobs inherit this by default. No other code needs to change.  
This ensures that the GITHUB_TOKEN is only granted the permissions needed to read repository contents and write to pull requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Tightens GitHub Actions permissions for the “Merge main into PRs” workflow to improve security and ensure it can update pull requests reliably. 🔐🤖

### 📊 Key Changes
- Added explicit permissions to `.github/workflows/merge-main-into-prs.yml`:
  - `contents: read`
  - `pull-requests: write`

### 🎯 Purpose & Impact
- Enhances security by using least-privilege permissions for the workflow. 🛡️
- Prevents “Resource not accessible by integration” errors by allowing the workflow to write to PRs. ✅
- Improves CI reliability when auto-merging `main` into open PR branches. 🔄
- No changes to models, training, or runtime behavior—purely CI/config updates. 🚀