### PR TITLE
Fix OverflowError on segmentation images with 256+ instances

### DIFF
--- a/utils/segment/dataloaders.py
+++ b/utils/segment/dataloaders.py
@@ -7,7 +7,7 @@ import random
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
-from ultralytics.data.utils import polygons2masks, polygons2masks_overlap
+from ultralytics.data.utils import polygon2mask, polygons2masks, polygons2masks_overlap  # noqa: F401
 
 from ..augmentations import augment_hsv, copy_paste, letterbox
 from ..dataloaders import PIN_MEMORY, InfiniteDataLoader, LoadImagesAndLabels, SmartDistributedSampler, seed_worker

--- a/utils/segment/dataloaders.py
+++ b/utils/segment/dataloaders.py
@@ -4,10 +4,10 @@
 import os
 import random
 
-import cv2
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
+from ultralytics.data.utils import polygons2masks, polygons2masks_overlap
 
 from ..augmentations import augment_hsv, copy_paste, letterbox
 from ..dataloaders import PIN_MEMORY, InfiniteDataLoader, LoadImagesAndLabels, SmartDistributedSampler, seed_worker
@@ -299,75 +299,3 @@ class LoadImagesAndLabelsAndMasks(LoadImagesAndLabels):  # for training/testing
         for i, labels in enumerate(label):
             labels[:, 0] = i  # add target image index for build_targets()
         return torch.stack(img, 0), torch.cat(label, 0), path, shapes, batched_masks
-
-
-def polygon2mask(img_size, polygons, color=1, downsample_ratio=1):
-    """Convert polygons to a binary mask of the given image size.
-
-    Args:
-        img_size (tuple): The image size as (h, w).
-        polygons (np.ndarray): [N, M], N is the number of polygons, M is the number of points (divided by 2).
-        color (int): Fill value for the mask.
-        downsample_ratio (int): Mask downsample factor.
-
-    Returns:
-        (np.ndarray): Binary mask of shape (h // downsample_ratio, w // downsample_ratio).
-    """
-    mask = np.zeros(img_size, dtype=np.uint8)
-    polygons = np.asarray(polygons)
-    polygons = polygons.astype(np.int32)
-    shape = polygons.shape
-    polygons = polygons.reshape(shape[0], -1, 2)
-    cv2.fillPoly(mask, polygons, color=color)
-    nh, nw = (img_size[0] // downsample_ratio, img_size[1] // downsample_ratio)
-    # NOTE: fillPoly firstly then resize is trying the keep the same way
-    # of loss calculation when mask-ratio=1.
-    mask = cv2.resize(mask, (nw, nh))
-    return mask
-
-
-def polygons2masks(img_size, polygons, color, downsample_ratio=1):
-    """Convert a list of polygons to an array of binary masks of the given image size.
-
-    Args:
-        img_size (tuple): The image size as (h, w).
-        polygons (list[np.ndarray]): Each polygon is [N, M], N is the number of polygons, M is the number of points
-            (divided by 2).
-        color (int): Fill value for the masks.
-        downsample_ratio (int): Mask downsample factor.
-
-    Returns:
-        (np.ndarray): Array of binary masks.
-    """
-    masks = []
-    for si in range(len(polygons)):
-        mask = polygon2mask(img_size, [polygons[si].reshape(-1)], color, downsample_ratio)
-        masks.append(mask)
-    return np.array(masks)
-
-
-def polygons2masks_overlap(img_size, segments, downsample_ratio=1):
-    """Return a (640, 640) overlap mask."""
-    masks = np.zeros(
-        (img_size[0] // downsample_ratio, img_size[1] // downsample_ratio),
-        dtype=np.int32 if len(segments) > 255 else np.uint8,
-    )
-    areas = []
-    ms = []
-    for si in range(len(segments)):
-        mask = polygon2mask(
-            img_size,
-            [segments[si].reshape(-1)],
-            downsample_ratio=downsample_ratio,
-            color=1,
-        )
-        ms.append(mask)
-        areas.append(mask.sum())
-    areas = np.asarray(areas)
-    index = np.argsort(-areas)
-    ms = np.array(ms)[index]
-    for i in range(len(segments)):
-        mask = ms[i] * (i + 1)
-        masks = masks + mask
-        masks = np.clip(masks, a_min=0, a_max=i + 1)
-    return masks, index

--- a/utils/segment/dataloaders.py
+++ b/utils/segment/dataloaders.py
@@ -7,7 +7,7 @@ import random
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
-from ultralytics.data.utils import polygon2mask, polygons2masks, polygons2masks_overlap  # noqa: F401
+from ultralytics.data.utils import polygons2masks, polygons2masks_overlap
 
 from ..augmentations import augment_hsv, copy_paste, letterbox
 from ..dataloaders import PIN_MEMORY, InfiniteDataLoader, LoadImagesAndLabels, SmartDistributedSampler, seed_worker


### PR DESCRIPTION
`polygons2masks_overlap` builds the overlap mask by accumulating the instance index into a `uint8` array:

```python
masks = np.zeros(..., dtype=np.int32 if len(segments) > 255 else np.uint8)
...
mask = ms[i] * (i + 1)          # ms is uint8
masks = np.clip(masks + mask, 0, i + 1)
```

Two defects:

1. **Hard crash at 256+ instances.** The dtype guard promotes `masks` to `int32`, but `ms[i]` stays `uint8`, and NumPy refuses to cast the scalar `256` into it.
2. **Silent corruption above ~128 instances.** Add-then-clip loses instance identity where masks overlap, well before the crash threshold.

Measured on the current code:

| instances/img | before | after |
|---|---|---|
| 10, 100 | ok | ok (identical) |
| 150 | ok, values wrong | ok |
| 256 | `OverflowError: Python integer 256 out of bounds for uint8` | ok |
| 300 | `OverflowError` | ok |

`ultralytics.data.utils` already owns a fixed implementation that accumulates with a running maximum and promotes the dtype, so the three local helpers are **deleted** rather than patched. `import cv2` went with them — nothing else in the file used it.

### Equivalence

Verified against the deleted code before removing it:

- `polygon2mask`: **0 mismatches** across 900 cases (300 random polygons × downsample ratios 1/2/4).
- `polygons2masks`: bit-identical at all three ratios.
- `polygons2masks_overlap`: identical for 1–100 instances; diverges only above ~128, i.e. only where the local version was already producing wrong output.

Both call sites (`utils/segment/dataloaders.py:185,191`) pass arguments positionally or by a keyword the upstream signature shares, so **no call-site edits**. Both sit behind `if nl:`, so the empty-input path is unreachable.

### Scope of behavior change

None for any realistic dataset. `coco128-seg` peaks at **42** instances in a single image and has **zero** images at the ≥128 divergence threshold, so shipped training and validation are bit-identical. Datasets that would change are exclusively ones that crash or corrupt today — dense crowd, cell, and aerial imagery.

### Validation

- `python segment/train.py --imgsz 64 --batch 8 --weights yolov5n-seg.pt --epochs 1 --device cpu` → completes (exercises the `--overlap-mask` default path)
- Instance sweep at n = 10 / 100 / 256 / 300 → all succeed, dtype promotes `uint8`→`int32` automatically
- `ruff format` + `ruff check` → clean

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

♻️ Reuses centralized Ultralytics polygon-to-mask utilities instead of maintaining duplicate segmentation code in YOLOv5.

### 📊 Key Changes

- Removed the local `polygon2mask`, `polygons2masks`, and `polygons2masks_overlap` implementations from `utils/segment/dataloaders.py`.
- Imported `polygons2masks` and `polygons2masks_overlap` from `ultralytics.data.utils`.
- Removed the now-unneeded OpenCV import from the segmentation dataloader.

### 🎯 Purpose & Impact

- ✅ Reduces duplicated code and simplifies maintenance.
- 🔄 Keeps YOLOv5 segmentation data loading aligned with shared Ultralytics utilities.
- 📦 May reduce direct OpenCV dependency usage in this module while preserving existing mask-generation behavior.
- 🛠️ Centralizes future improvements and bug fixes for polygon-to-mask conversion.