### PR TITLE
Simplify Slack notification messages

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -154,4 +154,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n"
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ❌ `${{ github.repository }}`  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"


### PR DESCRIPTION
Replaces the verbose multi-line Slack notifications with a single dense line — bold workflow name, status emoji, `${{ github.repository }}`, and a *Run* backlink — matching the format used in `ultralytics/portal`.

- Scopes the broad `<!channel>` ping down to `@yolo-team` to cut company-wide notification noise.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR simplifies and sharpens CI failure notifications by updating the Slack alert message format in the GitHub Actions workflow.

### 📊 Key Changes
- Reworked the Slack notification payload in `.github/workflows/ci-testing.yml`.
- Replaced the broad `<!channel>` alert with a targeted Slack subteam mention: `<!subteam^S082BPCRAJ3>`.
- Shortened the notification text to a more compact format showing:
  - the workflow name
  - the repository name
  - a direct link to the failed GitHub Actions run
- Removed extra fields from the Slack message, including:
  - repository URL
  - action URL shown as plain text
  - author
  - event type

### 🎯 Purpose & Impact
- 🎯 **Targets the right audience** by notifying a specific Slack team instead of alerting the entire channel.
- ⚡ **Improves readability** with a shorter, cleaner message that is easier to scan quickly.
- 🔗 **Speeds up debugging** by keeping a direct link to the failed run front and center.
- 📉 **Reduces notification noise** by removing less critical metadata from CI failure alerts.
- 👥 **Helps team response workflows** by making automated alerts more focused and actionable.