### PR TITLE
Set explicit workflow permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@
 name: Publish Docker Images
 
 permissions:
-  contents: read
+  contents: read # Required for checkout only; Docker Hub push uses repository secrets.
 
 on:
   push:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -11,7 +11,7 @@
 name: Check Broken links
 
 permissions:
-  contents: read
+  contents: read # Required for checkout and authenticated link checks only.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/merge-main-into-prs.yml
+++ b/.github/workflows/merge-main-into-prs.yml
@@ -6,7 +6,7 @@
 name: Merge main into PRs
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 on:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,15 +1,17 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: Close stale issues
+
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: "0 0 * * *" # Runs at 00:00 UTC every day
 
 jobs:
   stale:
-    permissions:
-      issues: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10


### PR DESCRIPTION
## Summary
- move stale workflow token permissions to workflow scope
- grant the PR branch updater the `contents: write` permission required by `update_branch()`
- document the existing read-only token scope for link checking and Docker publishing workflows

## CodeQL alerts
Addresses the open `actions/missing-workflow-permissions` alerts on `master`:
- #4: https://github.com/ultralytics/yolov5/security/code-scanning/4
- #8: https://github.com/ultralytics/yolov5/security/code-scanning/8
- #13: https://github.com/ultralytics/yolov5/security/code-scanning/13
- #14: https://github.com/ultralytics/yolov5/security/code-scanning/14

## Validation
- Parsed all four edited workflow YAML files with `yaml.safe_load()`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR updates GitHub Actions workflow permissions to better match what each automation job actually needs, improving clarity, reliability, and security.

### 📊 Key Changes
- Added explanatory comments to `contents: read` permissions in:
  - `.github/workflows/docker.yml`
  - `.github/workflows/links.yml`
- Changed permissions in `.github/workflows/merge-main-into-prs.yml`:
  - `contents: read` → `contents: write`
  - Kept `pull-requests: write`
- Moved permissions in `.github/workflows/stale.yml` from the job level to the workflow level:
  - `issues: write`
  - `pull-requests: write`
- Kept the stale issue cleanup behavior the same, while making permission setup more explicit and standardized 🧹

### 🎯 Purpose & Impact
- Improves workflow correctness ✅  
  - The merge automation now has the required write access to update branches and merge `main` into open PRs.
- Makes CI/CD configuration easier to understand 📘  
  - Added comments clarify why permissions are needed, which helps maintainers review and troubleshoot workflows faster.
- Encourages better security hygiene 🔒  
  - Permissions are more intentionally declared, helping avoid over- or under-scoped GitHub Actions access.
- Standardizes workflow configuration ⚙️  
  - Moving stale workflow permissions to the top level makes the setup cleaner and more consistent across the repository.