### PR TITLE
Use retrying dataset downloads

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -36,6 +36,35 @@ jobs:
           uv pip install --system -r requirements.txt coremltools openvino-dev "tensorflow<=2.19.0" "keras>=3.5.0,<=3.12.0" --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
           yolo checks
           uv pip list
+      - name: Cache CI assets
+        uses: actions/cache@v5
+        with:
+          path: |
+            ../datasets
+            yolov5*.pt
+          key: yolov5-ci-assets-${{ runner.os }}-${{ matrix.model }}-${{ hashFiles('.github/workflows/ci-testing.yml', 'data/coco128*.yaml') }}
+          restore-keys: |
+            yolov5-ci-assets-${{ runner.os }}-${{ matrix.model }}-
+      - name: Pre-cache CI assets
+        shell: bash # for Windows compatibility
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          from utils.downloads import attempt_download
+          from utils.general import DATASETS_DIR, download
+
+          assets_url = "https://github.com/ultralytics/assets/releases/download/v0.0.0"
+          for name in "coco128", "coco128-seg", "mnist160":
+              path = DATASETS_DIR / name
+              if not path.exists():
+                  download(f"{assets_url}/{name}.zip", dir=DATASETS_DIR, curl=True)
+              assert path.exists(), f"Dataset pre-cache failed: {path}"
+
+          for name in "${{ matrix.model }}.pt", "${{ matrix.model }}-seg.pt", "${{ matrix.model }}-cls.pt":
+              path = Path(attempt_download(name))
+              assert path.exists(), f"Weight pre-cache failed: {path}"
+          PY
       - name: Benchmark DetectionModel
         run: |
           python benchmarks.py --data coco128.yaml --weights ${{ matrix.model }}.pt --img 320 --hard-fail 0.29
@@ -77,6 +106,35 @@ jobs:
           fi
           uv pip install --system -r requirements.txt $torch --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
         shell: bash # for Windows compatibility
+      - name: Cache CI assets
+        uses: actions/cache@v5
+        with:
+          path: |
+            ../datasets
+            yolov5*.pt
+          key: yolov5-ci-assets-${{ runner.os }}-${{ matrix.model }}-${{ hashFiles('.github/workflows/ci-testing.yml', 'data/coco128*.yaml') }}
+          restore-keys: |
+            yolov5-ci-assets-${{ runner.os }}-${{ matrix.model }}-
+      - name: Pre-cache CI assets
+        shell: bash # for Windows compatibility
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          from utils.downloads import attempt_download
+          from utils.general import DATASETS_DIR, download
+
+          assets_url = "https://github.com/ultralytics/assets/releases/download/v0.0.0"
+          for name in "coco128", "coco128-seg", "mnist160":
+              path = DATASETS_DIR / name
+              if not path.exists():
+                  download(f"{assets_url}/{name}.zip", dir=DATASETS_DIR, curl=True)
+              assert path.exists(), f"Dataset pre-cache failed: {path}"
+
+          for name in "${{ matrix.model }}.pt", "${{ matrix.model }}-seg.pt", "${{ matrix.model }}-cls.pt":
+              path = Path(attempt_download(name))
+              assert path.exists(), f"Weight pre-cache failed: {path}"
+          PY
       - name: Update macOS security policy
         if: runner.os == 'macOS'
         run: |  # fix occasional torch multiprocessing failure

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -36,35 +36,6 @@ jobs:
           uv pip install --system -r requirements.txt coremltools openvino-dev "tensorflow<=2.19.0" "keras>=3.5.0,<=3.12.0" --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
           yolo checks
           uv pip list
-      - name: Cache CI assets
-        uses: actions/cache@v5
-        with:
-          path: |
-            ../datasets
-            yolov5*.pt
-          key: yolov5-ci-assets-${{ runner.os }}-${{ matrix.model }}-${{ hashFiles('.github/workflows/ci-testing.yml', 'data/coco128*.yaml') }}
-          restore-keys: |
-            yolov5-ci-assets-${{ runner.os }}-${{ matrix.model }}-
-      - name: Pre-cache CI assets
-        shell: bash # for Windows compatibility
-        run: |
-          python - <<'PY'
-          from pathlib import Path
-
-          from utils.downloads import attempt_download
-          from utils.general import DATASETS_DIR, download
-
-          assets_url = "https://github.com/ultralytics/assets/releases/download/v0.0.0"
-          for name in "coco128", "coco128-seg", "mnist160":
-              path = DATASETS_DIR / name
-              if not path.exists():
-                  download(f"{assets_url}/{name}.zip", dir=DATASETS_DIR, curl=True)
-              assert path.exists(), f"Dataset pre-cache failed: {path}"
-
-          for name in "${{ matrix.model }}.pt", "${{ matrix.model }}-seg.pt", "${{ matrix.model }}-cls.pt":
-              path = Path(attempt_download(name))
-              assert path.exists(), f"Weight pre-cache failed: {path}"
-          PY
       - name: Benchmark DetectionModel
         run: |
           python benchmarks.py --data coco128.yaml --weights ${{ matrix.model }}.pt --img 320 --hard-fail 0.29
@@ -106,35 +77,6 @@ jobs:
           fi
           uv pip install --system -r requirements.txt $torch --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
         shell: bash # for Windows compatibility
-      - name: Cache CI assets
-        uses: actions/cache@v5
-        with:
-          path: |
-            ../datasets
-            yolov5*.pt
-          key: yolov5-ci-assets-${{ runner.os }}-${{ matrix.model }}-${{ hashFiles('.github/workflows/ci-testing.yml', 'data/coco128*.yaml') }}
-          restore-keys: |
-            yolov5-ci-assets-${{ runner.os }}-${{ matrix.model }}-
-      - name: Pre-cache CI assets
-        shell: bash # for Windows compatibility
-        run: |
-          python - <<'PY'
-          from pathlib import Path
-
-          from utils.downloads import attempt_download
-          from utils.general import DATASETS_DIR, download
-
-          assets_url = "https://github.com/ultralytics/assets/releases/download/v0.0.0"
-          for name in "coco128", "coco128-seg", "mnist160":
-              path = DATASETS_DIR / name
-              if not path.exists():
-                  download(f"{assets_url}/{name}.zip", dir=DATASETS_DIR, curl=True)
-              assert path.exists(), f"Dataset pre-cache failed: {path}"
-
-          for name in "${{ matrix.model }}.pt", "${{ matrix.model }}-seg.pt", "${{ matrix.model }}-cls.pt":
-              path = Path(attempt_download(name))
-              assert path.exists(), f"Weight pre-cache failed: {path}"
-          PY
       - name: Update macOS security policy
         if: runner.os == 'macOS'
         run: |  # fix occasional torch multiprocessing failure

--- a/classify/train.py
+++ b/classify/train.py
@@ -110,7 +110,7 @@ def train(opt, device):
                 subprocess.run(["bash", str(ROOT / "data/scripts/get_imagenet.sh")], shell=True, check=True)
             else:
                 url = f"https://github.com/ultralytics/assets/releases/download/v0.0.0/{data}.zip"
-                download(url, dir=data_dir.parent)
+                download(url, dir=data_dir.parent, curl=True)
             s = f"Dataset download success ✅ ({time.time() - t:.1f}s), saved to {colorstr('bold', data_dir)}\n"
             LOGGER.info(s)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,4 +48,4 @@ setuptools>=70.0.0 # Snyk vulnerability fix
 # mss  # screenshots
 # albumentations>=1.0.3
 # pycocotools>=2.0.6  # COCO mAP
-urllib3>=2.6.0 ; python_version > "3.8" # not directly required, pinned by Snyk to avoid a vulnerability
+urllib3>=2.6.0 ; python_version > '3.8' # not directly required, pinned by Snyk to avoid a vulnerability

--- a/utils/general.py
+++ b/utils/general.py
@@ -564,12 +564,7 @@ def check_dataset(data, autodownload=True):
                 raise Exception("Dataset not found ❌")
             t = time.time()
             if s.startswith("http") and s.endswith(".zip"):  # URL
-                f = Path(s).name  # filename
-                LOGGER.info(f"Downloading {s} to {f}...")
-                torch.hub.download_url_to_file(s, f)
-                Path(DATASETS_DIR).mkdir(parents=True, exist_ok=True)  # create root
-                unzip_file(f, path=DATASETS_DIR)  # unzip
-                Path(f).unlink()  # remove zip
+                download(s, dir=DATASETS_DIR, curl=True)
                 r = None  # success
             elif s.startswith("bash "):  # bash script
                 LOGGER.info(f"Running {s} ...")

--- a/utils/general.py
+++ b/utils/general.py
@@ -44,7 +44,7 @@ except (ImportError, AssertionError):
     os.system("pip install -U ultralytics")
     import ultralytics
 
-from ultralytics.utils.checks import check_requirements
+from ultralytics.utils.checks import check_requirements as check_requirements_ultralytics
 from ultralytics.utils.patches import torch_load
 
 from utils import TryExcept, emojis
@@ -72,6 +72,13 @@ os.environ["OMP_NUM_THREADS"] = "1" if platform.system() == "darwin" else str(NU
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"  # suppress verbose TF compiler warnings in Colab
 os.environ["TORCH_CPP_LOG_LEVEL"] = "ERROR"  # suppress "NNPACK.cpp could not initialize NNPACK" warnings
 os.environ["KINETO_LOG_LEVEL"] = "5"  # suppress verbose PyTorch profiler output when computing FLOPs
+
+
+def check_requirements(requirements=ROOT / "requirements.txt", exclude=(), install=True, cmds="", **kwargs):
+    """Check repository requirements with the installed Ultralytics checker."""
+    if isinstance(requirements, Path) and sys.version_info < (3, 9):
+        exclude = (*exclude, "urllib3")
+    return check_requirements_ultralytics(requirements, exclude=exclude, install=install, cmds=cmds, **kwargs)
 
 
 def is_ascii(s=""):


### PR DESCRIPTION
## Summary
- reuse the existing retrying `download(..., curl=True)` path for classification dataset assets
- keep the earlier `check_dataset()` source-level retry fix for URL zip datasets
- make the `urllib3` Python marker shell-safe and skip that Python >3.8 requirement during Python 3.8 repo requirement checks

## Validation
- `python -m compileall -q utils/general.py classify/train.py`
- `git diff --check`
- mocked `utils.general.download` and verified `check_dataset()` calls it with `curl=True` for URL zip datasets
- verified `classify/train.py` routes asset downloads through `download(..., curl=True)`
- mocked Python 3.8 `check_requirements(Path("requirements.txt"))` and verified only `urllib3` is added to the exclude list
- `uv pip install --dry-run --python "$(python -c 'import sys; print(sys.executable)')" "urllib3>=2.6.0 ; python_version > '3.8'" --index-strategy=unsafe-best-match --break-system-packages`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves dataset downloading reliability in YOLOv5 by switching key downloads to `curl`-based handling and adding a safer local requirements wrapper for older Python environments. 🚀

### 📊 Key Changes
- Switched classification dataset downloads in `classify/train.py` to use `download(..., curl=True)` instead of the default downloader. 📥
- Simplified dataset auto-download logic in `utils/general.py` by replacing manual ZIP download/unzip/delete steps with a single `download(..., curl=True)` call. 🧹
- Added a local `check_requirements()` wrapper in `utils/general.py` that delegates to the Ultralytics requirement checker while applying a compatibility fix for Python versions below 3.9. 🛠️
- Renamed the imported Ultralytics checker to avoid naming conflicts: `check_requirements as check_requirements_ultralytics`. 🔄
- Updated a small formatting detail in `requirements.txt` for the `urllib3` Python-version marker, without changing functionality. ✨

### 🎯 Purpose & Impact
- Makes dataset downloads more robust and consistent, especially in environments where `curl` works better than the previous download path. 🌐
- Reduces maintenance burden by replacing custom download/unzip logic with a single shared utility call. ✅
- Helps prevent requirement-check issues on older Python versions by excluding `urllib3` when needed. 🐍
- Improves code clarity and reduces duplication, which should make future updates easier and less error-prone for developers. 👨‍💻
- For users, this likely means smoother dataset setup and fewer download-related failures during training. 🎯