### PR TITLE
Fix segmentation mask resize over 512 channels

### DIFF
--- a/tests/test_invariant_common.py
+++ b/tests/test_invariant_common.py
@@ -3,11 +3,14 @@
 import os
 import sys
 
+import cv2
+import numpy as np
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from models.common import _request_ssrf_url, _validate_ssrf_url
+from utils.segment.general import scale_image
 
 BLOCKED_URLS = [
     "http://169.254.169.254/latest/meta-data/",  # AWS metadata / link-local
@@ -63,3 +66,14 @@ def test_ssrf_redirect_target_is_validated(monkeypatch):
     with pytest.raises(ValueError):
         _request_ssrf_url("https://example.com/image.jpg")
     assert calls == ["https://example.com/image.jpg", "http://169.254.169.254/latest/meta-data/"]
+
+
+def test_scale_image_many_masks():
+    """scale_image must resize more than 512 masks, which OpenCV cannot resize as channels directly."""
+    masks = np.arange(4 * 5 * 513, dtype=np.float32).reshape(4, 5, 513)
+
+    resized = scale_image((4, 5), masks, (8, 10, 3))
+    expected = np.stack([cv2.resize(masks[:, :, i], (10, 8)) for i in range(masks.shape[2])], axis=2)
+
+    assert resized.shape == (8, 10, 513)
+    np.testing.assert_allclose(resized, expected)

--- a/utils/segment/general.py
+++ b/utils/segment/general.py
@@ -100,10 +100,13 @@ def scale_image(im1_shape, masks, im0_shape, ratio_pad=None):
     if len(masks.shape) < 2:
         raise ValueError(f'"len of masks shape" should be 2 or 3, but got {len(masks.shape)}')
     masks = masks[top:bottom, left:right]
-    # masks = masks.permute(2, 0, 1).contiguous()
-    # masks = F.interpolate(masks[None], im0_shape[:2], mode='bilinear', align_corners=False)[0]
-    # masks = masks.permute(1, 2, 0).contiguous()
-    masks = cv2.resize(masks, (im0_shape[1], im0_shape[0]))
+    if masks.ndim == 3 and masks.shape[2] > 512:
+        masks = [
+            cv2.resize(masks[:, :, i : i + 512], (im0_shape[1], im0_shape[0])) for i in range(0, masks.shape[2], 512)
+        ]
+        masks = np.concatenate([x if x.ndim == 3 else x[:, :, None] for x in masks], axis=2)
+    else:
+        masks = cv2.resize(masks, (im0_shape[1], im0_shape[0]))
 
     if len(masks.shape) == 2:
         masks = masks[:, :, None]


### PR DESCRIPTION
## Summary
- chunk native mask resizing when segmentation outputs exceed OpenCV's 512-channel resize limit
- preserve the existing OpenCV dependency and output shape behavior for single-mask and normal multi-mask cases
- add a CPU-only regression test for 513 masks

Fixes #10272

## Validation
- python -m pytest tests/test_invariant_common.py::test_scale_image_many_masks -q
- python -m pytest tests/test_invariant_common.py -m "not network" -q
- ruff format utils/segment/general.py tests/test_invariant_common.py && ruff check --fix utils/segment/general.py tests/test_invariant_common.py
- git diff --check

Deleted: stale commented-out torch interpolation resize path in utils/segment/general.py

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes segmentation mask resizing when processing more than 512 masks, improving reliability for large-instance segmentation outputs 🛠️

### 📊 Key Changes
- Updated `scale_image()` in `utils/segment/general.py` to handle 3D mask arrays with more than 512 channels.
- Added chunked resizing in groups of up to 512 masks to avoid OpenCV channel-limit issues.
- Preserved existing behavior for smaller mask sets and 2D masks.
- Added a new unit test, `test_scale_image_many_masks()`, to verify correct resizing for 513 masks ✅

### 🎯 Purpose & Impact
- Prevents failures or incorrect behavior when resizing large numbers of segmentation masks.
- Improves robustness for images with many detected objects or dense segmentation results.
- Ensures consistent output shape and values after resizing.
- Adds test coverage to help prevent regressions in future updates 🚀