### PR TITLE
Fix lychee install workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -25,7 +25,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install lychee
-        run: curl -sSfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" | sudo tar xz -C /usr/local/bin
+        run: |
+          curl -sSfL "https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz" |
+            sudo tar xz --strip-components=1 -C /usr/local/bin lychee-x86_64-unknown-linux-gnu/lychee
 
       - name: Test Markdown and HTML links with retry
         uses: ultralytics/actions/retry@main


### PR DESCRIPTION
## Summary\n- Extract the lychee binary from the nested release archive path\n- Match the working handbook install command pattern\n\n## Tests\n- actionlint .github/workflows/links.yml\n- git diff --check -- .github/workflows/links.yml\n- Verified latest lychee archive contains lychee-x86_64-unknown-linux-gnu/lychee

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub link-checking workflow to install the `lychee` tool more reliably by extracting only the needed binary from its release archive.

### 📊 Key Changes
- Updated `.github/workflows/links.yml` in the **Install lychee** step.
- Replaced the previous one-line archive extraction command with a multi-line command for clearer handling.
- Added `--strip-components=1` to the `tar` command so only the `lychee` binary is extracted into `/usr/local/bin`.
- Explicitly targets `lychee-x86_64-unknown-linux-gnu/lychee` inside the downloaded archive instead of unpacking the full archive contents.

### 🎯 Purpose & Impact
- ✅ Improves the reliability of the CI link-checking workflow by ensuring the correct executable is installed.
- 🧹 Prevents unnecessary files or directory structure from being extracted into `/usr/local/bin`.
- 🔍 Helps reduce workflow failures caused by archive layout changes or incorrect extraction behavior.
- 🚀 Makes automated Markdown and HTML link validation more stable for contributors and maintainers.