### PR TITLE
Reuse ultralytics box_iou, bbox_iou and smooth_bce

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     "torch>=1.8.0",
     "torchvision>=0.9.0",
     "psutil", # system utilization
-    "ultralytics-thop>=2.1.0", # FLOPs computation https://github.com/ultralytics/thop
+    "ultralytics-thop>=2.1.2", # FLOPs computation https://github.com/ultralytics/thop
     "pandas>=1.1.4",
     "seaborn>=0.11.0", # plotting
     "packaging", # general utilities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "pandas>=1.1.4",
     "seaborn>=0.11.0", # plotting
     "packaging", # general utilities
-    "ultralytics>=8.4.83"
+    "ultralytics>=8.4.109"
 ]
 
 # Optional dependencies ------------------------------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ psutil  # system resources
 PyYAML>=5.3.1
 requests>=2.32.2
 scipy>=1.4.1
-ultralytics-thop>=2.1.0  # FLOPs computation
+ultralytics-thop>=2.1.2  # FLOPs computation
 torch>=1.8.0  # see https://pytorch.org/get-started/locally (recommended)
 torchvision>=0.9.0
 ultralytics>=8.4.83  # https://ultralytics.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ scipy>=1.4.1
 ultralytics-thop>=2.1.2  # FLOPs computation
 torch>=1.8.0  # see https://pytorch.org/get-started/locally (recommended)
 torchvision>=0.9.0
-ultralytics>=8.4.83  # https://ultralytics.com
+ultralytics>=8.4.109  # https://ultralytics.com
 # protobuf<=3.20.1  # https://github.com/ultralytics/yolov5/issues/8012
 
 # Logging ---------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ setuptools>=70.0.0 # Snyk vulnerability fix
 # albumentations>=1.0.3
 # pycocotools>=2.0.6  # COCO mAP
 urllib3>=2.6.0 ; python_version > '3.8' # not directly required, pinned by Snyk to avoid a vulnerability
+filelock>=3.20.3 ; python_version >= '3.10' # not directly required, pinned by Snyk to avoid a vulnerability

--- a/segment/predict.py
+++ b/segment/predict.py
@@ -186,14 +186,7 @@ def run(
                     s += f"{n} {names[int(c)]}{'s' * (n > 1)}, "  # add to string
 
                 # Mask plotting
-                annotator.masks(
-                    masks,
-                    colors=[colors(x, True) for x in det[:, 5]],
-                    im_gpu=torch.as_tensor(im0, dtype=torch.float16).to(device).permute(2, 0, 1).flip(0).contiguous()
-                    / 255
-                    if retina_masks
-                    else im[i],
-                )
+                annotator.masks(masks, colors=[colors(x, True) for x in det[:, 5]])
 
                 # Write results
                 for j, (*xyxy, conf, cls) in enumerate(reversed(det[:, :6])):

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -3,16 +3,9 @@
 
 import torch
 from torch import nn
+from ultralytics.utils.metrics import bbox_iou, smooth_bce
 
-from utils.metrics import bbox_iou
 from utils.torch_utils import de_parallel
-
-
-def smooth_BCE(eps=0.1):
-    """Returns label smoothing BCE targets for reducing overfitting; pos: `1.0 - 0.5*eps`, neg: `0.5*eps`. For details
-    see https://github.com/ultralytics/yolov3/issues/238#issuecomment-598028441.
-    """
-    return 1.0 - 0.5 * eps, 0.5 * eps
 
 
 class BCEBlurWithLogitsLoss(nn.Module):
@@ -121,7 +114,7 @@ class ComputeLoss:
         BCEobj = nn.BCEWithLogitsLoss(pos_weight=torch.tensor([h["obj_pw"]], device=device))
 
         # Class label smoothing https://arxiv.org/pdf/1902.04103.pdf eqn 3
-        self.cp, self.cn = smooth_BCE(eps=h.get("label_smoothing", 0.0))  # positive, negative BCE targets
+        self.cp, self.cn = smooth_bce(eps=h.get("label_smoothing", 0.0))  # positive, negative BCE targets
 
         # Focal loss
         g = h["fl_gamma"]  # focal loss gamma

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,14 +1,13 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 """Model validation metrics."""
 
-import math
 import warnings
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-from ultralytics.utils.metrics import smooth
+from ultralytics.utils.metrics import box_iou, smooth
 
 from utils import TryExcept, threaded
 
@@ -221,50 +220,6 @@ class ConfusionMatrix:
             print(" ".join(map(str, self.matrix[i])))
 
 
-def bbox_iou(box1, box2, xywh=True, GIoU=False, DIoU=False, CIoU=False, eps=1e-7):
-    """Calculates IoU, GIoU, DIoU, or CIoU between two boxes, supporting xywh/xyxy formats.
-
-    box1 and box2 broadcast over the last dim; common shapes are (n,4) x (n,4) (loss) or (1,4) x (n,4).
-    """
-    # Get the coordinates of bounding boxes
-    if xywh:  # transform from xywh to xyxy
-        (x1, y1, w1, h1), (x2, y2, w2, h2) = box1.chunk(4, -1), box2.chunk(4, -1)
-        w1_, h1_, w2_, h2_ = w1 / 2, h1 / 2, w2 / 2, h2 / 2
-        b1_x1, b1_x2, b1_y1, b1_y2 = x1 - w1_, x1 + w1_, y1 - h1_, y1 + h1_
-        b2_x1, b2_x2, b2_y1, b2_y2 = x2 - w2_, x2 + w2_, y2 - h2_, y2 + h2_
-    else:  # x1, y1, x2, y2 = box1
-        b1_x1, b1_y1, b1_x2, b1_y2 = box1.chunk(4, -1)
-        b2_x1, b2_y1, b2_x2, b2_y2 = box2.chunk(4, -1)
-        w1, h1 = b1_x2 - b1_x1, (b1_y2 - b1_y1).clamp(eps)
-        w2, h2 = b2_x2 - b2_x1, (b2_y2 - b2_y1).clamp(eps)
-
-    # Intersection area
-    inter = (b1_x2.minimum(b2_x2) - b1_x1.maximum(b2_x1)).clamp(0) * (
-        b1_y2.minimum(b2_y2) - b1_y1.maximum(b2_y1)
-    ).clamp(0)
-
-    # Union Area
-    union = w1 * h1 + w2 * h2 - inter + eps
-
-    # IoU
-    iou = inter / union
-    if CIoU or DIoU or GIoU:
-        cw = b1_x2.maximum(b2_x2) - b1_x1.minimum(b2_x1)  # convex (smallest enclosing box) width
-        ch = b1_y2.maximum(b2_y2) - b1_y1.minimum(b2_y1)  # convex height
-        if CIoU or DIoU:  # Distance or Complete IoU https://arxiv.org/abs/1911.08287v1
-            c2 = cw**2 + ch**2 + eps  # convex diagonal squared
-            rho2 = ((b2_x1 + b2_x2 - b1_x1 - b1_x2) ** 2 + (b2_y1 + b2_y2 - b1_y1 - b1_y2) ** 2) / 4  # center dist ** 2
-            if CIoU:  # https://github.com/Zzh-tju/DIoU-SSD-pytorch/blob/master/utils/box/box_utils.py#L47
-                v = (4 / math.pi**2) * (torch.atan(w2 / h2) - torch.atan(w1 / h1)).pow(2)
-                with torch.no_grad():
-                    alpha = v / (v - iou + (1 + eps))
-                return iou - (rho2 / c2 + v * alpha)  # CIoU
-            return iou - rho2 / c2  # DIoU
-        c_area = cw * ch + eps  # convex area
-        return iou - (c_area - union) / c_area  # GIoU https://arxiv.org/pdf/1902.09630.pdf
-    return iou  # IoU
-
-
 def process_batch(detections, labels, iouv, pred_masks=None, gt_masks=None, overlap=False, masks=False):
     """Return a correct prediction matrix given detections and labels at various IoU thresholds.
 
@@ -309,28 +264,6 @@ def process_batch(detections, labels, iouv, pred_masks=None, gt_masks=None, over
                 matches = matches[np.unique(matches[:, 0], return_index=True)[1]]
             correct[matches[:, 1].astype(int), i] = True
     return torch.tensor(correct, dtype=torch.bool, device=iouv.device)
-
-
-def box_iou(box1, box2, eps=1e-7):
-    # https://github.com/pytorch/vision/blob/main/torchvision/ops/boxes.py
-    """Return intersection-over-union (Jaccard index) of boxes.
-
-    Both sets of boxes are expected to be in (x1, y1, x2, y2) format.
-
-    Args:
-        box1: (Tensor[N, 4])
-        box2: (Tensor[M, 4])
-        eps: Small value to avoid division by zero.
-
-    Returns:
-        iou (Tensor[N, M]): the NxM matrix containing the pairwise IoU values for every element in boxes1 and boxes2
-    """
-    # inter(N,M) = (rb(N,M,2) - lt(N,M,2)).clamp(0).prod(2)
-    (a1, a2), (b1, b2) = box1.unsqueeze(1).chunk(2, 2), box2.unsqueeze(0).chunk(2, 2)
-    inter = (torch.min(a2, b2) - torch.max(a1, b1)).clamp(0).prod(2)
-
-    # IoU = inter / (area1 + area2 - inter)
-    return inter / ((a2 - a1).prod(2) + (b2 - b1).prod(2) - inter + eps)
 
 
 def bbox_ioa(box1, box2, eps=1e-7):

--- a/utils/segment/loss.py
+++ b/utils/segment/loss.py
@@ -4,10 +4,10 @@
 import torch
 import torch.nn.functional as F
 from torch import nn
+from ultralytics.utils.metrics import bbox_iou, smooth_bce
 
 from ..general import xywh2xyxy
-from ..loss import FocalLoss, smooth_BCE
-from ..metrics import bbox_iou
+from ..loss import FocalLoss
 from ..torch_utils import de_parallel
 from .general import crop_mask
 
@@ -27,7 +27,7 @@ class ComputeLoss:
         BCEobj = nn.BCEWithLogitsLoss(pos_weight=torch.tensor([h["obj_pw"]], device=device))
 
         # Class label smoothing https://arxiv.org/pdf/1902.04103.pdf eqn 3
-        self.cp, self.cn = smooth_BCE(eps=h.get("label_smoothing", 0.0))  # positive, negative BCE targets
+        self.cp, self.cn = smooth_bce(eps=h.get("label_smoothing", 0.0))  # positive, negative BCE targets
 
         # Focal loss
         g = h["fl_gamma"]  # focal loss gamma


### PR DESCRIPTION
Deletes three duplicated metrics helpers in favor of `ultralytics.utils.metrics`, and fixes a live fp16 bug in the process. Net **−74 lines**.

### The fp16 bug

The local `box_iou` computes the union term in pure fp16:

```python
return inter / ((a2 - a1).prod(2) + (b2 - b1).prod(2) - inter + eps)
```

Any box larger than ~256 px overflows fp16 (`600 * 600 = 360000 > 65504`) → `inf` → IoU `0.0`. Upstream casts first, with an explicit note (`ultralytics/utils/metrics.py`):

```python
# NOTE: Need .float() to get accurate iou values
(a1, a2), (b1, b2) = box1.float().unsqueeze(1).chunk(2, 2), box2.float().unsqueeze(0).chunk(2, 2)
```

Measured on `[0,0,600,600]` vs `[10,10,610,610]`:

| | before | after |
|---|---|---|
| fp32 × fp16 | `0.0` | `0.9360` |
| fp16 × fp16 | `nan` | `0.9360` |

The path is live: `val.py:133` defaults `half=True`, `val.py:261` casts `im = im.half()`, and `train.py:463` vals at `half=amp` every epoch. It feeds `ConfusionMatrix.process_batch` and `process_batch`, so it silently depresses large-object mAP and can corrupt `best.pt` selection via `fitness`.

**Expect published `--half` numbers to move upward.** That is the fix, not a regression. FP32 validation is unaffected (`maxdiff 0.0`).

### The other two are exact

- `bbox_iou` — bitwise identical on the `xywh=True` path used by both call sites (`utils/loss.py:160`, `utils/segment/loss.py:70`): `maxdiff 0.0` for IoU, GIoU, DIoU and CIoU over 200 random box pairs.
- `smooth_BCE` → `smooth_bce` — identical one-line body, same return tuple.

`import math` becomes dead in `utils/metrics.py` once `bbox_iou` goes, so it is removed too.

### Notes

- Every symbol verified present at the pinned `ultralytics>=8.4.83` floor.
- `box_iou` is imported into `utils/metrics.py`, so the existing `from utils.metrics import box_iou` in `utils/general.py` and `utils/loggers/comet/` keeps resolving — no call-site churn. This matches what yolov3 already does.
- `bbox_iou`/`smooth_bce` are imported straight from ultralytics at their two consumers rather than re-exported, so no local name survives purely as a forwarding alias.
- Also bumps `ultralytics-thop` to `>=2.1.2` in `requirements.txt` and `pyproject.toml`. FLOPs-only, cannot affect metrics.

### Validation

- `python -m pytest tests/ -m "not network"` → 20 passed
- `python train.py --imgsz 64 --batch 32 --weights yolov5n.pt --cfg yolov5n.yaml --epochs 1 --device cpu` → completes, exercising `ComputeLoss` (`bbox_iou` + `smooth_bce`) and val (`box_iou`)
- `ruff format` + `ruff check` → clean

One limitation worth stating plainly: the fp16 path is GPU-only, so the end-to-end `--half` mAP delta was not measured here — this machine is CPU/macOS. The fix itself is verified directly at the function level, as shown above.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔄 Modernizes YOLOv5 dependencies and reuses shared Ultralytics utilities for metrics, loss functions, and segmentation mask rendering.

### 📊 Key Changes

- 📦 Updated `ultralytics` minimum version from `8.4.83` to `8.4.109`.
- 📈 Updated `ultralytics-thop` minimum version from `2.1.0` to `2.1.2` for FLOPs computation.
- 🔒 Added a Python 3.10+ `filelock` version pin to address a security vulnerability.
- 🧩 Replaced local implementations of `bbox_iou`, `box_iou`, and label-smoothing utilities with shared functions from `ultralytics.utils.metrics`.
- 🧹 Removed duplicated metric and loss code from YOLOv5.
- 🎨 Simplified segmentation mask plotting by using the annotator’s default mask rendering path.

### 🎯 Purpose & Impact

- ✅ Keeps YOLOv5 aligned with newer Ultralytics utility implementations and dependency fixes.
- 🛠️ Reduces duplicated code, making future maintenance and bug fixes easier.
- 🔐 Improves dependency security for supported Python 3.10+ environments.
- 📊 Preserves existing training and evaluation behavior while centralizing IoU and label-smoothing logic.
- 🚀 May improve compatibility with current Ultralytics packages, with segmentation visualization relying more on shared rendering behavior.