### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -27,7 +27,7 @@ jobs:
         model: [yolov5n]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - uses: ultralytics/actions/setup-uv@main
@@ -65,7 +65,7 @@ jobs:
             torch: "1.8.0" # min torch version CI https://pypi.org/project/torchvision/
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - uses: ultralytics/actions/setup-uv@main

--- a/.github/workflows/merge-main-into-prs.yml
+++ b/.github/workflows/merge-main-into-prs.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'ultralytics/yolov5'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⚙️ Updates GitHub Actions workflows to use `actions/setup-python@v7` for more current and reliable Python environment setup.

### 📊 Key Changes

- Replaced `actions/setup-python@v6` with `actions/setup-python@v7` in:
  - CI testing workflows.
  - The workflow that merges the main branch into pull requests.
- No changes were made to model behavior, training, inference, or user-facing APIs.

### 🎯 Purpose & Impact

- ✅ Keeps repository automation aligned with the latest supported GitHub Action version.
- 🔄 Improves compatibility and maintenance of Python-based CI workflows.
- 🧪 Ensures existing tests continue running with the updated setup action.
- 👥 Minimal direct impact for users; benefits are primarily improved reliability for contributors and maintainers.