### PR TITLE
Import feature_visualization from ultralytics

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -52,7 +52,7 @@ from models.common import (
 from models.experimental import MixConv2d
 from utils.autoanchor import check_anchor_order
 from utils.general import LOGGER, check_version, check_yaml, colorstr, make_divisible, print_args
-from utils.plots import feature_visualization
+from ultralytics.utils.plotting import feature_visualization
 from utils.torch_utils import (
     fuse_conv_and_bn,
     initialize_weights,

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -25,6 +25,8 @@ if str(ROOT) not in sys.path:
 if platform.system() != "Windows":
     ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
+from ultralytics.utils.plotting import feature_visualization
+
 from models.common import (
     C3,
     C3SPP,
@@ -52,7 +54,6 @@ from models.common import (
 from models.experimental import MixConv2d
 from utils.autoanchor import check_anchor_order
 from utils.general import LOGGER, check_version, check_yaml, colorstr, make_divisible, print_args
-from ultralytics.utils.plotting import feature_visualization
 from utils.torch_utils import (
     fuse_conv_and_bn,
     initialize_weights,

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -75,38 +75,6 @@ class Colors:
 colors = Colors()  # create instance for 'from utils.plots import colors'
 
 
-def feature_visualization(x, module_type, stage, n=32, save_dir=Path("runs/detect/exp")):
-    """Visualize feature maps of a given model module during inference.
-
-    Args:
-        x: Features to be visualized
-        module_type: Module type
-        stage: Module stage within model
-        n: Maximum number of feature maps to plot
-        save_dir: Directory to save results.
-    """
-    if ("Detect" not in module_type) and (
-        "Segment" not in module_type
-    ):  # 'Detect' for Object Detect task,'Segment' for Segment task
-        _batch, channels, height, width = x.shape  # batch, channels, height, width
-        if height > 1 and width > 1:
-            f = save_dir / f"stage{stage}_{module_type.split('.')[-1]}_features.png"  # filename
-
-            blocks = torch.chunk(x[0].cpu(), channels, dim=0)  # select batch index 0, block by channels
-            n = min(n, channels)  # number of plots
-            _fig, ax = plt.subplots(math.ceil(n / 8), 8, tight_layout=True)
-            ax = ax.ravel()
-            plt.subplots_adjust(wspace=0.05, hspace=0.05)
-            for i in range(n):
-                ax[i].imshow(blocks[i].squeeze())  # cmap='gray'
-                ax[i].axis("off")
-
-            LOGGER.info(f"Saving {f}... ({n}/{channels})")
-            plt.savefig(f, dpi=300, bbox_inches="tight")
-            plt.close()
-            np.save(str(f.with_suffix(".npy")), x[0].cpu().numpy())  # npy save
-
-
 def hist2d(x, y, n=100):
     """Generates a logarithmic 2D histogram, useful for visualizing label or evolution distributions.
 


### PR DESCRIPTION
`models/yolo.py` imported `feature_visualization` from `utils/plots.py`, and that module imports `matplotlib`, `seaborn` and `scipy` at module scope. So every consumer of `models.yolo` paid for the full plotting stack to get one function that is only reachable behind `--visualize`.

The ultralytics version has an **identical signature** and scopes `matplotlib` inside the function body, so the local copy is deleted rather than reimplemented.

### Measured effect

| import | before | after |
|---|---|---|
| `models.yolo` | 1.92 s / 3547 modules / seaborn ✅ scipy ✅ | **1.36 s / 2961 modules / seaborn ❌ scipy ❌** |
| `export` | 1.89 s / 3549 modules / seaborn ✅ scipy ✅ | **1.24 s / 2963 modules / seaborn ❌ scipy ❌** |

**−586 modules** off both.

To be precise about the scope, since it is narrower than it might appear:

| import | effect |
|---|---|
| `val`, `benchmarks` | **unchanged** — `val.py:61` imports `output_to_target, plot_images, plot_val_study` from `utils.plots` directly, so they still pull seaborn |
| `detect`, `hubconf` | **unchanged** — already seaborn-free; neither imports `models.yolo` at module scope |

So this helps `python export.py` and `python models/yolo.py`. Getting seaborn off `val.py` needs the `plot_images` / `plot_val_study` work, which is a separate change.

### Behavioral delta

Upstream returns early for more head types than the local copy — it skips `Pose`, `Classify`, `OBB` and `RTDETRDecoder` in addition to `Detect`/`Segment`. Of those only `Classify` exists here, so the sole difference is that `--visualize` would no longer emit a feature map for a `models.common.Classify` head. That path is unreachable today: `classify/predict.py` accepts `--visualize` but never forwards it (`:131` is a bare `model(im)`).

Upstream also guards on `isinstance(x, torch.Tensor)` where the local code was unconditional, and uses `rsplit('.', 1)[-1]` instead of `split('.')[-1]` — same result for every module type in this repo.

### Validation

- `python detect.py --weights yolov5n.pt --source data/images/bus.jpg --imgsz 320 --device cpu --visualize` → 24 `stage*_features.png` + 24 `.npy` written, same as before
- `python train.py --imgsz 64 --batch 32 --weights yolov5n.pt --cfg yolov5n.yaml --epochs 1 --device cpu` → completes
- `python -m pytest tests/ -m "not network"` → 20 passed
- `ruff format` + `ruff check` → clean

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧩 Moves feature-map visualization to the shared Ultralytics utilities package.

### 📊 Key Changes

- Imports `feature_visualization` in `models/yolo.py` from `ultralytics.utils.plotting`.
- Removes the duplicated `feature_visualization` implementation from `utils/plots.py`.
- Preserves feature-map visualization functionality while centralizing its implementation.

### 🎯 Purpose & Impact

- ✅ Reduces duplicate code and improves maintainability.
- 🔄 Aligns YOLOv5 with the shared Ultralytics utility structure.
- 🛠️ Keeps existing model feature-visualization workflows functional with minimal user impact.
- 📦 Helps ensure future improvements to plotting utilities can be shared across Ultralytics projects.