### PR TITLE
Revert "Update ultralytics requirement from >=8.4.47 to >=8.4.58"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
     "pandas>=1.1.4",
     "seaborn>=0.11.0", # plotting
     "packaging", # general utilities
-    "ultralytics>=8.4.58"
+    "ultralytics>=8.4.47"
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ thop>=0.1.1  # FLOPs computation
 torch>=1.8.0  # see https://pytorch.org/get-started/locally (recommended)
 torchvision>=0.9.0
 tqdm>=4.66.3
-ultralytics>=8.4.58  # https://ultralytics.com
+ultralytics>=8.4.47  # https://ultralytics.com
 # protobuf<=3.20.1  # https://github.com/ultralytics/yolov5/issues/8012
 
 # Logging ---------------------------------------------------------------------


### PR DESCRIPTION
Reverts ultralytics/yolov5#13776

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR lowers the minimum required `ultralytics` package version for YOLOv5 from `8.4.58` to `8.4.47` to restore broader compatibility.

### 📊 Key Changes
- Updated the minimum `ultralytics` dependency in `pyproject.toml`:
  - from `ultralytics>=8.4.58`
  - to `ultralytics>=8.4.47`
- Updated the same dependency in `requirements.txt` to keep installation requirements consistent 📦
- No model code, training logic, or inference behavior was changed—this is purely a dependency version adjustment.

### 🎯 Purpose & Impact
- Improves installation compatibility for YOLOv5 users who may be pinned to or already using `ultralytics` versions earlier than `8.4.58` ✅
- Reduces the chance of unnecessary version conflicts in environments where newer `ultralytics` releases are not available or introduce issues ⚙️
- Makes setup a bit more flexible and reliable across different systems and dependency stacks 🤝
- Since this does not change YOLOv5 functionality itself, most users should see no behavior changes beyond easier installation and compatibility 👍