### PR TITLE
Fix ClearML documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ python train.py --data coco.yaml --epochs 300 --weights '' --cfg yolov5x.yaml --
 - **[Transfer Learning with Frozen Layers](https://docs.ultralytics.com/yolov5/tutorials/transfer_learning_with_frozen_layers/)**: Adapt pretrained models to new tasks efficiently using [transfer learning](https://www.ultralytics.com/glossary/transfer-learning).
 - **[Architecture Summary](https://docs.ultralytics.com/yolov5/tutorials/architecture_description/)** 🌟 **NEW**: Understand the YOLOv5 model architecture.
 - **[Ultralytics Platform Training](https://platform.ultralytics.com)** 🚀 **RECOMMENDED**: Train and deploy YOLO models using Ultralytics Platform.
-- **[ClearML Logging](https://docs.ultralytics.com/yolov5/tutorials/clearml_logging_integration/)**: Integrate with [ClearML](https://clear.ml/) for experiment tracking.
+- **[ClearML Logging](https://docs.ultralytics.com/yolov5/tutorials/clearml_logging_integration/)**: Integrate with [ClearML](https://www.clear.ml/) for experiment tracking.
 - **[Neural Magic DeepSparse Integration](https://docs.ultralytics.com/yolov5/tutorials/neural_magic_pruning_quantization/)**: Accelerate inference with DeepSparse.
 - **[Comet Logging](https://docs.ultralytics.com/yolov5/tutorials/comet_logging_integration/)** 🌟 **NEW**: Log experiments using [Comet ML](https://www.comet.com/site/).
 

--- a/utils/loggers/clearml/README.md
+++ b/utils/loggers/clearml/README.md
@@ -6,7 +6,7 @@
 
 ## ℹ️ About ClearML
 
-[ClearML](https://clear.ml/) is an [open-source MLOps platform](https://github.com/clearml/clearml) designed to streamline your machine learning workflow and maximize productivity. Integrating ClearML with [Ultralytics YOLO](https://docs.ultralytics.com/models/yolov5/) unlocks a robust suite of tools for experiment tracking, data management, and scalable deployment:
+[ClearML](https://www.clear.ml/) is an [open-source MLOps platform](https://github.com/clearml/clearml) designed to streamline your machine learning workflow and maximize productivity. Integrating ClearML with [Ultralytics YOLO](https://docs.ultralytics.com/models/yolov5/) unlocks a robust suite of tools for experiment tracking, data management, and scalable deployment:
 
 - **Experiment Management:** Effortlessly track every [YOLO training run](https://docs.ultralytics.com/modes/train/), including parameters, metrics, and outputs. Explore the [Ultralytics ClearML integration guide](https://docs.ultralytics.com/integrations/clearml/) for step-by-step instructions.
 - **Data Versioning:** Manage and access your custom training data with ClearML's Data Versioning Tool, similar to [DVC integration](https://docs.ultralytics.com/integrations/dvc/).
@@ -23,7 +23,7 @@ You can use ClearML's experiment manager alone or combine these features into a 
 ClearML requires a server to track experiments and data. You have two main options:
 
 1. **ClearML Hosted Service:** Sign up for a free account at [app.clear.ml](https://app.clear.ml/).
-2. **Self-Hosted Server:** Deploy your own ClearML server using the [official setup guide](https://clear.ml/docs/latest/docs/deploying_clearml/clearml_server). The server is open-source, ensuring data privacy and control.
+2. **Self-Hosted Server:** Deploy your own ClearML server using the [official setup guide](https://docs.clear.ml/docs/latest/docs/deploying_clearml/clearml_server). The server is open-source, ensuring data privacy and control.
 
 To get started:
 
@@ -176,7 +176,7 @@ ClearML Agent enables you to execute experiments on remote machines, including o
 Learn more about ClearML Agent:
 
 - [YouTube Introduction to ClearML Agent](https://www.youtube.com/watch?v=MX3BrXnaULs)
-- [Official ClearML Agent Documentation](https://clear.ml/docs/latest/docs/clearml_agent)
+- [Official ClearML Agent Documentation](https://docs.clear.ml/docs/latest/docs/clearml_agent)
 
 Turn any machine into a ClearML agent by running:
 


### PR DESCRIPTION
## Summary
- update ClearML product links to the canonical www.clear.ml host
- update ClearML documentation links to docs.clear.ml to avoid link checker 415 responses

## Tests
- /tmp/codex-bin/lychee --scheme https --timeout 60 --insecure --accept 100..=103,200..=299,401,403,429,500,502,999 --exclude-all-private --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' --exclude-path './**/ci.yml' --header 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.183 Safari/537.36' README.md utils/loggers/clearml/README.md

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR makes small but helpful documentation fixes by updating outdated ClearML links in YOLOv5 docs to the current official ClearML URLs 🔗✅

### 📊 Key Changes
- Updated the ClearML website link in the main `README.md` from `clear.ml` to `www.clear.ml`.
- Updated multiple links in `utils/loggers/clearml/README.md` to point to the current official ClearML documentation site.
- Fixed links for:
  - the ClearML homepage
  - self-hosted server setup docs
  - ClearML Agent docs
- No code, training logic, or model behavior was changed — this is a documentation-only PR 📝

### 🎯 Purpose & Impact
- Improves documentation reliability by reducing broken or outdated links 🔧
- Makes it easier for users to find the correct ClearML resources for experiment tracking and deployment
- Helps new users onboard more smoothly when setting up YOLOv5 + ClearML integrations 🚀
- Low-risk change with no effect on inference, training results, or performance