### PR TITLE
Update base image in Dockerfile to PyTorch 2.8.0

### DIFF
--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -4,7 +4,7 @@
 # Image is CUDA-optimized for YOLOv5 single/multi-GPU training and inference
 
 # Start FROM PyTorch image https://hub.docker.com/r/pytorch/pytorch
-FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime
+FROM pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime
 
 # Downloads to user config dir
 ADD https://ultralytics.com/assets/Arial.ttf https://ultralytics.com/assets/Arial.Unicode.ttf /root/.config/Ultralytics/


### PR DESCRIPTION
Updated PyTorch base image to version 2.8.0 with CUDA 12.8 and cuDNN 9.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Upgrade Docker base image to PyTorch 2.8.0 with CUDA 12.8 and cuDNN 9 for YOLOv5 containers 🚀

### 📊 Key Changes
- Bumps base image in `utils/docker/Dockerfile` from `pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime` to `pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime`.
- Aligns the YOLOv5 Docker environment with modern CUDA 12.8 and cuDNN 9, matching current PyTorch releases.
- See the upstream base image details on the PyTorch Docker image page.

### 🎯 Purpose & Impact
- Improved performance and compatibility on newer NVIDIA GPUs and drivers ⚙️
- Access to newer PyTorch features, fixes, and security updates 🔒
- More future-proof environment for training and inference with YOLOv5 📈
- Potential impacts:
  - Requires NVIDIA drivers compatible with CUDA 12.x; older setups may need to stick with the previous image tag ⚠️
  - Image rebuild is needed; some dependency behavior may change, affecting reproducibility ♻️
  - Possible larger image size and different kernel availability due to CUDA/cuDNN upgrade 📦