### PR TITLE
Fix bugs and dead code across repo

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -134,12 +134,10 @@ def run(
 
     # Print results
     LOGGER.info("\n")
-    parse_opt()
     notebook_init()  # print system info
-    c = ["Format", "Size (MB)", "mAP50-95", "Inference time (ms)"] if map else ["Format", "Export", "", ""]
-    py = pd.DataFrame(y, columns=c)
+    py = pd.DataFrame(y, columns=["Format", "Size (MB)", "mAP50-95", "Inference time (ms)"])
     LOGGER.info(f"\nBenchmarks complete ({time.time() - t:.2f}s)")
-    LOGGER.info(str(py if map else py.iloc[:, :2]))
+    LOGGER.info(str(py))
     if hard_fail and isinstance(hard_fail, str):
         metrics = py["mAP50-95"].array  # values to compare to floor
         floor = eval(hard_fail)  # minimum metric floor to pass, i.e. = 0.29 mAP for YOLOv5n

--- a/classify/predict.py
+++ b/classify/predict.py
@@ -121,7 +121,7 @@ def run(
     seen, windows, dt = 0, [], (Profile(device=device), Profile(device=device), Profile(device=device))
     for path, im, im0s, vid_cap, s in dataset:
         with dt[0]:
-            im = torch.from_numpy(im).to(model.device)
+            im = torch.Tensor(im).to(model.device)
             im = im.half() if model.fp16 else im.float()  # uint8 to fp16/32
             if len(im.shape) == 3:
                 im = im[None]  # expand for batch dim

--- a/classify/predict.py
+++ b/classify/predict.py
@@ -121,7 +121,7 @@ def run(
     seen, windows, dt = 0, [], (Profile(device=device), Profile(device=device), Profile(device=device))
     for path, im, im0s, vid_cap, s in dataset:
         with dt[0]:
-            im = torch.Tensor(im).to(model.device)
+            im = torch.from_numpy(im).to(model.device)
             im = im.half() if model.fp16 else im.float()  # uint8 to fp16/32
             if len(im.shape) == 3:
                 im = im[None]  # expand for batch dim

--- a/detect.py
+++ b/detect.py
@@ -261,7 +261,7 @@ def run(
                 # Write results
                 for *xyxy, conf, cls in reversed(det):
                     c = int(cls)  # integer class
-                    label = names[c] if hide_conf else f"{names[c]}"
+                    label = names[c]
                     confidence = float(conf)
                     confidence_str = f"{confidence:.2f}"
 

--- a/export.py
+++ b/export.py
@@ -893,7 +893,8 @@ def export_tflite(
         converter.target_spec.supported_ops.append(tf.lite.OpsSet.SELECT_TF_OPS)
 
     tflite_model = converter.convert()
-    open(f, "wb").write(tflite_model)
+    with open(f, "wb") as fp:
+        fp.write(tflite_model)
     return f, None
 
 
@@ -1169,7 +1170,6 @@ def pipeline_coreml(model, im, file, names, y, mlmodel, prefix=colorstr("CoreML 
     print(spec.description)
 
     # Model from spec
-    weights_dir = None
     weights_dir = None if mlmodel else str(f / "Data/com.apple.CoreML/weights")
     model = ct.models.MLModel(spec, weights_dir=weights_dir)
 
@@ -1272,7 +1272,7 @@ def run(
     cache="",  # TensorRT: timing cache path
     simplify=False,  # ONNX: simplify model
     mlmodel=False,  # CoreML: Export in *.mlmodel format
-    opset=12,  # ONNX: opset version
+    opset=17,  # ONNX: opset version
     verbose=False,  # TensorRT: verbose log
     workspace=4,  # TensorRT: workspace size (GB)
     nms=False,  # TF: add NMS to model

--- a/export.py
+++ b/export.py
@@ -1272,7 +1272,7 @@ def run(
     cache="",  # TensorRT: timing cache path
     simplify=False,  # ONNX: simplify model
     mlmodel=False,  # CoreML: Export in *.mlmodel format
-    opset=17,  # ONNX: opset version
+    opset=12,  # ONNX: opset version
     verbose=False,  # TensorRT: verbose log
     workspace=4,  # TensorRT: workspace size (GB)
     nms=False,  # TF: add NMS to model

--- a/models/common.py
+++ b/models/common.py
@@ -714,6 +714,7 @@ class DetectMultiBackend(nn.Module):
                 for name in self.output_names:
                     i = self.model.get_binding_index(name)
                     self.bindings[name].data.resize_(tuple(self.context.get_binding_shape(i)))
+                    self.binding_addrs[name] = int(self.bindings[name].data.data_ptr())  # refresh after resize_
             s = self.bindings["images"].shape
             assert im.shape == s, f"input size {im.shape} {'>' if self.dynamic else 'not equal to'} max model size {s}"
             self.binding_addrs["images"] = int(im.data_ptr())

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -382,9 +382,7 @@ class LetterBox:
         imh, imw = im.shape[:2]
         r = min(self.h / imh, self.w / imw)  # ratio of new/old
         h, w = round(imh * r), round(imw * r)  # resized image
-        hs, ws = (
-            tuple(math.ceil(x / self.stride) * self.stride for x in (h, w)) if self.auto else (self.h, self.w)
-        )
+        hs, ws = tuple(math.ceil(x / self.stride) * self.stride for x in (h, w)) if self.auto else (self.h, self.w)
         top, left = round((hs - h) / 2 - 0.1), round((ws - w) / 2 - 0.1)
         im_out = np.full((self.h, self.w, 3), 114, dtype=im.dtype)
         im_out[top : top + h, left : left + w] = cv2.resize(im, (w, h), interpolation=cv2.INTER_LINEAR)

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -382,7 +382,9 @@ class LetterBox:
         imh, imw = im.shape[:2]
         r = min(self.h / imh, self.w / imw)  # ratio of new/old
         h, w = round(imh * r), round(imw * r)  # resized image
-        hs, ws = (math.ceil(x / self.stride) * self.stride for x in (h, w)) if self.auto else self.h, self.w
+        hs, ws = (
+            tuple(math.ceil(x / self.stride) * self.stride for x in (h, w)) if self.auto else (self.h, self.w)
+        )
         top, left = round((hs - h) / 2 - 0.1), round((ws - w) / 2 - 0.1)
         im_out = np.full((self.h, self.w, 3), 114, dtype=im.dtype)
         im_out[top : top + h, left : left + w] = cv2.resize(im, (w, h), interpolation=cv2.INTER_LINEAR)

--- a/utils/general.py
+++ b/utils/general.py
@@ -168,7 +168,7 @@ set_logging(LOGGING_NAME)  # run before defining LOGGER
 LOGGER = logging.getLogger(LOGGING_NAME)  # define globally (used in train.py, val.py, detect.py, etc.)
 if platform.system() == "Windows":
     for fn in LOGGER.info, LOGGER.warning:
-        setattr(LOGGER, fn.__name__, lambda x: fn(emojis(x)))  # emoji safe logging
+        setattr(LOGGER, fn.__name__, lambda x, fn=fn: fn(emojis(x)))  # emoji safe logging
 
 
 def user_config_dir(dir="Ultralytics", env_var="YOLOV5_CONFIG_DIR"):

--- a/utils/loggers/comet/__init__.py
+++ b/utils/loggers/comet/__init__.py
@@ -198,8 +198,6 @@ class CometLogger:
             )
             return self._get_experiment("offline", experiment_id)
 
-        return
-
     def log_metrics(self, log_dict, **kwargs):
         """Logs metrics to the current experiment, accepting a dictionary of metric names and values."""
         self.experiment.log_metrics(log_dict, **kwargs)
@@ -385,7 +383,7 @@ class CometLogger:
         elif isinstance(metadata_names, list):
             data_dict["names"] = {int(k): v for k, v in zip(range(len(metadata_names)), metadata_names)}
         else:
-            raise "Invalid 'names' field in dataset yaml file. Please use a list or dictionary"
+            raise ValueError("Invalid 'names' field in dataset yaml file. Please use a list or dictionary")
 
         return self.update_data_paths(data_dict)
 

--- a/utils/segment/plots.py
+++ b/utils/segment/plots.py
@@ -142,8 +142,6 @@ def plot_results_with_masks(file="path/to/results.csv", dir="", best=True):
                     # last
                     ax[i].scatter(x[-1], y[-1], color="r", label="last", marker="*", linewidth=3)
                     ax[i].set_title(s[j] + f"\n{round(y[-1], 5)}")
-                # if j in [8, 9, 10]:  # share train and val loss y axes
-                #     ax[i].get_shared_y_axes().join(ax[i], ax[i - 5])
         except Exception as e:
             print(f"Warning: Plotting error for {f}: {e}")
     ax[1].legend()

--- a/val.py
+++ b/val.py
@@ -175,7 +175,6 @@ def process_batch(detections, labels, iouv):
             if x[0].shape[0] > 1:
                 matches = matches[matches[:, 2].argsort()[::-1]]
                 matches = matches[np.unique(matches[:, 1], return_index=True)[1]]
-                # matches = matches[matches[:, 2].argsort()[::-1]]
                 matches = matches[np.unique(matches[:, 0], return_index=True)[1]]
             correct[matches[:, 1].astype(int), i] = True
     return torch.tensor(correct, dtype=torch.bool, device=iouv.device)


### PR DESCRIPTION
## Summary

Repo-wide bug scan with parallel review agents. Every change is a real bug fix or dead code removal — no new abstractions, no defensive validation for impossible states, net **-4 LOC** across 10 files.

## Bugs

- **`utils/general.py`** — Windows logger `lambda x: fn(emojis(x))` captured `fn` by reference (Python late binding), so by the time the loop ended both `LOGGER.info` and `LOGGER.warning` resolved to `LOGGER.warning`. Bind `fn` as a default argument.
- **`utils/augmentations.py`** — `LetterBox.__call__` had `hs, ws = genexp if self.auto else self.h, self.w`. The conditional binds tighter than the comma, so this parsed as `hs, ws = (genexp if ... else self.h), self.w`. With `auto=True`, `hs` was a generator object and the next line (`hs - h`) would raise `TypeError`. Parenthesize the tuple branches.
- **`utils/loggers/comet/__init__.py`** — `raise "Invalid 'names' field..."` is a `TypeError` in Python 3 (you can only raise exceptions, not strings). Promoted to `raise ValueError(...)`.
- **`models/common.py`** — TensorRT dynamic-shape path calls `bindings[name].data.resize_()` on output tensors but never refreshes `binding_addrs[name]`. If `resize_` reallocates storage, `execute_v2(list(self.binding_addrs.values()))` writes through stale pointers. Refresh `binding_addrs[name]` after `resize_`.
- **`export.py`** — TFLite export used `open(f, "wb").write(tflite_model)`, leaking the file handle. Wrap in a `with` block.
- **`export.py`** — `run()` had `opset=12` but the CLI parser defaulted `--opset 17`, so calling the function programmatically silently used a different ONNX opset than the documented default. Aligned to 17.
- **`benchmarks.py`** — `if map` referenced the Python builtin (always truthy), so the `else ["Format", "Export", "", ""]` branch and `py.iloc[:, :2]` slice were unreachable dead code. The append on every iteration always produced 4 columns. Removed the dead conditional. Also dropped a redundant `parse_opt()` call that re-parsed `sys.argv` for its print side-effect.
- **`detect.py`** — `label = names[c] if hide_conf else f"{names[c]}"` — both branches produced the same string. Simplified to `label = names[c]`.

## Dead code / cleanup

- **`val.py`** — Commented-out duplicate `argsort` step.
- **`export.py`** — `weights_dir = None` overwritten on the next line.
- **`utils/loggers/comet/__init__.py`** — Unreachable bare `return` after a try/except where both branches return.
- **`utils/segment/plots.py`** — Commented-out matplotlib block referencing the no-longer-existent `get_shared_y_axes().join()` API.

## Perf

- **`classify/predict.py`** — `torch.Tensor(im).to(model.device)` allocates a new tensor on CPU and copies; `torch.from_numpy(im).to(model.device)` shares numpy memory and avoids the extra CPU copy. Subsequent `.half()`/`.float()` produce the same dtype.

## Test plan

- [x] `python -m py_compile` passes for all modified files.
- [x] Standalone scripts verified the LetterBox precedence and Windows-logger late-binding fixes match expected behavior.
- [x] `python detect.py --help` and `python classify/predict.py --help` parse arguments cleanly. (`val.py`/`export.py`/`benchmarks.py --help` blocked locally by an unrelated missing `seaborn` dep — imports themselves are unchanged.)
- [ ] CI runs (training, val, all export formats, classify, segment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR mainly delivers small but important reliability, logging, and code-quality fixes across benchmarking, inference, export, and utility code in YOLOv5.

### 📊 Key Changes
- 📈 **Benchmark output was simplified and made more consistent**
  - Removed an unnecessary `parse_opt()` call from `benchmarks.py`.
  - Benchmark results are now always shown as a full table with format, model size, mAP50-95, and inference time.

- 🏷️ **Detection CSV labeling was cleaned up**
  - In `detect.py`, CSV-exported labels now always use the class name directly, avoiding confusing conditional behavior.

- 💾 **Safer file writing for TFLite export**
  - In `export.py`, TFLite models are now written using a context manager (`with open(...)`) for cleaner and safer file handling.

- 🍎 **Minor CoreML export cleanup**
  - Removed a redundant variable assignment in the CoreML export pipeline, improving readability.

- ⚡ **TensorRT dynamic-shape inference fix**
  - In `models/common.py`, binding memory addresses are now refreshed after tensor resize operations.
  - This helps prevent stale pointers during dynamic-shape inference.

- 🖼️ **Augmentation tuple handling was corrected**
  - In `utils/augmentations.py`, resize/padding dimensions are now explicitly returned as tuples, improving correctness and stability.

- 🪟 **Windows logging fix for emoji-safe messages**
  - In `utils/general.py`, logger wrapping now correctly captures function references, avoiding a common Python lambda issue.

- 🧪 **Comet logger error handling improved**
  - Removed an unnecessary bare `return`.
  - Replaced an invalid string-based exception with a proper `ValueError` when dataset `names` are malformed.

- 🧹 **General code cleanup**
  - Removed commented-out dead code in plotting and validation utilities for better maintainability.

### 🎯 Purpose & Impact
- ✅ **Improves runtime stability**
  - The TensorRT binding fix is the most impactful change, especially for users running inference with dynamic input sizes.

- 🔍 **Makes outputs easier to understand**
  - Benchmark results are more consistently displayed, which helps users compare export formats and model performance more easily.

- 🛡️ **Reduces risk of subtle bugs**
  - Safer file I/O, corrected tuple handling, and proper exception raising all help prevent hard-to-debug failures.

- 💻 **Improves cross-platform behavior**
  - The Windows logging fix makes console output more reliable, especially when emojis are used.

- 🧼 **Enhances maintainability for contributors**
  - Several changes are small refactors and cleanup items that make the codebase easier to read and maintain over time.