### PR TITLE
Fix ONNX export with `onnxscript` dependency

### DIFF
--- a/export.py
+++ b/export.py
@@ -328,7 +328,7 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr("ONNX
         export_onnx(model, im, file_path, opset=12, dynamic=True, simplify=True)
         ```
     """
-    check_requirements("onnx>=1.12.0")
+    check_requirements(("onnx>=1.12.0", "onnxscript"))
     import onnx
 
     LOGGER.info(f"\n{prefix} starting export with onnx {onnx.__version__}...")


### PR DESCRIPTION
May resolve https://github.com/ultralytics/yolov5/actions/runs/18513884456

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Adds `onnxscript` as a required dependency for ONNX export to make YOLOv5 exports more reliable and compatible with newer ONNX features. ✅

### 📊 Key Changes
- ONNX export now checks for both `onnx>=1.12.0` and `onnxscript` before running.
- No changes to the export flow or outputs—just dependency validation.

### 🎯 Purpose & Impact
- Prevents export-time errors caused by missing `onnxscript` when using certain ONNX ops or graph constructions.
- Improves compatibility with newer ONNX tooling and operator coverage.
- Users exporting to ONNX may need to install one extra package:
  ```bash
  pip install "onnx>=1.12.0" onnxscript
  ```
- Minimal overhead, better stability. 🚀

Helpful links:
- ONNX package on PyPI: [ONNX](https://pypi.org/project/onnx/)
- ONNX Script utilities: [onnxscript](https://pypi.org/project/onnxscript/)