### PR TITLE
Remove pip pin from App Engine requirements

### DIFF
--- a/utils/google_app_engine/additional_requirements.txt
+++ b/utils/google_app_engine/additional_requirements.txt
@@ -1,5 +1,4 @@
 # add these requirements in your app on top of the existing ones
-pip==26.0
 Flask==3.1.3
 gunicorn==23.0.0
 werkzeug>=3.0.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Summary
- remove the App Engine runtime requirement pin for `pip==26.0`
- leave the actual app runtime dependencies unchanged
- resolves the Dependabot alert for GHSA-58qw-9mgm-455v / CVE-2026-3219, which currently has no patched `pip` release

## Validation
- `rg -n "^pip([<>=!~ ]|$)|pip==" -g "*requirements*.txt" -g "pyproject.toml" -g "setup.cfg" -g "setup.py"`
- `git diff --check`
- `/tmp/yolov5-pip-alert-venv/bin/python -m pip install --dry-run -r utils/google_app_engine/additional_requirements.txt`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR removes the pinned `pip==26.0` dependency from the Google App Engine supplemental requirements to avoid unnecessarily forcing a specific `pip` version during deployment.

### 📊 Key Changes
- Removed `pip==26.0` from `utils/google_app_engine/additional_requirements.txt`
- Kept the existing Google App Engine-related packages unchanged:
  - `Flask==3.1.3`
  - `gunicorn==23.0.0`
  - `werkzeug>=3.0.1`

### 🎯 Purpose & Impact
- Reduces the chance of deployment issues caused by pinning `pip` as an application dependency ⚙️
- Keeps the requirements file focused on runtime packages actually needed by the app 📦
- Improves compatibility with Google App Engine environments, which typically manage `pip` separately ☁️
- Makes dependency management a bit cleaner and less brittle for users deploying YOLOv5 services 🚀