### PR TITLE
Update torch_utils.py

### DIFF
--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -115,8 +115,6 @@ def select_device(device="", batch_size=0, newline=True):
     device = str(device).strip().lower().replace("cuda:", "").replace("none", "")  # to string, 'cuda:0' to '0'
     cpu = device == "cpu"
     mps = device == "mps"  # Apple Metal Performance Shaders (MPS)
-    if cpu or mps:
-        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
         os.environ["CUDA_VISIBLE_DEVICES"] = device  # set environment variable - must be before assert is_available()
         assert torch.cuda.is_available() and torch.cuda.device_count() >= len(device.replace(",", "")), (

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -115,7 +115,7 @@ def select_device(device="", batch_size=0, newline=True):
     device = str(device).strip().lower().replace("cuda:", "").replace("none", "")  # to string, 'cuda:0' to '0'
     cpu = device == "cpu"
     mps = device == "mps"  # Apple Metal Performance Shaders (MPS)
-    elif device:  # non-cpu device requested
+    if device and not cpu and not mps:  # non-cpu device requested
         os.environ["CUDA_VISIBLE_DEVICES"] = device  # set environment variable - must be before assert is_available()
         assert torch.cuda.is_available() and torch.cuda.device_count() >= len(device.replace(",", "")), (
             f"Invalid CUDA '--device {device}' requested, use '--device cpu' or pass valid CUDA device(s)"


### PR DESCRIPTION
Removed setting the environment variable `CUDA_VISIBLE_DEVICES` to -1 when cpu is requested, as this sets a system-wide environment variable that causes issues with later calls to `torch.cuda.is_available()` and `device_count()`.

E.g. I noticed this issue when running some model loading tests to different devices - if I set the device to 'cpu' first, even when this model goes out of scope the environment variable still persists so on a later test, when I checked to see that the cuda device was available then `torch.cuda.device_count()` is 0

This function is not called again when `cpu` or `mps` is set so will not cause errors later on in the function - there is no need to set this envvar.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Refines `select_device` behavior by no longer forcing `CUDA_VISIBLE_DEVICES=-1` when using CPU or MPS, allowing more flexible CUDA visibility handling.

### 📊 Key Changes
- Removed the logic that set `os.environ['CUDA_VISIBLE_DEVICES'] = '-1'` when `device` is `cpu` or `mps`.
- Retained existing behavior for explicit non-CPU devices, where `CUDA_VISIBLE_DEVICES` is still set to the requested GPU indices.

### 🎯 Purpose & Impact
- 🧠 Allows users to select CPU or MPS without globally disabling CUDA visibility via environment variables.
- 🧪 Reduces side effects for mixed environments (e.g., systems with both CUDA and MPS) where CUDA availability checks are still desired.
- ⚙️ Makes device selection behavior more transparent and predictable for downstream tools and scripts.
