### PR TITLE
Delete four dead code paths

### DIFF
--- a/classify/predict.py
+++ b/classify/predict.py
@@ -74,8 +74,6 @@ def run(
     view_img=False,  # show results
     save_txt=False,  # save results to *.txt
     nosave=False,  # do not save images/videos
-    augment=False,  # augmented inference
-    visualize=False,  # visualize features
     update=False,  # update all models
     project=ROOT / "runs/predict-cls",  # save results to project/name
     name="exp",  # save results to project/name
@@ -219,8 +217,6 @@ def parse_opt():
     parser.add_argument("--view-img", action="store_true", help="show results")
     parser.add_argument("--save-txt", action="store_true", help="save results to *.txt")
     parser.add_argument("--nosave", action="store_true", help="do not save images/videos")
-    parser.add_argument("--augment", action="store_true", help="augmented inference")
-    parser.add_argument("--visualize", action="store_true", help="visualize features")
     parser.add_argument("--update", action="store_true", help="update all models")
     parser.add_argument("--project", default=ROOT / "runs/predict-cls", help="save results to project/name")
     parser.add_argument("--name", default="exp", help="save results to project/name")

--- a/segment/train.py
+++ b/segment/train.py
@@ -46,7 +46,6 @@ from models.experimental import attempt_load
 from models.yolo import SegmentationModel
 from utils.autoanchor import check_anchors
 from utils.autobatch import check_train_batch_size
-from utils.callbacks import Callbacks
 from utils.downloads import attempt_download, is_url
 from utils.general import (
     LOGGER,
@@ -97,7 +96,7 @@ WORLD_SIZE = int(os.getenv("WORLD_SIZE", "1"))
 GIT_INFO = check_git_info()
 
 
-def train(hyp, opt, device, callbacks):
+def train(hyp, opt, device):
     """Trains the YOLOv5 model on a dataset, managing hyperparameters, model optimization, logging, and validation.
 
     `hyp` is path/to/hyp.yaml or hyp dictionary.
@@ -133,7 +132,6 @@ def train(hyp, opt, device, callbacks):
         opt.freeze,
         opt.mask_ratio,
     )
-    # callbacks.run('on_pretrain_routine_start')
 
     # Directories
     w = save_dir / "weights"  # weights dir
@@ -296,7 +294,6 @@ def train(hyp, opt, device, callbacks):
 
             if plots:
                 plot_labels(labels, names, save_dir)
-        # callbacks.run('on_pretrain_routine_end', labels, names)
 
     # DDP mode
     if cuda and RANK != -1:
@@ -325,7 +322,6 @@ def train(hyp, opt, device, callbacks):
     scaler = torch.cuda.amp.GradScaler(enabled=amp)
     stopper, stop = EarlyStopping(patience=opt.patience), False
     compute_loss = ComputeLoss(model, overlap=overlap)  # init loss class
-    # callbacks.run('on_train_start')
     LOGGER.info(
         f"Image sizes {imgsz} train, {imgsz} val\n"
         f"Using {train_loader.num_workers * WORLD_SIZE} dataloader workers\n"
@@ -333,7 +329,6 @@ def train(hyp, opt, device, callbacks):
         f"Starting training for {epochs} epochs..."
     )
     for epoch in range(start_epoch, epochs):  # epoch ------------------------------------------------------------------
-        # callbacks.run('on_train_epoch_start')
         model.train()
 
         # Update image weights (optional, single-GPU only)
@@ -358,7 +353,6 @@ def train(hyp, opt, device, callbacks):
             pbar = TQDM(pbar, total=nb)  # progress bar
         optimizer.zero_grad()
         for i, (imgs, targets, paths, _, masks) in pbar:  # batch ------------------------------------------------------
-            # callbacks.run('on_train_batch_start')
             ni = i + nb * epoch  # number integrated batches (since train start)
             imgs = imgs.to(device, non_blocking=True).float() / 255  # uint8 to float32, 0-255 to 0.0-1.0
 
@@ -412,9 +406,6 @@ def train(hyp, opt, device, callbacks):
                     ("%11s" * 2 + "%11.4g" * 6)
                     % (f"{epoch}/{epochs - 1}", mem, *mloss, targets.shape[0], imgs.shape[-1])
                 )
-                # callbacks.run('on_train_batch_end', model, ni, imgs, targets, paths)
-                # if callbacks.stop_training:
-                #    return
 
                 # Mosaic plots
                 if plots:
@@ -431,7 +422,6 @@ def train(hyp, opt, device, callbacks):
 
         if RANK in {-1, 0}:
             # mAP
-            # callbacks.run('on_train_epoch_end', epoch=epoch)
             ema.update_attr(model, include=["yaml", "nc", "hyp", "names", "stride", "class_weights"])
             final_epoch = (epoch + 1 == epochs) or stopper.possible_stop
             if not noval or final_epoch:  # Calculate mAP
@@ -445,7 +435,6 @@ def train(hyp, opt, device, callbacks):
                     dataloader=val_loader,
                     save_dir=save_dir,
                     plots=False,
-                    callbacks=callbacks,
                     compute_loss=compute_loss,
                     mask_downsample_ratio=mask_ratio,
                     overlap=overlap,
@@ -456,7 +445,6 @@ def train(hyp, opt, device, callbacks):
             stop = stopper(epoch=epoch, fitness=fi)  # early stop check
             best_fitness = max(best_fitness, fi)
             log_vals = list(mloss) + list(results) + lr
-            # callbacks.run('on_fit_epoch_end', log_vals, epoch, best_fitness, fi)
             # Log val metrics and media
             metrics_dict = dict(zip(KEYS, log_vals))
             logger.log_metrics(metrics_dict, epoch)
@@ -483,7 +471,6 @@ def train(hyp, opt, device, callbacks):
                     torch.save(ckpt, w / f"epoch{epoch}.pt")
                     logger.log_model(w / f"epoch{epoch}.pt")
                 del ckpt
-                # callbacks.run('on_model_save', last, epoch, final_epoch, best_fitness, fi)
 
         # EarlyStopping
         if RANK != -1:  # if DDP training
@@ -515,17 +502,14 @@ def train(hyp, opt, device, callbacks):
                         save_json=is_coco,
                         verbose=True,
                         plots=plots,
-                        callbacks=callbacks,
                         compute_loss=compute_loss,
                         mask_downsample_ratio=mask_ratio,
                         overlap=overlap,
                     )  # val best model with plots
                     if is_coco:
-                        # callbacks.run('on_fit_epoch_end', list(mloss) + list(results) + lr, epoch, best_fitness, fi)
                         metrics_dict = dict(zip(KEYS, list(mloss) + list(results) + lr))
                         logger.log_metrics(metrics_dict, epoch)
 
-        # callbacks.run('on_train_end', last, best, epoch, results)
         # on train end callback using genericLogger
         logger.log_metrics(dict(zip(KEYS[4:16], results)), epochs)
         if not opt.evolve:
@@ -589,10 +573,8 @@ def parse_opt(known=False):
     return parser.parse_known_args()[0] if known else parser.parse_args()
 
 
-def main(opt, callbacks=None):
+def main(opt):
     """Initializes training or evolution of YOLOv5 models based on provided configuration and options."""
-    if callbacks is None:
-        callbacks = Callbacks()
     if RANK in {-1, 0}:
         print_args(vars(opt))
         check_git_status()
@@ -646,7 +628,7 @@ def main(opt, callbacks=None):
 
     # Train
     if not opt.evolve:
-        train(opt.hyp, opt, device, callbacks)
+        train(opt.hyp, opt, device)
 
     # Evolve hyperparameters (optional)
     else:
@@ -737,8 +719,7 @@ def main(opt, callbacks=None):
                 hyp[k] = round(hyp[k], 5)  # significant digits
 
             # Train mutation
-            results = train(hyp.copy(), opt, device, callbacks)
-            callbacks = Callbacks()
+            results = train(hyp.copy(), opt, device)
             # Write mutation results
             print_mutation(KEYS[4:16], results, hyp.copy(), save_dir, opt.bucket)
 

--- a/segment/val.py
+++ b/segment/val.py
@@ -131,7 +131,6 @@ def run(
     overlap=False,
     mask_downsample_ratio=1,
     compute_loss=None,
-    callbacks=None,
 ):
     """Validate a YOLOv5 segmentation model on specified dataset, producing metrics, plots, and optional JSON output."""
     if save_json:
@@ -231,10 +230,8 @@ def run(
     metrics = Metrics()
     loss = torch.zeros(4, device=device)
     jdict, stats = [], []
-    # callbacks.run('on_val_start')
     pbar = TQDM(dataloader, desc=s)  # progress bar
     for batch_i, (im, targets, paths, shapes, masks) in enumerate(pbar):
-        # callbacks.run('on_val_batch_start')
         with dt[0]:
             if cuda:
                 im = im.to(device, non_blocking=True)
@@ -312,7 +309,6 @@ def run(
                     im[si].shape[1:], pred_masks.permute(1, 2, 0).contiguous().cpu().numpy(), shape, shapes[si][1]
                 )
                 save_one_json(predn, jdict, path, class_map, pred_masks)  # append to COCO-JSON dictionary
-            # callbacks.run('on_val_image_end', pred, predn, path, names, im[si])
 
         # Plot images
         if plots and batch_i < 3:
@@ -327,8 +323,6 @@ def run(
                 save_dir / f"val_batch{batch_i}_pred.jpg",
                 names,
             )  # pred
-
-        # callbacks.run('on_val_batch_end')
 
     # Compute metrics
     stats = [torch.cat(x, 0).cpu().numpy() for x in zip(*stats)]  # to numpy
@@ -357,7 +351,6 @@ def run(
     # Plots
     if plots:
         confusion_matrix.plot(save_dir=save_dir, names=list(names.values()))
-    # callbacks.run('on_val_end')
 
     mp_bbox, mr_bbox, map50_bbox, map_bbox, mp_mask, mr_mask, map50_mask, map_mask = metrics.mean_results()
 

--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -44,14 +44,6 @@ class Callbacks:
         assert callable(callback), f"callback '{callback}' is not callable"
         self._callbacks[hook].append({"name": name, "callback": callback})
 
-    def get_registered_actions(self, hook=None):
-        """Returns all the registered actions by callback hook.
-
-        Args:
-            hook: The name of the hook to check, defaults to all
-        """
-        return self._callbacks[hook] if hook else self._callbacks
-
     def run(self, hook, *args, thread=False, **kwargs):
         """Loop through the registered actions and fire all callbacks on main thread.
 

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -4,7 +4,6 @@
 import contextlib
 import glob
 import hashlib
-import json
 import math
 import os
 import random
@@ -20,7 +19,6 @@ import psutil
 import torch
 import torch.nn.functional as F
 import torchvision
-import yaml
 from PIL import ExifTags, Image, ImageOps
 from torch.utils.data import DataLoader, Dataset, dataloader, distributed
 
@@ -39,15 +37,12 @@ from utils.general import (
     LOGGER,
     NUM_THREADS,
     TQDM,
-    check_dataset,
     check_requirements,
-    check_yaml,
     clean_str,
     cv2,
     is_colab,
     is_kaggle,
     segments2boxes,
-    unzip_file,
     xyn2xy,
     xywhn2xyxy,
     xyxy2xywhn,
@@ -1027,133 +1022,6 @@ def verify_image_label(args):
         nc = 1
         msg = f"{prefix}WARNING ⚠️ {im_file}: ignoring corrupt image/label: {e}"
         return [None, None, None, None, nm, nf, ne, nc, msg]
-
-
-class HUBDatasetStats:
-    """Class for generating HUB dataset JSON and `-hub` dataset directory.
-
-    Args:
-        path (str): Path to data.yaml or data.zip (with data.yaml inside data.zip).
-        autodownload (bool): Attempt to download dataset if not found locally.
-
-    Examples:
-        from utils.dataloaders import HUBDatasetStats
-        stats = HUBDatasetStats('coco128.yaml', autodownload=True)  # usage 1
-        stats = HUBDatasetStats('path/to/coco128.zip')  # usage 2
-        stats.get_json(save=False)
-        stats.process_images()
-    """
-
-    def __init__(self, path="coco128.yaml", autodownload=False):
-        """Initializes HUBDatasetStats with optional auto-download for datasets, given a path to dataset YAML or ZIP
-        file.
-        """
-        zipped, data_dir, yaml_path = self._unzip(Path(path))
-        try:
-            with open(check_yaml(yaml_path), errors="ignore") as f:
-                data = yaml.safe_load(f)  # data dict
-                if zipped:
-                    data["path"] = data_dir
-        except Exception as e:
-            raise RuntimeError("error/HUB/dataset_stats/yaml_load") from e
-
-        check_dataset(data, autodownload)  # download dataset if missing
-        self.hub_dir = Path(f"{data['path']}-hub")  # check_dataset() resolves 'path' to a Path
-        self.im_dir = self.hub_dir / "images"
-        self.im_dir.mkdir(parents=True, exist_ok=True)  # makes /images
-        self.stats = {"nc": data["nc"], "names": list(data["names"].values())}  # statistics dictionary
-        self.data = data
-
-    @staticmethod
-    def _find_yaml(dir):
-        """Finds and returns the path to a single '.yaml' file in the specified directory, preferring files that match
-        the directory name.
-        """
-        files = list(dir.glob("*.yaml")) or list(dir.rglob("*.yaml"))  # try root level first and then recursive
-        assert files, f"No *.yaml file found in {dir}"
-        if len(files) > 1:
-            files = [f for f in files if f.stem == dir.stem]  # prefer *.yaml files that match dir name
-            assert files, f"Multiple *.yaml files found in {dir}, only 1 *.yaml file allowed"
-        assert len(files) == 1, f"Multiple *.yaml files found: {files}, only 1 *.yaml file allowed in {dir}"
-        return files[0]
-
-    def _unzip(self, path):
-        """Unzips a .zip file at 'path', returning success status, unzipped directory, and path to YAML file within."""
-        if not str(path).endswith(".zip"):  # path is data.yaml
-            return False, None, path
-        assert Path(path).is_file(), f"Error unzipping {path}, file not found"
-        unzip_file(path, path=path.parent)
-        dir = path.with_suffix("")  # dataset directory == zip name
-        assert dir.is_dir(), f"Error unzipping {path}, {dir} not found. path/to/abc.zip MUST unzip to path/to/abc/"
-        return True, str(dir), self._find_yaml(dir)  # zipped, data_dir, yaml_path
-
-    def _hub_ops(self, f, max_dim=1920):
-        """Resizes and saves an image at reduced quality for web/app viewing, supporting both PIL and OpenCV."""
-        f_new = self.im_dir / Path(f).name  # dataset-hub image filename
-        try:  # use PIL
-            im = Image.open(f)
-            r = max_dim / max(im.height, im.width)  # ratio
-            if r < 1.0:  # image too large
-                im = im.resize((int(im.width * r), int(im.height * r)))
-            im.save(f_new, "JPEG", quality=50, optimize=True)  # save
-        except Exception as e:  # use OpenCV
-            LOGGER.info(f"WARNING ⚠️ HUB ops PIL failure {f}: {e}")
-            im = cv2.imread(f)
-            im_height, im_width = im.shape[:2]
-            r = max_dim / max(im_height, im_width)  # ratio
-            if r < 1.0:  # image too large
-                im = cv2.resize(im, (int(im_width * r), int(im_height * r)), interpolation=cv2.INTER_AREA)
-            cv2.imwrite(str(f_new), im)
-
-    def get_json(self, save=False, verbose=False):
-        """Generates dataset JSON for Ultralytics Platform, optionally saves or prints it."""
-
-        def _round(labels):
-            """Rounds class labels to integers and coordinates to 4 decimal places for improved label accuracy."""
-            return [[int(c), *(round(x, 4) for x in points)] for c, *points in labels]
-
-        for split in "train", "val", "test":
-            if self.data.get(split) is None:
-                self.stats[split] = None  # i.e. no test set
-                continue
-            dataset = LoadImagesAndLabels(self.data[split])  # load dataset
-            x = np.array(
-                [
-                    np.bincount(label[:, 0].astype(int), minlength=self.data["nc"])
-                    for label in TQDM(dataset.labels, total=dataset.n, desc="Statistics")
-                ]
-            )  # shape(128x80)
-            self.stats[split] = {
-                "instance_stats": {"total": int(x.sum()), "per_class": x.sum(0).tolist()},
-                "image_stats": {
-                    "total": dataset.n,
-                    "unlabelled": int(np.all(x == 0, 1).sum()),
-                    "per_class": (x > 0).sum(0).tolist(),
-                },
-                "labels": [{str(Path(k).name): _round(v.tolist())} for k, v in zip(dataset.im_files, dataset.labels)],
-            }
-
-        # Save, print and return
-        if save:
-            stats_path = self.hub_dir / "stats.json"
-            print(f"Saving {stats_path.resolve()}...")
-            with open(stats_path, "w") as f:
-                json.dump(self.stats, f)  # save stats.json
-        if verbose:
-            print(json.dumps(self.stats, indent=2, sort_keys=False))
-        return self.stats
-
-    def process_images(self):
-        """Compress images across 'train', 'val', 'test' splits and saves to specified directory."""
-        for split in "train", "val", "test":
-            if self.data.get(split) is None:
-                continue
-            dataset = LoadImagesAndLabels(self.data[split])  # load dataset
-            desc = f"{split} images"
-            for _ in TQDM(ThreadPool(NUM_THREADS).imap(self._hub_ops, dataset.im_files), total=dataset.n, desc=desc):
-                pass
-        print(f"Done. All images saved to {self.im_dir}")
-        return self.im_dir
 
 
 # Classification dataloaders -------------------------------------------------------------------------------------------


### PR DESCRIPTION
Removes ~174 lines that cannot execute. Each item was verified with a repo-wide grep (`--exclude-dir=.git`), including READMEs, workflows and YAML.

### `HUBDatasetStats` — `utils/dataloaders.py` (−132)
Zero callers. The only occurrences of the name outside the `class` statement are inside its own docstring. Deleting it orphans `import json`, `import yaml`, and `check_dataset` / `check_yaml` / `unzip_file` from `utils.general`, all removed here (`ThreadPool` stays — still used at `utils/dataloaders.py:682`). Dataset stats for Ultralytics HUB are maintained in the `ultralytics` package.

### Dead `Callbacks` plumbing in the segment triad (−27 / −7)
`Callbacks` is constructed in `segment/train.py:main()`, threaded through `train()` into `validate.run()`, and never fired — **all 16** `callbacks.run(...)` call sites across `segment/train.py` and `segment/val.py` are commented out. For contrast, root `train.py` has 11 live ones. The segment scripts log through `GenericLogger`. Removing the parameter from `segment/val.run()` is safe: `benchmarks.py:45` imports it as `val_seg` and never passes `callbacks`.

### `classify/predict.py --augment` / `--visualize` (−4)
Both are accepted by argparse and forwarded into `run()`, but inference at `classify/predict.py:131` is a bare `model(im)` — neither value is ever read. Today `--augment` silently does nothing; after this change argparse rejects it. Wiring them up instead would mean adding a classification TTA path that has never existed, so deletion is the smaller change.

### `Callbacks.get_registered_actions()` (−8)
Zero callers.

### Deliberately *not* deleted
`models/hub/anchors.yaml` fails to load (`KeyError: 'anchors'`) and has no references, but its own header says *\"Default COCO anchors for manual YOLOv5 anchor tuning; this file is not loaded by code.\"* It is a reference table of tuned anchor presets with recorded BPR metrics, so it stays.

### Validation
- `ruff check .` / `ruff format --check .` clean
- `python -m pytest tests/ -m "not network"` → 20 passed
- `python train.py --imgsz 64 --batch 32 --weights yolov5n.pt --cfg yolov5n.yaml --epochs 1 --device cpu`
- `python segment/train.py --imgsz 64 --batch 8 --weights yolov5n-seg.pt --epochs 1 --device cpu` (exercises the edited triad end to end, including `validate.run`)
- `python classify/predict.py --weights yolov5n-cls.pt --source data/images --device cpu`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧹 Simplifies YOLOv5 by removing unused classification inference options, segmentation callbacks, and legacy HUB dataset utilities.

### 📊 Key Changes

- Removed `--augment` and `--visualize` options from classification prediction.
- Removed callback support from segmentation training and validation, including unused callback hooks and parameters.
- Deleted `get_registered_actions()` from the callback utility.
- Removed the legacy `HUBDatasetStats` class and its related dataset processing functionality.
- Cleaned up now-unused imports and simplified training and validation function signatures.

### 🎯 Purpose & Impact

- 🚀 Reduces code complexity and maintenance overhead by eliminating obsolete functionality.
- 🧩 Makes segmentation training and validation APIs simpler, though integrations relying on callback arguments will need updates.
- 📦 Removes built-in HUB dataset statistics and image-processing utilities; users should use current Ultralytics dataset and platform workflows instead.
- ✅ Has minimal impact on standard prediction and training workflows, but may affect advanced users depending on removed callbacks or legacy HUB tools.