### PR TITLE
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -149,7 +149,7 @@ jobs:
     steps:
       - name: Check for failure and notify
         if: (needs.Benchmarks.result == 'failure' || needs.Tests.result == 'failure' || needs.Benchmarks.result == 'cancelled' || needs.Tests.result == 'cancelled') && github.repository == 'ultralytics/yolov5' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions Slack notification step to use a newer patch version of the Slack GitHub Action in the YOLOv5 CI workflow.

### 📊 Key Changes
- ⬆️ Upgraded `slackapi/slack-github-action` from `v3.0.2` to `v3.0.3` in `.github/workflows/ci-testing.yml`
- 🤖 The change affects the CI failure notification step that sends Slack alerts when benchmark or test jobs fail or are cancelled
- 🛠️ No model code, training logic, or inference behavior was changed

### 🎯 Purpose & Impact
- 🔒 Helps keep the CI pipeline up to date with the latest patch-level improvements from the Slack GitHub Action
- 📢 Improves reliability and maintainability of automated Slack notifications for failed scheduled or push-based CI runs
- ✅ Low-risk infrastructure update with no direct impact on YOLOv5 users, model performance, or results