### PR TITLE
Warn before YAML download script execution

### DIFF
--- a/tests/test_invariant_common.py
+++ b/tests/test_invariant_common.py
@@ -1,7 +1,9 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+import hashlib
 import os
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -63,3 +65,30 @@ def test_ssrf_redirect_target_is_validated(monkeypatch):
     with pytest.raises(ValueError):
         _request_ssrf_url("https://example.com/image.jpg")
     assert calls == ["https://example.com/image.jpg", "http://169.254.169.254/latest/meta-data/"]
+
+
+def test_yaml_shell_download_warns_with_hash(tmp_path, monkeypatch):
+    """YAML shell downloads must not execute silently."""
+    from utils import general
+
+    script = "bash scripts/download.sh"
+    data = tmp_path / "data.yaml"
+    data.write_text(
+        f"path: {tmp_path}\ntrain: images/train\nval: images/val\nnames:\n  0: person\ndownload: {script}\n"
+    )
+
+    events = []
+    monkeypatch.setattr(general.LOGGER, "warning", lambda message: events.append(("warning", message)))
+    monkeypatch.setattr(
+        general.subprocess,
+        "run",
+        lambda *args, **kwargs: events.append(("run", args, kwargs)) or SimpleNamespace(returncode=0),
+    )
+    monkeypatch.setattr(general, "check_font", lambda *args, **kwargs: None)
+
+    general.check_dataset(data)
+
+    assert events[0][0] == "warning"
+    assert "Dataset YAML download script will execute code" in events[0][1]
+    assert f"SHA256: {hashlib.sha256(script.encode()).hexdigest()}" in events[0][1]
+    assert events[1][0] == "run"

--- a/utils/general.py
+++ b/utils/general.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import contextlib
 import glob
+import hashlib
 import inspect
 import logging
 import logging.config
@@ -480,11 +481,16 @@ def check_dataset(data, autodownload=True):
             if s.startswith("http") and s.endswith(".zip"):  # URL
                 download(s, dir=DATASETS_DIR, curl=True)
                 r = None  # success
-            elif s.startswith("bash "):  # bash script
-                LOGGER.info(f"Running {s} ...")
-                r = subprocess.run(s, shell=True).returncode
-            else:  # python script
-                r = exec(s, {"yaml": data})  # return None
+            else:  # script
+                LOGGER.warning(
+                    "WARNING ⚠️ Dataset YAML download script will execute code. "
+                    f"Review the script for safety before running. SHA256: {hashlib.sha256(s.encode()).hexdigest()}"
+                )
+                if s.startswith("bash "):  # bash script
+                    LOGGER.info(f"Running {s} ...")
+                    r = subprocess.run(s, shell=True).returncode
+                else:  # python script
+                    r = exec(s, {"yaml": data})  # return None
             dt = f"({round(time.time() - t, 1)}s)"
             s = f"success ✅ {dt}, saved to {colorstr('bold', DATASETS_DIR)}" if r in (0, None) else f"failure {dt} ❌"
             LOGGER.info(f"Dataset download {s}")


### PR DESCRIPTION
## Summary
- warn before executing non-URL YAML `download:` scripts
- include the SHA256 fingerprint of the script content in the warning
- add a focused invariant test for shell download scripts

Fixes #6441

## Validation
- `ruff format utils/general.py tests/test_invariant_common.py && ruff check utils/general.py tests/test_invariant_common.py`
- `python -m pytest tests/test_invariant_common.py -q`
- `python -m py_compile utils/general.py tests/test_invariant_common.py`

Deleted: nothing. This is a narrow warning on an existing supported YAML autodownload execution path; deleting or relocating execution would break existing dataset YAML behavior.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a security warning when YOLOv5 dataset YAML files trigger executable download scripts, including a SHA256 hash for easier review 🔐

### 📊 Key Changes
- Added a warning before running any `download:` script defined in a dataset YAML file ⚠️
- Includes a SHA256 hash of the script command in the warning message for traceability 🧾
- Applies to both `bash` commands and inline Python download scripts 🐍
- Added a test to verify the warning appears before script execution and includes the expected hash ✅

### 🎯 Purpose & Impact
- Improves transparency by clearly notifying users when dataset setup may execute code 🚨
- Helps users and maintainers verify or audit download commands before they run 🔍
- Reduces the risk of silently executing potentially unsafe commands from dataset YAML files 🛡️
- Maintains existing autodownload behavior while making it safer and more visible for YOLOv5 users 🚀