### PR TITLE
Exclude ClearML from link checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -43,6 +43,7 @@ jobs:
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \
+            --exclude 'https?://([^/]+\.)?clear\.ml(/.*)?' \
             --exclude-path './**/ci-testing.yml' \
             --github-token ${{ secrets.GITHUB_TOKEN }} \
             --header "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.183 Safari/537.36" \
@@ -69,6 +70,7 @@ jobs:
             --accept 100..=103,200..=299,401,403,429,500,502,999 \
             --exclude-all-private \
             --exclude 'https?://(www\.)?(linkedin\.com|twitter\.com|x\.com|instagram\.com|kaggle\.com|fonts\.gstatic\.com|url\.com)' \
+            --exclude 'https?://([^/]+\.)?clear\.ml(/.*)?' \
             --exclude 'https?://[^[:space:]]*(%7B|%7D|\{|\}|sentry\.io|google-analytics\.com/mp/collect|storage\.googleapis\.com|packages\.cloud\.google\.com/apt)(/.*)?' \
             --exclude 'https://github\.com/ultralytics/assets/releases/download/v0\.0\.0' \
             --exclude 'https://image-net\.org/data/ILSVRC/2012/ILSVRC2012_img_val\.tar' \


### PR DESCRIPTION
## Summary
- exclude ClearML domains from scheduled and manual lychee runs
- avoid recurring ClearML 415 false positives from failing broken-link CI

## Tests
- lychee scheduled Markdown/HTML surface: 620 total, 0 errors
- lychee expanded workflow-dispatch surface: 1368 total, 0 errors
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the GitHub link-checking workflow to ignore `clear.ml` URLs, reducing false CI failures caused by external link checks.

### 📊 Key Changes
- Added a new exclusion rule in `.github/workflows/links.yml` for all `clear.ml` subdomains and paths.
- Applied the exclusion in both link-checking workflow sections to keep behavior consistent.
- Left the rest of the link validation rules unchanged.

### 🎯 Purpose & Impact
- ✅ Prevents unnecessary workflow failures when `clear.ml` links are unreachable, blocked, or behave inconsistently.
- 🚀 Makes CI more stable and reliable by avoiding known problematic external URLs.
- 🧹 Reduces maintenance noise for contributors, so broken-link reports are more likely to reflect real issues in the repository.
- 👥 Improves developer experience by cutting down on false alarms during documentation and README checks.