### PR TITLE
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -149,7 +149,7 @@ jobs:
     steps:
       - name: Check for failure and notify
         if: (needs.Benchmarks.result == 'failure' || needs.Tests.result == 'failure' || needs.Benchmarks.result == 'cancelled' || needs.Tests.result == 'cancelled') && github.repository == 'ultralytics/yolov5' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR updates the GitHub Actions Slack notification step in YOLOv5 CI to use `slackapi/slack-github-action@v3.0.2` instead of `v3.0.1`.

### 📊 Key Changes
- 🛠️ Upgraded the Slack GitHub Action in `.github/workflows/ci-testing.yml`
- ⬆️ Changed the action version from `slackapi/slack-github-action@v3.0.1` to `@v3.0.2`
- 🚨 This affects the workflow step that sends Slack alerts when benchmark or test jobs fail or are cancelled

### 🎯 Purpose & Impact
- ✅ Keeps CI tooling up to date with the latest patch release of the Slack action
- 🔒 May include small bug fixes, reliability improvements, or security updates from the action maintainers
- 📣 Helps ensure failure notifications in Slack remain dependable for the YOLOv5 team
- 👥 Minimal user-facing impact, but useful for maintainers who rely on timely CI alerts