### PR TITLE
Honor --opset on ONNX export

### DIFF
--- a/export.py
+++ b/export.py
@@ -322,8 +322,9 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr("ONNX
         pip install onnx onnxslim onnxruntime onnxruntime-gpu
         ```
     """
-    check_requirements(("onnx>=1.12.0", "onnxscript"))
+    check_requirements("onnx>=1.12.0")
     import onnx
+    from ultralytics.utils.export import torch2onnx
 
     LOGGER.info(f"\n{prefix} starting export with onnx {onnx.__version__}...")
     f = str(file.with_suffix(".onnx"))
@@ -337,16 +338,14 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr("ONNX
         elif isinstance(model, DetectionModel):
             dynamic["output0"] = {0: "batch", 1: "anchors"}  # shape(1,25200,85)
 
-    torch.onnx.export(
+    torch2onnx(
         model.cpu() if dynamic else model,  # --dynamic only compatible with cpu
         im.cpu() if dynamic else im,
         f,
-        verbose=False,
-        opset_version=opset,
-        do_constant_folding=True,  # WARNING: DNN inference with torch>=1.12 may require do_constant_folding=False
+        opset=opset,
         input_names=["images"],
         output_names=output_names,
-        dynamic_axes=dynamic or None,
+        dynamic=dynamic or None,
     )
 
     # Checks


### PR DESCRIPTION
`torch.onnx.export` defaults `dynamo=True` on torch ≥2.6. The dynamo path exports at opset 18 regardless of what you asked for, attempts a downgrade, fails, and writes the opset-18 file anyway.

Reproduced on torch 2.13 / onnx 1.18 with `--opset 12`:

```
W torch/onnx/_internal/exporter/_compat.py:133] Setting ONNX exporter to use operator set
  version 18 because the requested opset_version 12 is a lower version ...
The model version conversion is not supported by the onnxscript version converter and
  fallback is enabled. The model will be converted using the onnx C API (target version: 12).
Failed to convert the model to the target version 12 using the ONNX C API. The model was not modified
  File ".../onnxscript/version_converter/__init__.py", line 137, in call
```
```python
>>> onnx.load("yolov5n.onnx").opset_import
[domain: "" version: 18]        # requested 12
```

This is not cosmetic: `export_engine` hardcodes `opset=12` for TensorRT 7/8 (`export.py:641,645`) and has been receiving opset 18 the whole time.

`ultralytics.utils.export.torch2onnx` wraps the identical `torch.onnx.export` call with `dynamo=False` on `TORCH_2_4+`, so the local call is **replaced rather than re-implemented**. Every argument maps 1:1 (`dynamic_axes` → `dynamic`, `opset_version` → `opset`); `do_constant_folding=True` and `verbose=False` are already its defaults.

After:
```
ONNX: export success ✅ 0.1s, saved as yolov5n.onnx (7.3 MB)
>>> onnx.load("yolov5n.onnx").opset_import
[version: 12]
```
No traceback, no warning.

### Numerics unchanged

`val.py --data coco128.yaml --img 320 --device cpu`:

| model | P | R | mAP50 | mAP50-95 |
|---|---|---|---|---|
| master export (opset 18) | 0.558 | 0.397 | 0.459 | 0.294 |
| this PR (opset 12) | 0.558 | 0.397 | 0.459 | 0.294 |

Identical. (The `.pt` scores `0.455 / 0.288` at this size — that PyTorch↔ONNX gap exists on master too and is untouched by this change.)

### Notes

- **Import is function-scoped.** `models/common.py:802` does `from export import export_formats` on every `DetectMultiBackend` construction, so a module-level import would add 58 modules to every `detect.py` / `val.py` / `benchmarks.py` run. Placing it beside the existing `import onnx` keeps that cost on the export path only.
- **`onnxscript` dropped from `check_requirements`.** It is only reachable through the dynamo path; verified `'onnxscript' in sys.modules` is `False` after a full export. One less runtime pip install.

### Validation

All at `--opset 12`, all writing opset 12:

- default → export success, val metrics above
- `--dynamic` → success, batch dim preserved as `batch`
- `--simplify` → success
- `yolov5n-seg.pt` → success, both `output0` / `output1` present
- `ruff format` + `ruff check` → clean

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 Updates YOLOv5 ONNX export to use Ultralytics’ shared `torch2onnx` utility and removes the `onnxscript` dependency.

### 📊 Key Changes
- Replaces the direct `torch.onnx.export` call with `ultralytics.utils.export.torch2onnx`.
- Removes the required `onnxscript` package from ONNX export dependencies.
- Updates export arguments to use `opset` and `dynamic` with the shared utility.
- Preserves dynamic input/output handling for supported YOLOv5 models.

### 🎯 Purpose & Impact
- ✅ Simplifies dependency installation by requiring only `onnx>=1.12.0`.
- 🔧 Centralizes PyTorch-to-ONNX conversion logic for more consistent export behavior across Ultralytics projects.
- 🚀 May improve maintainability and compatibility as ONNX export support evolves.
- 📦 Existing ONNX export workflows should continue to produce equivalent model files with fewer direct dependencies.