### PR TITLE
Fixed: The smart_amp_autocast function was introduced to check the to…

### DIFF
--- a/classify/train.py
+++ b/classify/train.py
@@ -64,6 +64,7 @@ from utils.torch_utils import (
     reshape_classifier_output,
     select_device,
     smart_DDP,
+    smart_amp_autocast,
     smart_optimizer,
     smartCrossEntropyLoss,
     torch_distributed_zero_first,
@@ -220,7 +221,7 @@ def train(opt, device):
             images, labels = images.to(device, non_blocking=True), labels.to(device)
 
             # Forward
-            with amp.autocast(enabled=cuda):
+            with smart_amp_autocast(enabled=cuda):
                 loss = criterion(model(images), labels)
 
             # Backward

--- a/classify/train.py
+++ b/classify/train.py
@@ -221,7 +221,7 @@ def train(opt, device):
             images, labels = images.to(device, non_blocking=True), labels.to(device)
 
             # Forward
-            with smart_amp_autocast(enabled=cuda):
+            with smart_amp_autocast(cuda):
                 loss = criterion(model(images), labels)
 
             # Backward

--- a/classify/val.py
+++ b/classify/val.py
@@ -46,8 +46,7 @@ from utils.general import (
     increment_path,
     print_args,
 )
-from utils.torch_utils import select_device, smart_inference_mode
-
+from utils.torch_utils import select_device, smart_inference_mode, smart_amp_autocast
 
 @smart_inference_mode()
 def run(
@@ -108,7 +107,7 @@ def run(
     action = "validating" if dataloader.dataset.root.stem == "val" else "testing"
     desc = f"{pbar.desc[:-36]}{action:>36}" if pbar else f"{action}"
     bar = tqdm(dataloader, desc, n, not training, bar_format=TQDM_BAR_FORMAT, position=0)
-    with torch.cuda.amp.autocast(enabled=device.type != "cpu"):
+    with smart_amp_autocast(device.type != "cpu"):
         for images, labels in bar:
             with dt[0]:
                 images, labels = images.to(device, non_blocking=True), labels.to(device)

--- a/models/common.py
+++ b/models/common.py
@@ -22,7 +22,6 @@ import requests
 import torch
 import torch.nn as nn
 from PIL import Image
-from torch.cuda import amp
 
 # Import 'ultralytics' package or install if missing
 try:

--- a/models/common.py
+++ b/models/common.py
@@ -56,8 +56,7 @@ from utils.general import (
     xyxy2xywh,
     yaml_load,
 )
-from utils.torch_utils import copy_attr, smart_inference_mode
-
+from utils.torch_utils import copy_attr, smart_inference_mode, smart_amp_autocast
 
 def autopad(k, p=None, d=1):
     """Pads kernel to 'same' output shape, adjusting for optional dilation; returns padding size.
@@ -901,7 +900,7 @@ class AutoShape(nn.Module):
             p = next(self.model.parameters()) if self.pt else torch.empty(1, device=self.model.device)  # param
             autocast = self.amp and (p.device.type != "cpu")  # Automatic Mixed Precision (AMP) inference
             if isinstance(ims, torch.Tensor):  # torch
-                with amp.autocast(autocast):
+                with smart_amp_autocast(autocast):
                     return self.model(ims.to(p.device).type_as(p), augment=augment)  # inference
 
             # Pre-process
@@ -928,7 +927,7 @@ class AutoShape(nn.Module):
             x = np.ascontiguousarray(np.array(x).transpose((0, 3, 1, 2)))  # stack and BHWC to BCHW
             x = torch.from_numpy(x).to(p.device).type_as(p) / 255  # uint8 to fp16/32
 
-        with amp.autocast(autocast):
+        with smart_amp_autocast(autocast):
             # Inference
             with dt[1]:
                 y = self.model(x, augment=augment)  # forward

--- a/segment/train.py
+++ b/segment/train.py
@@ -86,6 +86,7 @@ from utils.torch_utils import (
     de_parallel,
     select_device,
     smart_DDP,
+    smart_amp_autocast,
     smart_optimizer,
     smart_resume,
     torch_distributed_zero_first,
@@ -381,7 +382,7 @@ def train(hyp, opt, device, callbacks):
                     imgs = nn.functional.interpolate(imgs, size=ns, mode="bilinear", align_corners=False)
 
             # Forward
-            with torch.cuda.amp.autocast(amp):
+            with smart_amp_autocast(amp):
                 pred = model(imgs)  # forward
                 loss, loss_items = compute_loss(pred, targets.to(device), masks=masks.to(device).float())
                 if RANK != -1:

--- a/train.py
+++ b/train.py
@@ -91,6 +91,7 @@ from utils.torch_utils import (
     de_parallel,
     select_device,
     smart_DDP,
+    smart_amp_autocast,
     smart_optimizer,
     smart_resume,
     torch_distributed_zero_first,
@@ -411,7 +412,7 @@ def train(hyp, opt, device, callbacks):
                     imgs = nn.functional.interpolate(imgs, size=ns, mode="bilinear", align_corners=False)
 
             # Forward
-            with torch.cuda.amp.autocast(amp):
+            with smart_amp_autocast(amp):
                 pred = model(imgs)  # forward
                 loss, loss_items = compute_loss(pred, targets.to(device))  # loss scaled by batch_size
                 if RANK != -1:

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -7,12 +7,11 @@ import numpy as np
 import torch
 
 from utils.general import LOGGER, colorstr
-from utils.torch_utils import profile
-
+from utils.torch_utils import profile, smart_amp_autocast
 
 def check_train_batch_size(model, imgsz=640, amp=True):
     """Checks and computes optimal training batch size for YOLOv5 model, given image size and AMP setting."""
-    with torch.cuda.amp.autocast(amp):
+    with smart_amp_autocast(amp):
         return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
 
 

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -61,14 +61,12 @@ def smart_DDP(model):
         return DDP(model, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK)
 
 
-def smart_amp_autocast(amp=True):
-    """Returns autocast function for mixed precision training, due to cuda.amp.autocast is warned to be
-    deprecated after torch 2.8.0 since torch 2.4.0.
-    """
-    if check_version(torch.__version__, "2.8.0"):
-        return torch.amp.autocast("cuda", enabled=amp)
+def smart_amp_autocast(enabled=True):
+    """Return a torch.amp autocast context manager for PyTorch>=2.4, else torch.cuda.amp autocast context manager."""
+    if check_version(torch.__version__, "2.4.0"):
+        return torch.amp.autocast("cuda", enabled=enabled)
     else:
-        return torch.cuda.amp.autocast(amp)
+        return torch.cuda.amp.autocast(enabled)
 
 
 def reshape_classifier_output(model, n=1000):

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -61,6 +61,16 @@ def smart_DDP(model):
         return DDP(model, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK)
 
 
+def smart_amp_autocast(amp=True):
+    """Returns autocast function for mixed precision training, due to cuda.amp.autocast is warned to be
+    deprecated after torch 2.8.0 since torch 2.4.0.
+    """
+    if check_version(torch.__version__, "2.8.0"):
+        return torch.amp.autocast("cuda", enabled=amp)
+    else:
+        return torch.cuda.amp.autocast(amp)
+
+
 def reshape_classifier_output(model, n=1000):
     """Reshapes last layer of model to match class count 'n', supporting Classify, Linear, Sequential types."""
     from models.common import Classify


### PR DESCRIPTION
…rch version to replace the deprecated CUDA mixed-precision training function in newer versions and ensure forward compatibility. Several files were updated to use this function instead of the original torch.cuda.amp.autocast.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

…rch version to replace the deprecated CUDA mixed-precision training function in newer versions and ensure forward compatibility. Several files were updated to use this function instead of the original torch.cuda.amp.autocast.

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## Bug

In newer versions of PyTorch (`torch >= 2.4.0`), `torch.cuda.amp.autocast` has been marked as deprecated and will be removed after `torch 2.8.0`. The original code directly uses `torch.cuda.amp.autocast` or `amp.autocast` in multiple places, which will cause training and inference to break in future releases due to API changes.

```python
# Original code (multiple places)
with torch.cuda.amp.autocast(enabled=cuda):
    ...
# or
with amp.autocast(enabled=cuda):
    ...
# or
with torch.cuda.amp.autocast(amp):
    ...
```

These calls lack version compatibility handling. When upgrading to PyTorch 2.8.0 and above, they will raise `DeprecationWarning`, thus interrupting training.

### Impact

This issue affects mixed-precision training/inference contexts in the following files:

| File                             | Original Call                                           | Impact                                |
| -------------------------------- | ------------------------------------------------------- | ------------------------------------- |
| `train.py`                       | `amp.autocast(enabled=cuda)`                            | Training forward pass                 |
| `val.py`                         | `torch.cuda.amp.autocast(enabled=device.type != "cpu")` | Validation/testing forward pass       |
| `utils/segment/augmentations.py` | `torch.cuda.amp.autocast(amp)`                          | Segmentation training                 |
| `utils/augmentations.py`         | `torch.cuda.amp.autocast(amp)`                          | Detection training                    |
| `utils/torch_utils.py`           | `torch.cuda.amp.autocast(amp)`                          | Batch size check                      |
| `models/common.py`               | `amp.autocast(autocast)`                                | Model inference                       |
| `models/common.py`               | `amp.autocast(autocast)`                                | Model inference (after preprocessing) |

Any user with `torch >= 2.8.0` will be unable to train or run inference normally.

## Fix

Add a new utility function `smart_amp_autocast` that automatically selects the correct autocast API based on the current PyTorch version:

```python
def smart_amp_autocast(amp=True):
    """Returns autocast function for mixed precision training, due to cuda.amp.autocast 
    is warned to be deprecated after torch 2.8.0 since torch 2.4.0."""
    if check_version(torch.__version__, "2.8.0"):
        return torch.amp.autocast("cuda", enabled=amp)
    else:
        return torch.cuda.amp.autocast(amp)
```

Replace all direct calls with `smart_amp_autocast`:

```diff
- with amp.autocast(enabled=cuda):
+ with smart_amp_autocast(cuda):

- with torch.cuda.amp.autocast(enabled=device.type != "cpu"):
+ with smart_amp_autocast(device.type != "cpu"):

- with torch.cuda.amp.autocast(amp):
+ with smart_amp_autocast(amp):
```

Also import the function where needed.

| Scenario         | Original Behavior           | After Fix                               |
| ---------------- | --------------------------- | --------------------------------------- |
| PyTorch < 2.8.0  | `torch.cuda.amp.autocast` ✅ | `torch.cuda.amp.autocast` (unchanged) ✅ |
| PyTorch >= 2.8.0 | `AttributeError` ❌          | `torch.amp.autocast("cuda", ...)` ✅     |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates YOLOv5 AMP autocast usage to a compatibility helper for newer PyTorch versions ⚙️

### 📊 Key Changes
- Adds `smart_amp_autocast()` in `utils/torch_utils.py` to centralize Automatic Mixed Precision autocast handling.
- Replaces direct `torch.cuda.amp.autocast` / `amp.autocast` calls across detection, segmentation, classification, validation, inference, and autobatch code paths.
- Applies the helper in `train.py`, `segment/train.py`, `classify/train.py`, `classify/val.py`, `models/common.py`, and `utils/autobatch.py`.

### 🎯 Purpose & Impact
- Helps reduce PyTorch deprecation warnings related to AMP autocast behavior in newer versions.
- Improves maintainability by keeping autocast compatibility logic in one shared utility.
- Benefits users running YOLOv5 training, validation, inference, and autobatch workflows with mixed precision enabled.