### PR TITLE
Add `UTM` enabled banner redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <a href="https://platform.ultralytics.com/ultralytics/yolo26" target="_blank">
+    <a href="https://platform.ultralytics.com/?utm_source=github?utm_medium=referral?utm_campaign=platform_launch?utm_content=banner?utm_term=ultralytics_github" target="_blank">
       <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>
   </p>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <a href="https://platform.ultralytics.com/?utm_source=github?utm_medium=referral?utm_campaign=platform_launch?utm_content=banner?utm_term=ultralytics_github" target="_blank">
+    <a href="https://platform.ultralytics.com/?utm_source=github&utm_medium=referral&utm_campaign=platform_launch&utm_content=banner&utm_term=ultralytics_github" target="_blank">
       <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO banner"></a>
   </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <a href="https://platform.ultralytics.com/ultralytics/yolo26" target="_blank">
+    <a href="https://platform.ultralytics.com/?utm_source=github?utm_medium=referral?utm_campaign=platform_launch?utm_content=banner?utm_term=ultralytics_github" target="_blank">
       <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO 横幅"></a>
   </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 <div align="center">
   <p>
-    <a href="https://platform.ultralytics.com/?utm_source=github?utm_medium=referral?utm_campaign=platform_launch?utm_content=banner?utm_term=ultralytics_github" target="_blank">
+    <a href="https://platform.ultralytics.com/?utm_source=github&utm_medium=referral&utm_campaign=platform_launch&utm_content=banner&utm_term=ultralytics_github" target="_blank">
       <img width="100%" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics YOLO 横幅"></a>
   </p>
 


### PR DESCRIPTION
## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the README banner links to use a UTM-enabled redirect to the Ultralytics Platform for improved referral tracking 📈

### 📊 Key Changes
- Replaced the top banner link in `README.md` with a UTM-tagged Ultralytics Platform URL.
- Applied the same banner link update in `README.zh-CN.md` for consistency across localized documentation.
- Kept the existing banner image and placement unchanged, modifying only the destination URL.

### 🎯 Purpose & Impact
- Enables campaign and referral attribution for traffic coming from the GitHub README banner.
- Helps improve visibility into user acquisition and banner performance across repository entry points.
- Has minimal user-facing impact beyond redirecting banner clicks through a tracked platform URL.