### PR TITLE
Run Python dependency updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
       time: "04:00"
     open-pull-requests-limit: 10
     labels:


### PR DESCRIPTION
## Summary
- change Dependabot `pip` updates from weekly to monthly
- leave GitHub Actions dependency update cadence unchanged

## Validation
- `git diff --check -- .github/dependabot.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR reduces Dependabot checks for Python packages in `ultralytics/yolov5` from weekly to monthly.

### 📊 Key Changes
- Updated `.github/dependabot.yml` for the `pip` ecosystem.
- Changed the Dependabot update schedule interval from `weekly` to `monthly`.
- No source code, model, training, or inference logic was modified.

### 🎯 Purpose & Impact
- 📉 Reduces the number of automated dependency update PRs opened in the repository.
- 🧹 Helps maintainers spend less time reviewing routine package bumps and managing PR backlog.
- 🎯 Keeps dependency updates more manageable while still maintaining regular package maintenance.
- 👥 For most users, there is no direct effect on YOLOv5 functionality, but repository maintenance may become calmer and more streamlined.