### PR TITLE
Bump slackapi/slack-github-action from v3.0.5 to v4.0.0 in /.github/workflows

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -149,7 +149,7 @@ jobs:
     steps:
       - name: Check for failure and notify
         if: (needs.Benchmarks.result == 'failure' || needs.Tests.result == 'failure' || needs.Benchmarks.result == 'cancelled' || needs.Tests.result == 'cancelled') && github.repository == 'ultralytics/yolov5' && (github.event_name == 'schedule' || github.event_name == 'push') && github.run_attempt == '1'
-        uses: slackapi/slack-github-action@v3.0.5
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.5 to v4.0.0 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Upgraded the GitHub Actions Slack notification integration to version 4.0.0. 🔔

### 📊 Key Changes
- Updated `slackapi/slack-github-action` from `v3.0.5` to `v4.0.0` in the CI workflow.
- Applied the change to notifications for failed or cancelled benchmark and test jobs.

### 🎯 Purpose & Impact
- Ensures CI failure alerts use the latest supported Slack GitHub Action. ✅
- Improves compatibility, maintenance, and reliability of Slack notifications.
- No changes to model behavior, training, inference, or user-facing YOLOv5 functionality.