### PR TITLE
Use ultralytics' LOGGER instead of a private one

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -126,7 +126,7 @@ def run(
         except Exception as e:
             if hard_fail:
                 assert type(e) is AssertionError, f"Benchmark --hard-fail for {name}: {e}"
-            LOGGER.warning(f"WARNING ⚠️ Benchmark failure for {name}: {e}")
+            LOGGER.warning(f"Benchmark failure for {name}: {e}")
             y.append([name, None, None, None])  # mAP, t_inference
         if pt_only and i == 0:
             break  # break after PyTorch

--- a/classify/train.py
+++ b/classify/train.py
@@ -148,7 +148,7 @@ def train(opt, device):
             m = hub.list("ultralytics/yolov5")  # + hub.list('pytorch/vision')  # models
             raise ModuleNotFoundError(f"--model {opt.model} not found. Available models are: \n" + "\n".join(m))
         if isinstance(model, DetectionModel):
-            LOGGER.warning("WARNING ⚠️ pass YOLOv5 classifier model with '-cls' suffix, i.e. '--model yolov5s-cls.pt'")
+            LOGGER.warning("pass YOLOv5 classifier model with '-cls' suffix, i.e. '--model yolov5s-cls.pt'")
             model = ClassificationModel(model=model, nc=nc, cutoff=opt.cutoff or 10)  # convert to classification model
         reshape_classifier_output(model, nc)  # update class count
     for m in model.modules():

--- a/export.py
+++ b/export.py
@@ -674,7 +674,7 @@ def export_engine(
 
     if dynamic:
         if im.shape[0] <= 1:
-            LOGGER.warning(f"{prefix} WARNING ⚠️ --dynamic model requires maximum --batch-size argument")
+            LOGGER.warning(f"{prefix} --dynamic model requires maximum --batch-size argument")
         profile = builder.create_optimization_profile()
         for inp in inputs:
             profile.set_shape(inp.name, (1, *im.shape[1:]), (max(1, im.shape[0] // 2), *im.shape[1:]), im.shape)
@@ -755,8 +755,8 @@ def export_saved_model(
     LOGGER.info(f"\n{prefix} starting export with tensorflow {tf.__version__}...")
     if tf.__version__ > "2.13.1":
         helper_url = "https://github.com/ultralytics/yolov5/issues/12489"
-        LOGGER.info(
-            f"WARNING ⚠️ using Tensorflow {tf.__version__} > 2.13.1 might cause issue when exporting the model to tflite {helper_url}"
+        LOGGER.warning(
+            f"using Tensorflow {tf.__version__} > 2.13.1 might cause issue when exporting the model to tflite {helper_url}"
         )  # handling issue https://github.com/ultralytics/yolov5/issues/12489
     f = str(file).replace(".pt", "_saved_model")
     batch_size, ch, *imgsz = list(im.shape)  # BCHW

--- a/hubconf.py
+++ b/hubconf.py
@@ -49,14 +49,13 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
         For more information on model loading and customization, visit the
         [YOLOv5 PyTorch Hub Documentation](https://docs.ultralytics.com/yolov5/tutorials/pytorch_hub_model_loading).
     """
+    import logging
     from pathlib import Path
 
     from models.common import AutoShape, DetectMultiBackend
     from models.experimental import attempt_load
     from models.yolo import ClassificationModel, DetectionModel, SegmentationModel
     from utils.downloads import attempt_download
-    import logging
-
     from utils.general import LOGGER, ROOT, check_requirements, intersect_dicts
     from utils.torch_utils import select_device
 

--- a/hubconf.py
+++ b/hubconf.py
@@ -55,7 +55,9 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
     from models.experimental import attempt_load
     from models.yolo import ClassificationModel, DetectionModel, SegmentationModel
     from utils.downloads import attempt_download
-    from utils.general import LOGGER, ROOT, check_requirements, intersect_dicts, logging
+    import logging
+
+    from utils.general import LOGGER, ROOT, check_requirements, intersect_dicts
     from utils.torch_utils import select_device
 
     if not verbose:
@@ -71,12 +73,12 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
                 if autoshape:
                     if model.pt and isinstance(model.model, ClassificationModel):
                         LOGGER.warning(
-                            "WARNING ⚠️ YOLOv5 ClassificationModel is not yet AutoShape compatible. "
+                            "YOLOv5 ClassificationModel is not yet AutoShape compatible. "
                             "You must pass torch tensors in BCHW to this model, i.e. shape(1,3,224,224)."
                         )
                     elif model.pt and isinstance(model.model, SegmentationModel):
                         LOGGER.warning(
-                            "WARNING ⚠️ YOLOv5 SegmentationModel is not yet AutoShape compatible. "
+                            "YOLOv5 SegmentationModel is not yet AutoShape compatible. "
                             "You will not be able to run inference with this model."
                         )
                     else:

--- a/segment/train.py
+++ b/segment/train.py
@@ -235,7 +235,7 @@ def train(hyp, opt, device, callbacks):
     # DP mode
     if cuda and RANK == -1 and torch.cuda.device_count() > 1:
         LOGGER.warning(
-            "WARNING ⚠️ DP not recommended, use torch.distributed.run for best DDP Multi-GPU results.\n"
+            "DP not recommended, use torch.distributed.run for best DDP Multi-GPU results.\n"
             "See Multi-GPU Tutorial at https://docs.ultralytics.com/yolov5/tutorials/multi_gpu_training to get started."
         )
         model = torch.nn.DataParallel(model)

--- a/segment/val.py
+++ b/segment/val.py
@@ -341,7 +341,7 @@ def run(
     pf = "%22s" + "%11i" * 2 + "%11.3g" * 8  # print format
     LOGGER.info(pf % ("all", seen, nt.sum(), *metrics.mean_results()))
     if nt.sum() == 0:
-        LOGGER.warning(f"WARNING ⚠️ no labels found in {task} set, can not compute metrics without labels")
+        LOGGER.warning(f"no labels found in {task} set, can not compute metrics without labels")
 
     # Print results per class
     if (verbose or (nc < 50 and not training)) and nc > 1 and len(stats):
@@ -438,9 +438,9 @@ def main(opt):
 
     if opt.task in ("train", "val", "test"):  # run normally
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466
-            LOGGER.warning(f"WARNING ⚠️ confidence threshold {opt.conf_thres} > 0.001 produces invalid results")
+            LOGGER.warning(f"confidence threshold {opt.conf_thres} > 0.001 produces invalid results")
         if opt.save_hybrid:
-            LOGGER.warning("WARNING ⚠️ --save-hybrid returns high mAP from hybrid labels, not from predictions alone")
+            LOGGER.warning("--save-hybrid returns high mAP from hybrid labels, not from predictions alone")
         run(**vars(opt))
 
     else:

--- a/train.py
+++ b/train.py
@@ -273,7 +273,7 @@ def train(hyp, opt, device, callbacks):
     # DP mode
     if cuda and RANK == -1 and torch.cuda.device_count() > 1:
         LOGGER.warning(
-            "WARNING ⚠️ DP not recommended, use torch.distributed.run for best DDP Multi-GPU results.\n"
+            "DP not recommended, use torch.distributed.run for best DDP Multi-GPU results.\n"
             "See Multi-GPU Tutorial at https://docs.ultralytics.com/yolov5/tutorials/multi_gpu_training to get started."
         )
         model = torch.nn.DataParallel(model)

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -6,9 +6,9 @@ import random
 
 import cv2
 import numpy as np
-from ultralytics.utils.metrics import bbox_ioa
 import torch
 import torchvision.transforms as T
+from ultralytics.utils.metrics import bbox_ioa
 
 from utils.general import LOGGER, check_version, colorstr, resample_segments, segment2box
 

--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -127,7 +127,7 @@ def kmean_anchors(dataset="./data/coco128.yaml", n=9, img_size=640, thr=4.0, gen
     # Filter
     i = (wh0 < 3.0).any(1).sum()
     if i:
-        LOGGER.info(f"{PREFIX}WARNING ⚠️ Extremely small objects found: {i} of {len(wh0)} labels are <3 pixels in size")
+        LOGGER.warning(f"{PREFIX}Extremely small objects found: {i} of {len(wh0)} labels are <3 pixels in size")
     wh = wh0[(wh0 >= 2.0).any(1)].astype(np.float32)  # filter > 2 pixels
     # wh = wh * (npr.rand(wh.shape[0], 1) * 0.9 + 0.1)  # multiply by random scale 0-1
 
@@ -139,7 +139,7 @@ def kmean_anchors(dataset="./data/coco128.yaml", n=9, img_size=640, thr=4.0, gen
         k = kmeans(wh / s, n, iter=30)[0] * s  # points
         assert n == len(k)  # kmeans may return fewer points than requested if wh is insufficient or too similar
     except Exception:
-        LOGGER.warning(f"{PREFIX}WARNING ⚠️ switching strategies from kmeans to random init")
+        LOGGER.warning(f"{PREFIX}switching strategies from kmeans to random init")
         k = np.sort(npr.rand(n * 2)).reshape(n, 2) * img_size  # random init
     wh, wh0 = (torch.tensor(x, dtype=torch.float32) for x in (wh, wh0))
     k = print_results(k, verbose=False)

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -64,7 +64,7 @@ def autobatch(model, imgsz=640, fraction=0.8, batch_size=16):
             b = batch_sizes[max(i - 1, 0)]  # select prior safe point
     if b < 1 or b > 1024:  # b outside of safe range
         b = batch_size
-        LOGGER.warning(f"{prefix}WARNING ⚠️ CUDA anomaly detected, recommend restart environment and retry command.")
+        LOGGER.warning(f"{prefix}CUDA anomaly detected, recommend restart environment and retry command.")
 
     fraction = (np.polyval(p, b) + r + a) / t  # actual fraction predicted
     LOGGER.info(f"{prefix}Using batch-size {b} for {d} {t * fraction:.2f}G/{t:.2f}G ({fraction * 100:.0f}%) ✅")

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -131,7 +131,7 @@ def create_dataloader(
 ):
     """Creates and returns a configured DataLoader instance for loading and processing image datasets."""
     if rect and shuffle:
-        LOGGER.warning("WARNING ⚠️ --rect is incompatible with DataLoader shuffle, setting shuffle=False")
+        LOGGER.warning("--rect is incompatible with DataLoader shuffle, setting shuffle=False")
         shuffle = False
     with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
         dataset = LoadImagesAndLabels(
@@ -426,7 +426,7 @@ class LoadStreams:
         self.auto = auto and self.rect
         self.transforms = transforms  # optional
         if not self.rect:
-            LOGGER.warning("WARNING ⚠️ Stream shapes differ. For optimal performance supply similarly-shaped streams.")
+            LOGGER.warning("Stream shapes differ. For optimal performance supply similarly-shaped streams.")
 
     def update(self, i, cap, stream):
         """Reads frames from stream `i`, updating imgs array; handles stream reopening on signal loss."""
@@ -439,7 +439,7 @@ class LoadStreams:
                 if success:
                     self.imgs[i] = im
                 else:
-                    LOGGER.warning("WARNING ⚠️ Video stream unresponsive, please check your IP camera connection.")
+                    LOGGER.warning("Video stream unresponsive, please check your IP camera connection.")
                     self.imgs[i] = np.zeros_like(self.imgs[i])
                     cap.open(stream)  # re-open stream if signal was lost
             time.sleep(0.0)  # wait time
@@ -683,7 +683,7 @@ class LoadImagesAndLabels(Dataset):
         if msgs:
             LOGGER.info("\n".join(msgs))
         if nf == 0:
-            LOGGER.warning(f"{prefix}WARNING ⚠️ No labels found in {path}. {HELP_URL}")
+            LOGGER.warning(f"{prefix}No labels found in {path}. {HELP_URL}")
         x["hash"] = get_hash(self.label_files + self.im_files)
         x["results"] = nf, nm, ne, nc, len(self.im_files)
         x["msgs"] = msgs  # warnings
@@ -693,7 +693,7 @@ class LoadImagesAndLabels(Dataset):
             path.with_suffix(".cache.npy").rename(path)  # remove .npy suffix
             LOGGER.info(f"{prefix}New cache created: {path}")
         except Exception as e:
-            LOGGER.warning(f"{prefix}WARNING ⚠️ Cache directory {path.parent} is not writeable: {e}")  # not writeable
+            LOGGER.warning(f"{prefix}Cache directory {path.parent} is not writeable: {e}")  # not writeable
         return x
 
     def __len__(self):

--- a/utils/general.py
+++ b/utils/general.py
@@ -41,8 +41,8 @@ except (ImportError, AssertionError):
     import ultralytics
 
 from ultralytics.data.converter import coco80_to_coco91_class  # noqa: F401
-from ultralytics.utils import TQDM as _TQDM
 from ultralytics.utils import LOGGER, colorstr, get_default_args  # noqa: F401
+from ultralytics.utils import TQDM as _TQDM
 from ultralytics.utils.checks import check_requirements as check_requirements_ultralytics
 from ultralytics.utils.checks import is_ascii, print_args  # noqa: F401
 from ultralytics.utils.files import WorkingDirectory, file_date, file_size, get_latest_run  # noqa: F401

--- a/utils/general.py
+++ b/utils/general.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 import contextlib
 import glob
 import inspect
-import logging
-import logging.config
 import os
 import platform
 import random
@@ -44,7 +42,7 @@ except (ImportError, AssertionError):
 
 from ultralytics.data.converter import coco80_to_coco91_class  # noqa: F401
 from ultralytics.utils import TQDM as _TQDM
-from ultralytics.utils import colorstr, get_default_args  # noqa: F401
+from ultralytics.utils import LOGGER, colorstr, get_default_args  # noqa: F401
 from ultralytics.utils.checks import check_requirements as check_requirements_ultralytics
 from ultralytics.utils.checks import is_ascii, print_args  # noqa: F401
 from ultralytics.utils.files import WorkingDirectory, file_date, file_size, get_latest_run  # noqa: F401
@@ -142,43 +140,6 @@ def is_writeable(dir, test=False):
         return True
     except OSError:
         return False
-
-
-LOGGING_NAME = "yolov5"
-
-
-def set_logging(name=LOGGING_NAME, verbose=True):
-    """Configures logging with specified verbosity; `name` sets the logger's name, `verbose` controls logging level."""
-    rank = int(os.getenv("RANK", "-1"))  # rank in world for Multi-GPU trainings
-    level = logging.INFO if verbose and rank in {-1, 0} else logging.ERROR
-    logging.config.dictConfig(
-        {
-            "version": 1,
-            "disable_existing_loggers": False,
-            "formatters": {name: {"format": "%(message)s"}},
-            "handlers": {
-                name: {
-                    "class": "logging.StreamHandler",
-                    "formatter": name,
-                    "level": level,
-                }
-            },
-            "loggers": {
-                name: {
-                    "level": level,
-                    "handlers": [name],
-                    "propagate": False,
-                }
-            },
-        }
-    )
-
-
-set_logging(LOGGING_NAME)  # run before defining LOGGER
-LOGGER = logging.getLogger(LOGGING_NAME)  # define globally (used in train.py, val.py, detect.py, etc.)
-if platform.system() == "Windows":
-    for fn in LOGGER.info, LOGGER.warning:
-        setattr(LOGGER, fn.__name__, lambda x, fn=fn: fn(emojis(x)))  # emoji safe logging
 
 
 def user_config_dir(dir="Ultralytics", env_var="YOLOV5_CONFIG_DIR"):
@@ -293,9 +254,9 @@ def check_version(current="0.0.0", minimum="0.0.0", name="version ", pinned=Fals
     """Checks if the current version meets the minimum required version, exits or warns based on parameters."""
     current, minimum = (packaging.version.parse(x) for x in (current, minimum))
     result = (current == minimum) if pinned else (current >= minimum)  # bool
-    s = f"WARNING ⚠️ {name}{minimum} is required by YOLOv5, but {name}{current} is currently installed"  # string
+    s = f"{name}{minimum} is required by YOLOv5, but {name}{current} is currently installed"  # string
     if hard:
-        assert result, emojis(s)  # assert min requirements met
+        assert result, emojis(f"WARNING ⚠️ {s}")  # assert min requirements met
     if verbose and not result:
         LOGGER.warning(s)
     return result
@@ -309,7 +270,7 @@ def check_img_size(imgsz, s=32, floor=0):
         imgsz = list(imgsz)  # convert to list if tuple
         new_size = [max(make_divisible(x, int(s)), floor) for x in imgsz]
     if new_size != imgsz:
-        LOGGER.warning(f"WARNING ⚠️ --img-size {imgsz} must be multiple of max stride {s}, updating to {new_size}")
+        LOGGER.warning(f"--img-size {imgsz} must be multiple of max stride {s}, updating to {new_size}")
     return new_size
 
 
@@ -325,7 +286,7 @@ def check_imshow(warn=False):
         return True
     except Exception as e:
         if warn:
-            LOGGER.warning(f"WARNING ⚠️ Environment does not support cv2.imshow() or PIL Image.show()\n{e}")
+            LOGGER.warning(f"Environment does not support cv2.imshow() or PIL Image.show()\n{e}")
         return False
 
 
@@ -782,7 +743,7 @@ def non_max_suppression(
         if mps:
             output[xi] = output[xi].to(device)
         if (time.time() - t) > time_limit:
-            LOGGER.warning(f"WARNING ⚠️ NMS time limit {time_limit:.3f}s exceeded")
+            LOGGER.warning(f"NMS time limit {time_limit:.3f}s exceeded")
             break  # time limit exceeded
 
     return output

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -135,7 +135,7 @@ class Loggers:
                 self.clearml = None
                 prefix = colorstr("ClearML: ")
                 LOGGER.warning(
-                    f"{prefix}WARNING ⚠️ ClearML is installed but not configured, skipping ClearML logging."
+                    f"{prefix}ClearML is installed but not configured, skipping ClearML logging."
                     f" See https://docs.ultralytics.com/yolov5/tutorials/clearml_logging_integration"
                 )
 
@@ -386,7 +386,7 @@ class GenericLogger:
                 self.clearml = None
                 prefix = colorstr("ClearML: ")
                 LOGGER.warning(
-                    f"{prefix}WARNING ⚠️ ClearML is installed but not configured, skipping ClearML logging."
+                    f"{prefix}ClearML is installed but not configured, skipping ClearML logging."
                     f" See https://docs.ultralytics.com/yolov5/tutorials/clearml_logging_integration"
                 )
         else:
@@ -464,7 +464,7 @@ def log_tensorboard_graph(tb, model, imgsz=(640, 640)):
             warnings.simplefilter("ignore")  # suppress jit trace warning
             tb.add_graph(torch.jit.trace(de_parallel(model), im, strict=False), [])
     except Exception as e:
-        LOGGER.warning(f"WARNING ⚠️ TensorBoard graph visualization failure {e}")
+        LOGGER.warning(f"TensorBoard graph visualization failure {e}")
 
 
 def web_project_name(project):

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -17,7 +17,7 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
 RANK = int(os.getenv("RANK", "-1"))
 DEPRECATION_WARNING = (
-    f"{colorstr('wandb')}: WARNING ⚠️ wandb is deprecated and will be removed in a future release. "
+    f"{colorstr('wandb')}: wandb is deprecated and will be removed in a future release. "
     f"See supported integrations at https://github.com/ultralytics/yolov5#integrations."
 )
 

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -15,7 +15,7 @@ import seaborn as sn
 import torch
 from PIL import Image, ImageDraw
 from scipy.ndimage import gaussian_filter1d
-from ultralytics.utils.plotting import Annotator, colors  # noqa: F401
+from ultralytics.utils.plotting import Annotator, colors
 
 from utils import TryExcept, threaded
 from utils.general import LOGGER, xywh2xyxy, xyxy2xywh

--- a/utils/segment/dataloaders.py
+++ b/utils/segment/dataloaders.py
@@ -41,7 +41,7 @@ def create_dataloader(
 ):
     """Creates a dataloader for training, validating, or testing YOLO models with various dataset options."""
     if rect and shuffle:
-        LOGGER.warning("WARNING ⚠️ --rect is incompatible with DataLoader shuffle, setting shuffle=False")
+        LOGGER.warning("--rect is incompatible with DataLoader shuffle, setting shuffle=False")
         shuffle = False
     with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
         dataset = LoadImagesAndLabelsAndMasks(

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -54,7 +54,7 @@ def smartCrossEntropyLoss(label_smoothing=0.0):
     if check_version(torch.__version__, "1.10.0"):
         return nn.CrossEntropyLoss(label_smoothing=label_smoothing)
     if label_smoothing > 0:
-        LOGGER.warning(f"WARNING ⚠️ label smoothing {label_smoothing} requires torch>=1.10.0")
+        LOGGER.warning(f"label smoothing {label_smoothing} requires torch>=1.10.0")
     return nn.CrossEntropyLoss()
 
 

--- a/val.py
+++ b/val.py
@@ -336,7 +336,7 @@ def run(
     pf = "%22s" + "%11i" * 2 + "%11.3g" * 4  # print format
     LOGGER.info(pf % ("all", seen, nt.sum(), mp, mr, map50, map))
     if nt.sum() == 0:
-        LOGGER.warning(f"WARNING ⚠️ no labels found in {task} set, can not compute metrics without labels")
+        LOGGER.warning(f"no labels found in {task} set, can not compute metrics without labels")
 
     # Print results per class
     if (verbose or (nc < 50 and not training)) and nc > 1 and len(stats):
@@ -493,9 +493,9 @@ def main(opt):
 
     if opt.task in ("train", "val", "test"):  # run normally
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466
-            LOGGER.info(f"WARNING ⚠️ confidence threshold {opt.conf_thres} > 0.001 produces invalid results")
+            LOGGER.warning(f"confidence threshold {opt.conf_thres} > 0.001 produces invalid results")
         if opt.save_hybrid:
-            LOGGER.info("WARNING ⚠️ --save-hybrid will return high mAP from hybrid labels, not from predictions alone")
+            LOGGER.warning("--save-hybrid will return high mAP from hybrid labels, not from predictions alone")
         run(**vars(opt))
 
     else:


### PR DESCRIPTION
> Stacked on #13836. Base retargets to `master` as the chain merges.

`utils/general.py` stood up its own `"yolov5"` logger through `logging.config.dictConfig` and exported it. ultralytics already builds an equivalent one, so `LOGGING_NAME`, `set_logging`, the module-scope `set_logging()` call, the `LOGGER = logging.getLogger(...)` assignment and the Windows-only emoji monkeypatch are all deleted in favour of one name on the existing `from ultralytics.utils import ...` line.

`set_logging` has **zero external callers** — the only two references were its own `def` and the module-scope call — so there is no per-rank `set_logging(verbose=RANK in {-1, 0})` to preserve. The ~15 modules doing `from utils.general import LOGGER` need no edits.

Behaviour matches: same `%(message)s` format, same `INFO if verbose and rank in {-1, 0} else ERROR` level rule, same `propagate=False`. ultralytics' `PrefixFormatter` runs `emojis()` on **every** level, superseding the Windows-only patch this removes.

### `hubconf.py` — the edit that makes this safe

`hubconf.py` was laundering stdlib `logging` through this module:

```python
from utils.general import LOGGER, ROOT, check_requirements, intersect_dicts, logging
```

Deleting `set_logging` orphans `import logging` in `utils/general.py`. The next `ruff --fix` — which Ultralytics Actions pushes automatically via `format.yml` — would strip it, and `hubconf` would then fail at runtime on `LOGGER.setLevel(logging.WARNING)`. `hubconf.py` now imports `logging` directly. I re-ran `ruff check --fix .` afterwards and re-imported `hubconf` to confirm the format bot can no longer break it.

### The doubled `WARNING ⚠️` literal

ultralytics' formatter prepends the marker itself:

```python
if record.levelno == logging.WARNING:
    prefix = "WARNING" if WINDOWS else "WARNING ⚠️"
    record.msg = f"{prefix} {record.msg}"
```

so every embedded literal became doubled — confirmed end to end before the fix:

```
WARNING ⚠️ WARNING ⚠️ --img-size 641 must be multiple of max stride 32, updating to 672
```

Of 39 sites: **31 stripped**, **4 promoted** from `LOGGER.info` to `LOGGER.warning` and then stripped (`val.py:496`, `val.py:498`, `export.py:759`, `utils/autoanchor.py:130` — all were warnings written at info level), and **8 deliberately left alone**:

| site | why it must keep the literal |
|---|---|
| `export.py:1485`, `:1487` | generated PyTorch Hub **code comment** printed inside a `LOGGER.info` block |
| `utils/dataloaders.py:920`, `:941`, `:951` | `verify_image_label` messages accumulated into a list emitted by a single `LOGGER.info("\n".join(msgs))` — never doubled, and promoting would only prefix the first line of the joined block |
| `utils/dataloaders.py:1023` | inside `HUBDatasetStats`, which #13834 deletes — touching it would only create a conflict |
| `utils/loggers/wandb/wandb_utils.py:3` | a Python source comment, not code |

### `check_version` — marker relocated, not removed

`utils/general.py` built one string used by **two** paths:

```python
s = f"WARNING ⚠️ {name}{minimum} is required by YOLOv5, but ..."
if hard:
    assert result, emojis(s)      # no logger involved — keeps the literal
if verbose and not result:
    LOGGER.warning(s)             # doubled
```

Stripping would have silently dropped the marker from the `AssertionError`. The literal now lives on the assert path only. Verified:

```
AssertionError: WARNING ⚠️ torch2.0.0 is required by YOLOv5, but torch1.0.0 is currently installed
WARNING ⚠️ torch2.0.0 is required by YOLOv5, but torch1.0.0 is currently installed   # via the formatter
```

### Log output moves from stderr to stdout

ultralytics' handler is `logging.StreamHandler(sys.stdout)`; the local one defaulted to stderr. Anyone redirecting `2>` to capture YOLOv5 output will now see it on `1>` instead. Confirmed `python val.py ... 2>/dev/null` still prints the whole run log.

Secondary cosmetic effect: at `f"{prefix}WARNING ⚠️ ..."` sites the auto-prefix lands **outside** the `colorstr` prefix, so e.g. `AutoBatch: WARNING ⚠️ msg` becomes `WARNING ⚠️ AutoBatch: msg`.

### Validation

| check | result |
|---|---|
| `val.py --weights yolov5n.pt --data coco128.yaml --img 640 --device cpu 2>/dev/null` | full log on stdout, `all 128 929 0.607 0.5 0.549 0.35` |
| `hubconf._create(..., verbose=False)` and `verbose=True` | both load and return `AutoShape` |
| `ruff check --fix .` re-run, then `import hubconf` | still imports — format bot cannot break it |
| `train.py --epochs 1 --device cpu` | pass |
| `pytest -m "not network"` | 20 passed |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Standardizes warning logging across YOLOv5 by removing redundant “WARNING ⚠️” text and centralizing logger management through the Ultralytics utilities. 🧹

### 📊 Key Changes
- Removed manually embedded `WARNING ⚠️` prefixes from warnings and moved affected messages to `LOGGER.warning()`.
- Replaced YOLOv5’s custom logging setup with the shared Ultralytics `LOGGER`.
- Updated warnings across training, validation, export, benchmarking, data loading, autoanchor, inference, and integrations.
- Imported Python’s standard `logging` module locally in `hubconf.py` where needed.
- Cleaned up minor imports and lint-related annotations in augmentation and plotting utilities.

### 🎯 Purpose & Impact
- ✅ Produces cleaner, more consistent console output without duplicated warning indicators.
- 🛠️ Improves compatibility with the shared Ultralytics logging infrastructure.
- 📣 Ensures messages are classified correctly as warnings, making them easier for users and tools to identify.
- 🚫 No intended changes to model training, validation, export behavior, or inference results.