### PR TITLE
Logan/convnext testing

### DIFF
--- a/data/coco.yaml
+++ b/data/coco.yaml
@@ -8,7 +8,7 @@
 #     └── coco  ← downloads here (20.1 GB)
 
 # Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
-path: ../datasets/coco # dataset root dir
+path: /projectnb/ec523bn/projects/ConvNeXt-YOLO/datasets/coco # dataset root dir
 train: train2017.txt # train images (relative to 'path') 118287 images
 val: val2017.txt # val images (relative to 'path') 5000 images
 test: test-dev2017.txt # 20288 of 40670 images, submit to https://competitions.codalab.org/competitions/20794

--- a/logs/yolo.qlog
+++ b/logs/yolo.qlog
@@ -1,0 +1,56 @@
+loading annotations into memory...
+Done (t=0.44s)
+creating index...
+index created!
+Loading and preparing results...
+DONE (t=6.57s)
+creating index...
+index created!
+Running per image evaluation...
+Evaluate annotation type *bbox*
+DONE (t=67.29s).
+Accumulating evaluation results...
+DONE (t=11.46s).
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.371
+ Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.564
+ Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.405
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.214
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.422
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.475
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.305
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.513
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.570
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.393
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.634
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.718
+
+ val: data=/projectnb/ec523bn/students/rsyed/ConvNeXt-YOLO/yolov5/data/coco.yaml, weights=['runs/train/exp3/weights/best.pt'], batch_size=32, imgsz=640, conf_thres=0.001, iou_thres=0.6, max_det=300, task=val, device=, workers=8, single_cls=False, augment=False, verbose=False, save_txt=False, save_hybrid=False, save_conf=False, save_json=True, project=runs/val, name=exp, exist_ok=False, half=False, dnn=False
+YOLOv5 🚀 v7.0-444-g1f1e7b90 Python-3.12.4 torch-2.9.1+cu128 CUDA:0 (NVIDIA RTX 6000 Ada Generation, 45455MiB)
+
+Fusing layers... 
+Model summary: 157 layers, 7225885 parameters, 0 gradients, 16.4 GFLOPs
+val: Scanning /projectnb/ec523bn/projects/ConvNeXt-YOLO/datasets/coco/val2017.ca
+                 Class     Images  Instances          P          R      mAP50   
+                   all       5000      36335      0.641      0.496      0.539      0.347
+Speed: 0.1ms pre-process, 0.9ms inference, 1.1ms NMS per image at shape (32, 3, 640, 640)
+
+Evaluating pycocotools mAP... saving runs/val/exp2/best_predictions.json...
+loading annotations into memory...
+Done (t=0.42s)
+creating index...
+index created!
+Loading and preparing results...
+DONE (t=4.98s)
+creating index...
+index created!
+Running per image evaluation...
+Evaluate annotation type *bbox*
+DONE (t=65.88s).
+Accumulating evaluation results...
+DONE (t=11.81s).
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.350
+...
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.365
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.613
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.703
+Results saved to runs/val/exp2

--- a/logs/yolo.qlog
+++ b/logs/yolo.qlog
@@ -24,33 +24,40 @@ DONE (t=11.46s).
  Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.634
  Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.718
 
- val: data=/projectnb/ec523bn/students/rsyed/ConvNeXt-YOLO/yolov5/data/coco.yaml, weights=['runs/train/exp3/weights/best.pt'], batch_size=32, imgsz=640, conf_thres=0.001, iou_thres=0.6, max_det=300, task=val, device=, workers=8, single_cls=False, augment=False, verbose=False, save_txt=False, save_hybrid=False, save_conf=False, save_json=True, project=runs/val, name=exp, exist_ok=False, half=False, dnn=False
-YOLOv5 🚀 v7.0-444-g1f1e7b90 Python-3.12.4 torch-2.9.1+cu128 CUDA:0 (NVIDIA RTX 6000 Ada Generation, 45455MiB)
+ val: data=/projectnb/ec523bn/students/rsyed/ConvNeXt-YOLO/yolov5/data/coco.yaml, weights=['runs/train/50_epoch/weights/best.pt'], batch_size=32, imgsz=640, conf_thres=0.001, iou_thres=0.6, max_det=300, task=val, device=, workers=8, single_cls=False, augment=False, verbose=False, save_txt=False, save_hybrid=False, save_conf=False, save_json=True, project=runs/val, name=exp, exist_ok=False, half=False, dnn=False
+YOLOv5 🚀 v7.0-447-g95f78510 Python-3.12.4 torch-2.9.1+cu128 CUDA:0 (NVIDIA RTX 6000 Ada Generation, 45455MiB)
 
 Fusing layers... 
 Model summary: 157 layers, 7225885 parameters, 0 gradients, 16.4 GFLOPs
-val: Scanning /projectnb/ec523bn/projects/ConvNeXt-YOLO/datasets/coco/val2017.ca
-                 Class     Images  Instances          P          R      mAP50   
-                   all       5000      36335      0.641      0.496      0.539      0.347
-Speed: 0.1ms pre-process, 0.9ms inference, 1.1ms NMS per image at shape (32, 3, 640, 640)
+val: Scanning /projectnb/ec523bn/projects/ConvNeXt-YOLO/datasets/coco
+                 Class     Images  Instances          P          R   
+                   all       5000      36335      0.651      0.521      0.561      0.367
+Speed: 0.1ms pre-process, 0.9ms inference, 1.0ms NMS per image at shape (32, 3, 640, 640)
 
 Evaluating pycocotools mAP... saving runs/val/exp2/best_predictions.json...
 loading annotations into memory...
-Done (t=0.42s)
+Done (t=0.43s)
 creating index...
 index created!
 Loading and preparing results...
-DONE (t=4.98s)
+DONE (t=4.20s)
 creating index...
 index created!
 Running per image evaluation...
 Evaluate annotation type *bbox*
-DONE (t=65.88s).
+DONE (t=62.69s).
 Accumulating evaluation results...
-DONE (t=11.81s).
- Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.350
-...
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.365
- Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.613
- Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.703
+DONE (t=10.60s).
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.370
+ Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.568
+ Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.400
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.215
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.421
+ Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.475
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.306
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.512
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.562
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.388
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.624
+ Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.713
 Results saved to runs/val/exp2

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -48,6 +48,9 @@ from models.common import (
     GhostBottleneck,
     GhostConv,
     Proto,
+    ConvNextTiny,
+    ConvNextP3,
+    ConvNextP4
 )
 from models.experimental import MixConv2d
 from utils.autoanchor import check_anchor_order
@@ -444,9 +447,17 @@ def parse_model(d, ch):
             c2 = ch[f] * args[0] ** 2
         elif m is Expand:
             c2 = ch[f] // args[0] ** 2
+        elif m is ConvNextTiny:
+            # ConvNextTiny: first arg is output channels (c2)
+            c2 = args[0] if args else 512
+        elif m in {ConvNextP3, ConvNextP4}:
+            # These helper modules retrieve stored features
+            # ConvNextP3 outputs 128 channels, ConvNextP4 outputs 256 channels
+            c2 = 128 if m is ConvNextP3 else 256
         else:
             c2 = ch[f]
 
+        print(f"Module: {m.__name__}, args: {args}")
         m_ = nn.Sequential(*(m(*args) for _ in range(n))) if n > 1 else m(*args)  # module
         t = str(m)[8:-2].replace("__main__.", "")  # module type
         np = sum(x.numel() for x in m_.parameters())  # number params

--- a/models/yolov5s.yaml
+++ b/models/yolov5s.yaml
@@ -9,7 +9,7 @@ anchors:
   - [30, 61, 62, 45, 59, 119] # P4/16
   - [116, 90, 156, 198, 373, 326] # P5/32
 
-# YOLOv5 v6.0 backbone
+# YOLOv5 v6.0 backbone (10 Layers)
 backbone:
   # [from, number, module, args]
   [

--- a/train.qsub
+++ b/train.qsub
@@ -1,0 +1,22 @@
+#!/bin/bash -l
+
+#$ -P ec500bn
+#$ -j y
+#$ -N yolov5
+#$ -o logs/yolo.qlog
+
+#$ -l h_rt=24:00:00
+#$ -pe omp 4
+
+#$ -l gpus=1
+#$ -l gpu_c=7.0
+
+# updated dino env combining dino reqs with breast-CLIP-downstream reqs
+module load python3
+source .venv/bin/activate
+
+# train
+python train.py --img 640 --batch 16 --epochs 50 --data coco.yaml --weights yolov5s.pt --cache disk
+
+# eval
+python val.py --weights runs/train/exp3/weights/best.pt --data coco.yaml --img 640


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

**WARNING ⚠️** this PR is very large, summary may not cover all changes.

### 🌟 Summary
Experimental integration of a ConvNeXt-Tiny backbone into YOLOv5 with HPC-specific training artifacts and notebook output updates, but with several environment-specific and debugging changes that are unlikely to be merge-ready.

### 📊 Key Changes
- 🧠 **New ConvNeXt backbone modules**
  - Adds `ConvNextTiny`, `ConvNextP3`, and `ConvNextP4` in `models/common.py`, using `timm.create_model('convnext_tiny', features_only=True, out_indices=[1, 2, 3])`.
  - Implements a global `_CONVNEXT_FEATURES` registry to pass multi-scale P3/P4/P5 features between modules.
  - Adapters map ConvNeXt feature channels to YOLOv5-style heads (P3→128, P4→256, P5→`c2`).
- 🧩 **Model parser integration**
  - Registers `ConvNextTiny`, `ConvNextP3`, and `ConvNextP4` in `models/yolo.py::parse_model` with fixed output channel assumptions.
  - Adds verbose `print(f"Module: {m.__name__}, args: {args}")` for every parsed layer (debug output).
- 🧷 **Dataset & environment coupling**
  - Replaces the generic `data/coco.yaml` path with a hard-coded absolute HPC path: `/projectnb/ec523bn/projects/ConvNeXt-YOLO/datasets/coco`.
  - Introduces `train.qsub` for a specific SGE/HPC setup and adds `logs/yolo.qlog` as a tracked log file.
- 📓 **Notebook output updates**
  - Modifies `tutorial.ipynb` to include executed cell outputs, environment-specific paths, warnings, and minor code/comment tweaks (e.g., commented-out clone, added `print(sys.executable)`).
- 📝 **Minor metadata/comment tweaks**
  - Adjusts a comment in `models/yolov5s.yaml` to annotate backbone layer count.

### 🎯 Purpose & Impact
- 🎯 **Intended purpose**
  - Enable experimentation with a ConvNeXt-Tiny backbone inside YOLOv5 for potential accuracy/feature improvements on COCO.
  - Capture and reuse multi-scale ConvNeXt features without modifying the standard detection head logic.
- ⚠️ **Potential issues / merge blockers**
  - Hard-coded absolute dataset path in `coco.yaml` breaks portability and standard usage patterns.
  - New runtime dependency on `timm` is added without updates to `requirements.txt` or documentation.
  - Global `_CONVNEXT_FEATURES` state and input `data_ptr()` keys are fragile for multi-GPU, dataloader workers, or concurrent inference.
  - Extensive `print` statements (initialization, stage channels, `parse_model` logs, and warning fallbacks) will spam stdout and slow training/CI.
  - `logs/yolo.qlog`, `train.qsub`, and executed `tutorial.ipynb` outputs are project- and environment-specific artifacts that generally should not be committed.
- 📈 **User impact (if refined)**
  - A cleaned-up version could offer users an additional ConvNeXt-based backbone option for detection experiments.
  - Proper integration would require configuration examples, docs, CI coverage, and robust handling of features without global mutable state.
