### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - name: Install requirements
         run: |
           uv pip install --system -r requirements.txt coremltools "openvino>=2024.0.0" "tensorflow<=2.19.0" "keras>=3.5.0,<=3.12.0" --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - name: Install requirements
         run: |
           torch=""

--- a/.github/workflows/merge-main-into-prs.yml
+++ b/.github/workflows/merge-main-into-prs.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: ultralytics/actions/setup-uv@main
       - name: Install requirements
         run: |
           uv pip install --system pygithub


### PR DESCRIPTION
## Summary

- replace all three Astral uv setup steps with the shared retried owner
- preserve benchmark, CI, and branch-maintenance behavior

Reused: `ultralytics/actions/setup-uv@main` is the single latest-uv installer owner.

Deleted: three direct `astral-sh/setup-uv` dependencies.

## Validation

- zero `uses: astral-sh/setup-uv` occurrences
- `actionlint` on both changed workflows
- `git diff --check`
- shared owner passed Windows, Ubuntu, and macOS CI in ultralytics/actions#819

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated GitHub Actions workflows to use Ultralytics’ shared `setup-uv` action instead of the external Astral action. 🔧

### 📊 Key Changes
- Replaced `astral-sh/setup-uv@v7` with `ultralytics/actions/setup-uv@main` in:
  - Continuous integration testing workflows.
  - The workflow that merges the latest `main` branch into pull requests.
- Kept the existing Python setup and dependency installation steps unchanged.

### 🎯 Purpose & Impact
- 🧩 Centralizes `uv` setup through Ultralytics’ shared GitHub Actions infrastructure.
- ⚙️ Standardizes dependency-management behavior across Ultralytics repositories.
- ✅ Maintains existing CI and automated merge functionality while simplifying future updates and maintenance.