### PR TITLE
Reuse ultralytics TryExcept

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,26 +3,7 @@
 
 import contextlib
 
-from ultralytics.utils import emojis, threaded  # noqa: F401
-
-
-class TryExcept(contextlib.ContextDecorator):
-    """A context manager and decorator for error handling that prints an optional message with emojis on exception."""
-
-    def __init__(self, msg=""):
-        """Initializes TryExcept with an optional message, used as a decorator or context manager for error handling."""
-        self.msg = msg
-
-    def __enter__(self):
-        """Enter the runtime context related to this object for error handling with an optional message."""
-
-    def __exit__(self, exc_type, value, traceback):
-        """Context manager exit method that prints an error message with emojis if an exception occurred, always returns
-        True.
-        """
-        if value:
-            print(emojis(f"{self.msg}{': ' if self.msg else ''}{value}"))
-        return True
+from ultralytics.utils import TryExcept, emojis, threaded  # noqa: F401
 
 
 def notebook_init(verbose=True):

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -181,7 +181,7 @@ class ConfusionMatrix:
                 if not any(m1 == i):
                     self.matrix[dc, self.nc] += 1  # predicted background
 
-    @TryExcept("WARNING ⚠️ ConfusionMatrix plot failure")
+    @TryExcept("ConfusionMatrix plot failure")
     def plot(self, normalize=True, save_dir="", names=()):
         """Plots confusion matrix using seaborn, optional normalization; can save plot to specified directory."""
         import seaborn as sn


### PR DESCRIPTION
The local `TryExcept` is a strict subset of `ultralytics.utils.TryExcept` — same `ContextDecorator` shape, same "swallow and continue" contract, same `return True`. Upstream adds a `verbose` flag and routes the message through `LOGGER.warning` instead of `print(emojis(...))`.

Deleted rather than kept, and folded into the import line that was already there:

```python
from ultralytics.utils import TryExcept, emojis, threaded  # noqa: F401
```

All 5 decorator sites (`utils/metrics.py`, `utils/plots.py`, `utils/autoanchor.py`, `utils/general.py`, `models/common.py`) import `TryExcept` from `utils`, so they keep resolving with **no call-site import edits**. Verified `utils.TryExcept is ultralytics.utils.TryExcept` → `True`.

### One required edit

`utils/metrics.py:184` embedded the prefix in its message:

```python
@TryExcept("WARNING ⚠️ ConfusionMatrix plot failure")
```

The ultralytics formatter prepends `WARNING ⚠️ ` itself, so the literal is dropped to avoid `WARNING ⚠️ WARNING ⚠️ ...`. Confirmed at both arities:

```
TryExcept()                             -> WARNING ⚠️ bare
TryExcept("ConfusionMatrix plot failure") -> WARNING ⚠️ ConfusionMatrix plot failure: boom
```

### Behavior change worth knowing

Messages now go through the ultralytics logger rather than a bare `print`. Two consequences:

1. **Silent on non-zero DDP ranks.** The ultralytics logger sits at `ERROR` when `RANK not in {-1, 0}`. Verified: `RANK=1` emits nothing. All five sites are non-critical (plot failures, an autoanchor error path, "showing images is not supported"), so suppressing duplicates across ranks is an improvement rather than a loss.
2. `emojis()` no longer wraps the message. The ultralytics logger applies its own Windows-safe encoding handling.

`contextlib` stays — still used by `notebook_init`.

### Validation

- `python -m pytest tests/ -m "not network"` → 20 passed
- `python train.py --imgsz 64 --batch 32 --weights yolov5n.pt --cfg yolov5n.yaml --epochs 1 --device cpu` → completes; AutoAnchor path (`@TryExcept(f"{PREFIX}ERROR")`) runs clean and `confusion_matrix.png` is written, so `ConfusionMatrix.plot` executed under the new decorator
- `ruff format` + `ruff check` → clean

### Sequencing

This should land **before** any change that adopts `ultralytics.utils.LOGGER` wholesale — both touch the same embedded `WARNING ⚠️ ` literals, and doing LOGGER first would make this PR's single edit disappear into a much larger diff.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Centralizes the `TryExcept` utility in the Ultralytics package and simplifies confusion-matrix error handling. 🛠️

### 📊 Key Changes

- Replaced the local `TryExcept` implementation in `utils/__init__.py` with the shared `ultralytics.utils.TryExcept`.
- Continued exposing `emojis` and `threaded` through the YOLOv5 utilities module.
- Simplified the confusion-matrix plot decorator message by removing the duplicated warning prefix and emoji.

### 🎯 Purpose & Impact

- ✅ Reduces duplicate utility code and improves consistency across Ultralytics repositories.
- 🧹 Makes error messages cleaner by relying on the centralized `TryExcept` behavior.
- 🔧 Maintains graceful handling of confusion-matrix plotting failures without changing the plotting API or core detection functionality.
- 📦 Users should see no behavioral changes beyond potentially cleaner warning output.