### PR TITLE
fix: harden Flask REST API uploads

### DIFF
--- a/tests/test_flask_rest_api.py
+++ b/tests/test_flask_rest_api.py
@@ -1,0 +1,76 @@
+# Ultralytics AGPL-3.0 License - https://ultralytics.com/license
+import io
+
+import pytest
+from PIL import Image
+
+from utils.flask_rest_api.restapi import DETECTION_URL, MAX_IMAGE_SIZE, app, models
+
+MODEL_NAME = "yolov5s"
+DETECTION_PATH = DETECTION_URL.replace("<model>", MODEL_NAME)
+
+
+class DummyResults:
+    class _Pandas:
+        xyxy = [type("DummyDf", (), {"to_json": lambda self, orient: "[]"})()]
+
+    def pandas(self):
+        return self._Pandas()
+
+
+class DummyModel:
+    def __call__(self, im, size=640):
+        return DummyResults()
+
+
+@pytest.fixture(autouse=True)
+def setup_model():
+    models.clear()
+    models[MODEL_NAME] = DummyModel()
+    yield
+    models.clear()
+
+
+@pytest.fixture
+def client():
+    app.config.update(TESTING=True)
+    return app.test_client()
+
+
+def make_image_bytes(fmt="PNG"):
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), color="white").save(buf, format=fmt)
+    buf.seek(0)
+    return buf
+
+
+def post_image(client, file_obj, filename):
+    return client.post(
+        DETECTION_PATH,
+        data={"image": (file_obj, filename)},
+        content_type="multipart/form-data",
+    )
+
+
+def test_rejects_non_image_upload_with_allowed_extension(client):
+    response = post_image(client, io.BytesIO(b"not really an image"), "fake.jpg")
+    assert response.status_code == 400
+    assert b"Invalid image file" in response.data
+
+
+def test_rejects_upload_with_disallowed_extension(client):
+    response = post_image(client, io.BytesIO(b"hello"), "payload.txt")
+    assert response.status_code == 400
+    assert b"Invalid file type" in response.data
+
+
+def test_rejects_oversized_upload(client):
+    response = post_image(client, io.BytesIO(b"a" * (MAX_IMAGE_SIZE + 1)), "large.jpg")
+    assert response.status_code in {413, 400}
+    assert b"File too large" in response.data or b"Request Entity Too Large" in response.data
+
+
+def test_accepts_valid_image_upload(client):
+    response = post_image(client, make_image_bytes(), "image.png")
+    assert response.status_code == 200
+    assert response.data == b"[]"

--- a/tests/test_flask_rest_api.py
+++ b/tests/test_flask_rest_api.py
@@ -66,8 +66,8 @@ def test_rejects_upload_with_disallowed_extension(client):
 
 def test_rejects_oversized_upload(client):
     response = post_image(client, io.BytesIO(b"a" * (MAX_IMAGE_SIZE + 1)), "large.jpg")
-    assert response.status_code in {413, 400}
-    assert b"File too large" in response.data or b"Request Entity Too Large" in response.data
+    assert response.status_code == 413
+    assert response.json == {"error": "File too large. Maximum size is 16 MB."}
 
 
 def test_accepts_valid_image_upload(client):

--- a/utils/flask_rest_api/restapi.py
+++ b/utils/flask_rest_api/restapi.py
@@ -6,6 +6,7 @@ import io
 
 from flask import Flask, request
 from PIL import Image
+from werkzeug.exceptions import RequestEntityTooLarge
 
 DETECTION_URL = "/v1/object-detection/<model>"
 ALLOWED_EXTENSIONS = {"jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp"}
@@ -14,6 +15,12 @@ MAX_IMAGE_SIZE = 16 * 1024 * 1024  # 16 MB
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = MAX_IMAGE_SIZE
 models = {}
+
+
+@app.errorhandler(RequestEntityTooLarge)
+def handle_large_upload(_):
+    """Return a JSON error for uploads rejected by Flask before request parsing."""
+    return {"error": "File too large. Maximum size is 16 MB."}, 413
 
 
 @app.route(DETECTION_URL, methods=["POST"])
@@ -31,7 +38,7 @@ def predict(model):
         filename = im_file.filename or ""
         ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
         if ext not in ALLOWED_EXTENSIONS:
-            return {"error": "Invalid file type. Allowed types: " + ", ".join(ALLOWED_EXTENSIONS)}, 400
+            return {"error": "Invalid file type. Allowed types: " + ", ".join(sorted(ALLOWED_EXTENSIONS))}, 400
 
         # Enforce upload size limit
         im_bytes = im_file.read(MAX_IMAGE_SIZE + 1)

--- a/utils/flask_rest_api/restapi.py
+++ b/utils/flask_rest_api/restapi.py
@@ -4,16 +4,16 @@
 import argparse
 import io
 
-import torch
 from flask import Flask, request
 from PIL import Image
-
-app = Flask(__name__)
-models = {}
 
 DETECTION_URL = "/v1/object-detection/<model>"
 ALLOWED_EXTENSIONS = {"jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp"}
 MAX_IMAGE_SIZE = 16 * 1024 * 1024  # 16 MB
+
+app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = MAX_IMAGE_SIZE
+models = {}
 
 
 @app.route(DETECTION_URL, methods=["POST"])
@@ -38,9 +38,12 @@ def predict(model):
         if len(im_bytes) > MAX_IMAGE_SIZE:
             return {"error": "File too large. Maximum size is 16 MB."}, 413
 
+        try:
+            with Image.open(io.BytesIO(im_bytes)) as im:
+                im.verify()
+        except Exception:
+            return {"error": "Invalid image file"}, 400
         im = Image.open(io.BytesIO(im_bytes))
-        im.verify()  # Verify it is a valid image (raises exception if not)
-        im = Image.open(io.BytesIO(im_bytes))  # Re-open after verify (verify closes the stream)
 
         if model in models:
             results = models[model](im, size=640)  # reduce size=320 for faster inference
@@ -48,6 +51,8 @@ def predict(model):
 
 
 if __name__ == "__main__":
+    import torch
+
     parser = argparse.ArgumentParser(description="Flask API exposing YOLOv5 model")
     parser.add_argument("--port", default=5000, type=int, help="port number")
     parser.add_argument("--model", nargs="+", default=["yolov5s"], help="model(s) to run, i.e. --model yolov5n yolov5s")

--- a/utils/flask_rest_api/restapi.py
+++ b/utils/flask_rest_api/restapi.py
@@ -12,6 +12,8 @@ app = Flask(__name__)
 models = {}
 
 DETECTION_URL = "/v1/object-detection/<model>"
+ALLOWED_EXTENSIONS = {"jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp"}
+MAX_IMAGE_SIZE = 16 * 1024 * 1024  # 16 MB
 
 
 @app.route(DETECTION_URL, methods=["POST"])
@@ -23,14 +25,22 @@ def predict(model):
         return
 
     if request.files.get("image"):
-        # Method 1
-        # with request.files["image"] as f:
-        #     im = Image.open(io.BytesIO(f.read()))
-
-        # Method 2
         im_file = request.files["image"]
-        im_bytes = im_file.read()
+
+        # Validate file extension against allowlist
+        filename = im_file.filename or ""
+        ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        if ext not in ALLOWED_EXTENSIONS:
+            return {"error": "Invalid file type. Allowed types: " + ", ".join(ALLOWED_EXTENSIONS)}, 400
+
+        # Enforce upload size limit
+        im_bytes = im_file.read(MAX_IMAGE_SIZE + 1)
+        if len(im_bytes) > MAX_IMAGE_SIZE:
+            return {"error": "File too large. Maximum size is 16 MB."}, 413
+
         im = Image.open(io.BytesIO(im_bytes))
+        im.verify()  # Verify it is a valid image (raises exception if not)
+        im = Image.open(io.BytesIO(im_bytes))  # Re-open after verify (verify closes the stream)
 
         if model in models:
             results = models[model](im, size=640)  # reduce size=320 for faster inference
@@ -46,4 +56,4 @@ if __name__ == "__main__":
     for m in opt.model:
         models[m] = torch.hub.load("ultralytics/yolov5", m, force_reload=True, skip_validation=True)
 
-    app.run(host="0.0.0.0", port=opt.port)  # debug=True causes Restarting with stat
+    app.run(host="127.0.0.1", port=opt.port)  # debug=True causes Restarting with stat


### PR DESCRIPTION
## Summary
Hardens the demo Flask REST API upload path by rejecting unsupported, malformed, and oversized image uploads before inference.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | MEDIUM |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `utils/flask_rest_api/restapi.py:25` |

The endpoint previously accepted uploaded files without type or size validation before passing them to image parsing and inference.

## Changes
- Adds an image extension allowlist and `PIL.Image.verify()` validation for uploaded files.
- Enforces a 16 MB upload/request limit and returns JSON for oversized uploads rejected by Flask.
- Rejects malformed image uploads with a 400 client error instead of a server error.
- Changes the default Flask bind address from `0.0.0.0` to `127.0.0.1` to avoid exposing the demo API on all interfaces by default.
- Adds focused Flask test-client regression coverage for invalid, disallowed, oversized, and valid uploads.

## Behavior Change
The demo server now binds to `127.0.0.1` by default. Users who previously accessed it remotely via the default all-interface bind will need to make an intentional host/proxy configuration change.

## Validation
- `PYTHONPATH=$PWD pytest -q -c /dev/null -p no:cacheprovider tests/test_flask_rest_api.py` (4 passed)
- `python -m py_compile utils/flask_rest_api/restapi.py tests/test_flask_rest_api.py`
- `ruff check utils/flask_rest_api/restapi.py tests/test_flask_rest_api.py`

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*