### PR TITLE
Replace `pkg_resources` with `packaging`

### DIFF
--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -6,8 +6,8 @@ import os
 import warnings
 from pathlib import Path
 
-import pkg_resources as pkg
 import torch
+from packaging.version import parse
 
 from utils.general import LOGGER, colorstr, cv2
 from utils.loggers.clearml.clearml_utils import ClearmlLogger
@@ -31,7 +31,7 @@ try:
     import wandb
 
     assert hasattr(wandb, "__version__")  # verify package import not local dir
-    if pkg.parse_version(wandb.__version__) >= pkg.parse_version("0.12.2") and RANK in {0, -1}:
+    if parse(wandb.__version__) >= parse("0.12.2") and RANK in {0, -1}:
         try:
             wandb_login_success = wandb.login(timeout=30)
         except wandb.errors.UsageError:  # known non-TTY terminal issue


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Replaces `pkg_resources` version checks with `packaging.version.parse` for Weights & Biases (W&B) login gating in YOLOv5 logging 🔧📈

### 📊 Key Changes
- Swapped `import pkg_resources as pkg` ➜ `from packaging.version import parse`
- Updated the W&B version comparison logic to use `parse(wandb.__version__) >= parse("0.12.2")`
- Kept existing behavior: only attempts `wandb.login()` when running on primary ranks (`RANK in {0, -1}`) 🚦

### 🎯 Purpose & Impact
- Reduces reliance on `pkg_resources` (often considered heavier and increasingly discouraged) ➜ cleaner dependency usage 🧹
- Improves compatibility and reliability of version parsing/comparisons for W&B 🧩
- Minimal user-facing change: logging behavior should remain the same, but environments without `pkg_resources` quirks are less likely to hit import/version issues ✅