### PR TITLE
Delegate TF GraphDef export and output discovery to ultralytics

### DIFF
--- a/export.py
+++ b/export.py
@@ -808,7 +808,6 @@ def export_pb(keras_model, file, prefix=colorstr("TensorFlow GraphDef:")):  # no
         file = Path("model.pb")
         export_pb(keras_model, file)
         ```
-
     """
     from ultralytics.utils.export.tensorflow import keras2pb
 

--- a/export.py
+++ b/export.py
@@ -809,21 +809,11 @@ def export_pb(keras_model, file, prefix=colorstr("TensorFlow GraphDef:")):  # no
         export_pb(keras_model, file)
         ```
 
-    Notes:
-        For more details, refer to the guide on frozen graphs: https://github.com/leimao/Frozen_Graph_TensorFlow
     """
-    import tensorflow as tf
-    from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
+    from ultralytics.utils.export.tensorflow import keras2pb
 
-    LOGGER.info(f"\n{prefix} starting export with tensorflow {tf.__version__}...")
-    f = file.with_suffix(".pb")
-
-    m = tf.function(lambda x: keras_model(x))  # full model
-    m = m.get_concrete_function(tf.TensorSpec(keras_model.inputs[0].shape, keras_model.inputs[0].dtype))
-    frozen_func = convert_variables_to_constants_v2(m)
-    frozen_func.graph.as_graph_def()
-    tf.io.write_graph(graph_or_graph_def=frozen_func.graph, logdir=str(f.parent), name=f.name, as_text=False)
-    return f, None
+    # keras2pb does not derive the suffix despite its docstring, so pass the .pb path explicitly
+    return keras2pb(keras_model, file.with_suffix(".pb"), prefix=prefix), None
 
 
 @try_export

--- a/models/common.py
+++ b/models/common.py
@@ -595,20 +595,13 @@ class DetectMultiBackend(nn.Module):
         elif pb:  # GraphDef https://www.tensorflow.org/guide/migrate#a_graphpb_or_graphpbtxt
             LOGGER.info(f"Loading {w} for TensorFlow GraphDef inference...")
             import tensorflow as tf
+            from ultralytics.utils.export.tensorflow import gd_outputs
 
             def wrap_frozen_graph(gd, inputs, outputs):
                 """Wraps a TensorFlow GraphDef for inference, returning a pruned function."""
                 x = tf.compat.v1.wrap_function(lambda: tf.compat.v1.import_graph_def(gd, name=""), [])  # wrapped
                 ge = x.graph.as_graph_element
                 return x.prune(tf.nest.map_structure(ge, inputs), tf.nest.map_structure(ge, outputs))
-
-            def gd_outputs(gd):
-                """Generates a sorted list of graph outputs excluding NoOp nodes and inputs, formatted as '<name>:0'."""
-                name_list, input_list = [], []
-                for node in gd.node:  # tensorflow.core.framework.node_def_pb2.NodeDef
-                    name_list.append(node.name)
-                    input_list.extend(node.input)
-                return sorted(f"{x}:0" for x in list(set(name_list) - set(input_list)) if not x.startswith("NoOp"))
 
             gd = tf.Graph().as_graph_def()  # TF GraphDef
             with open(w, "rb") as f:


### PR DESCRIPTION
Two more duplicated TensorFlow helpers. Independent of the other open dedup PRs — touches only `export.py` and `models/common.py`.

### `export_pb` → `ultralytics.utils.export.tensorflow.keras2pb` (−13)

The local body and upstream's `keras2pb` are the same code: same `tf.function` wrap, same `get_concrete_function(tf.TensorSpec(...))`, same `convert_variables_to_constants_v2`, same `tf.io.write_graph(..., as_text=False)`.

The `@try_export` decorator, the signature and the `(path, None)` return **stay** — `try_export` reads `prefix` off the signature defaults via `get_default_args` and supplies the timing/size/failure logging, and the call site at `export.py:1464` unpacks a 2-tuple. Only the body delegates. Replacing the wrapper itself would need a shim, which the Core Principles forbid.

One sharp edge worth flagging: `keras2pb`'s docstring says *"suffix will be changed to .pb"*, but the body does no such thing — it writes to whatever path it is handed. The caller therefore passes `file.with_suffix(".pb")` explicitly, and there is a comment saying so.

### `gd_outputs` → ultralytics (−8)

`models/common.py` defined it inline inside `DetectMultiBackend.__init__`'s `elif pb:` branch. Upstream's body is character-identical apart from the docstring. It becomes a **function-scoped** import inside the same branch rather than a module-level one, so nothing is added to import time — `export.py` is pulled in by `models/common.py` on every `DetectMultiBackend` init, and this repo already paid that lesson in #13830.

The sibling `wrap_frozen_graph` is deliberately left alone: upstream's equivalent lives in `ultralytics/nn/backends/tensorflow.py` inside a different class with different surroundings, so it is not a drop-in.

### `export_formats()` deliberately not touched

Swapping to `ultralytics.engine.exporter.export_formats` returns a 21-row × 7-column dict against this repo's 12 × 5. That breaks:

- `export.py:1392` — the 11-way `jit, onnx, xml, engine, ... = flags` unpack
- `benchmarks.py:99`/`:193` — `.iterrows()`, and the hardcoded positional guard on the TF rows
- `models/common.py:805` — `.Suffix`, and `types[8] &= not types[9]  # tflite &= not edgetpu`, whose indices no longer mean what the comment says

and it reports CoreML as `.mlpackage` where this repo writes `.mlmodel`. Reconciling would need a DataFrame-rebuilding shim. Converting the local DataFrame to a plain dict is possible but nets −3 lines and does **not** drop the pandas dependency (`utils/general.py:75` sets `pd.options.display.max_columns` at module scope), so it isn't worth the churn.

### Validation — run with TensorFlow 2.21

| check | result |
|---|---|
| `export.py --weights yolov5n.pt --include pb --imgsz 320 --device cpu` | succeeds |
| `cmp master.pb branch.pb` | **byte-identical**, 7,722,575 bytes |
| `val.py --weights yolov5n.pb --data coco128.yaml --img 320 --device cpu` | `all 128 929 0.558 0.397 0.459 0.294` — identical to master, and exercises `gd_outputs` on the load path |
| `ruff check .` / `ruff format --check .` | clean |

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔄 Refactored TensorFlow GraphDef export and inference utilities to use shared Ultralytics helper functions.

### 📊 Key Changes

- Replaced the custom frozen-graph conversion logic in `export.py` with the shared `keras2pb` utility.
- Ensured GraphDef files are explicitly written with the `.pb` suffix.
- Moved GraphDef output-node discovery from `models/common.py` into the reusable `gd_outputs` utility.
- Removed duplicated TensorFlow graph-processing code and outdated documentation.

### 🎯 Purpose & Impact

- ✅ Centralizes TensorFlow export and GraphDef handling for easier maintenance.
- 🧩 Reduces code duplication and improves consistency across Ultralytics tools.
- 🚀 Helps keep TensorFlow model export and inference behavior aligned.
- 👥 Users should see no major workflow changes, but benefit from more reliable and maintainable `.pb` export support.