### PR TITLE
Fix segment2box empty-points check (len(x) instead of any(x))

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -703,7 +703,7 @@ def segment2box(segment, width=640, height=640):
         x,
         y,
     ) = x[inside], y[inside]
-    return np.array([x.min(), y.min(), x.max(), y.max()]) if any(x) else np.zeros((1, 4))  # xyxy
+    return np.array([x.min(), y.min(), x.max(), y.max()]) if len(x) else np.zeros((1, 4))  # xyxy
 
 
 def segments2boxes(segments):


### PR DESCRIPTION
## Bug

`segment2box` (`utils/general.py`) converts a segment's vertices to the bounding box of the points that fall **inside** the image, returning a zero box when none do. The "are there inside points?" guard uses `any(x)`:

```python
def segment2box(segment, width=640, height=640):
    x, y = segment.T
    inside = (x >= 0) & (y >= 0) & (x <= width) & (y <= height)
    (x, y,) = x[inside], y[inside]
    return np.array([x.min(), y.min(), x.max(), y.max()]) if any(x) else np.zeros((1, 4))  # xyxy
```

`any(x)` tests whether any x-coordinate is **non-zero**, not whether the filtered arrays are **non-empty**. So when every inside vertex lies on the **left image border** (`x == 0`), `any(x)` is `False` and the real box `[0, y_min, 0, y_max]` is thrown away in favor of a degenerate `[0, 0, 0, 0]`. (The check is also asymmetric — it only looks at `x`, never `y`.) The empty case happens to work by accident; the all-zero-`x` case does not.

### Reproduction (run-verified)

A segment whose only inside-image vertices sit on the left edge:

```python
import numpy as np
seg = np.array([[0., 100.], [0., 260.], [-50., 300.], [700., -20.]])  # inside pts: (0,100),(0,260)
# current  -> [0., 0., 0., 0.]      (wrong: real box discarded)
# fixed    -> [0., 100., 0., 260.]  (correct)
```

| input | current `any(x)` | fixed `len(x)` |
|---|---|---|
| left-edge object (inside x all == 0) | `[0,0,0,0]` ❌ | `[0,100,0,260]` ✅ |
| normal object (x != 0) | `[10,20,50,80]` | `[10,20,50,80]` (unchanged) |
| no points inside | `[0,0,0,0]` | `[0,0,0,0]` (unchanged) |

### Impact

`segment2box` is called by `random_perspective` in both `utils/augmentations.py` and `utils/segment/augmentations.py`, and its result is written straight into the label box (`new[i] = segment2box(...)`). So during affine/perspective augmentation, any instance whose post-warp visible boundary lands on the left edge gets a corrupted `[0,0,0,0]` training label.

## Fix

Use `len(x)` (test for inside points) instead of `any(x)` (test for non-zero coordinate). The empty and normal cases are unchanged; only the previously-broken all-zero-`x` case is corrected.

```diff
-    return np.array([x.min(), y.min(), x.max(), y.max()]) if any(x) else np.zeros((1, 4))  # xyxy
+    return np.array([x.min(), y.min(), x.max(), y.max()]) if len(x) else np.zeros((1, 4))  # xyxy
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a small but important edge case in `segment2box()` by checking `len(x)` instead of `any(x)` when determining whether filtered segment points are present. 🛠️

### 📊 Key Changes
- Replaced `any(x)` with `len(x)` in `utils/general.py` inside `segment2box()`.
- Ensures the function correctly distinguishes between an empty array and valid coordinates that may include zeros.
- Preserves the existing fallback behavior of returning a zero box when no valid points remain after filtering.

### 🎯 Purpose & Impact
- Prevents incorrect handling of valid segmentation points when `x` contains zero-valued coordinates.
- Improves robustness of segmentation-to-bounding-box conversion logic. 🎯
- Reduces the chance of subtle bugs in segmentation workflows and downstream box generation for users working with instance segmentation. 📦