### PR TITLE
Remove the ndjson training logs

### DIFF
--- a/train.py
+++ b/train.py
@@ -79,7 +79,7 @@ from utils.general import (
     strip_optimizer,
     yaml_save,
 )
-from utils.loggers import LOGGERS, Loggers
+from utils.loggers import Loggers
 from utils.loggers.comet.comet_utils import check_comet_resume
 from utils.loss import ComputeLoss
 from utils.metrics import fitness
@@ -173,20 +173,7 @@ def train(hyp, opt, device, callbacks):
     # Loggers
     data_dict = None
     if RANK in {-1, 0}:
-        include_loggers = list(LOGGERS)
-        if getattr(opt, "ndjson_console", False):
-            include_loggers.append("ndjson_console")
-        if getattr(opt, "ndjson_file", False):
-            include_loggers.append("ndjson_file")
-
-        loggers = Loggers(
-            save_dir=save_dir,
-            weights=weights,
-            opt=opt,
-            hyp=hyp,
-            logger=LOGGER,
-            include=tuple(include_loggers),
-        )
+        loggers = Loggers(save_dir=save_dir, weights=weights, opt=opt, hyp=hyp, logger=LOGGER)
 
         # Register actions
         for k in methods(loggers):
@@ -610,8 +597,6 @@ def parse_opt(known=False):
     parser.add_argument("--artifact_alias", type=str, default="latest", help="Version of dataset artifact to use")
 
     # NDJSON logging
-    parser.add_argument("--ndjson-console", action="store_true", help="Log ndjson to console")
-    parser.add_argument("--ndjson-file", action="store_true", help="Log ndjson to file")
 
     return parser.parse_known_args()[0] if known else parser.parse_args()
 

--- a/train.py
+++ b/train.py
@@ -596,8 +596,6 @@ def parse_opt(known=False):
     parser.add_argument("--bbox_interval", type=int, default=-1, help="Set bounding-box image logging interval")
     parser.add_argument("--artifact_alias", type=str, default="latest", help="Version of dataset artifact to use")
 
-    # NDJSON logging
-
     return parser.parse_known_args()[0] if known else parser.parse_args()
 
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -74,7 +74,7 @@ NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLOv5 multiproces
 DATASETS_DIR = Path(os.getenv("YOLOv5_DATASETS_DIR", ROOT.parent / "datasets"))  # global datasets directory
 AUTOINSTALL = str(os.getenv("YOLOv5_AUTOINSTALL", "true")).lower() == "true"  # global auto-install mode
 VERBOSE = str(os.getenv("YOLOv5_VERBOSE", "true")).lower() == "true"  # global verbose mode
-TQDM = partial(_TQDM, file=sys.stderr)  # progress bars on stderr like LOGGER, keeping stdout free for --ndjson-console
+TQDM = partial(_TQDM, file=sys.stderr)  # progress bars on stderr like LOGGER, keeping stdout free for piped output
 FONT = "Arial.ttf"  # https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf
 
 torch.set_printoptions(linewidth=320, precision=5, profile="long")

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -1,7 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 """Logging utils."""
 
-import json
 import os
 import warnings
 from pathlib import Path
@@ -61,19 +60,6 @@ except (ImportError, AssertionError):
     comet_ml = None
 
 
-def _json_default(value):
-    """Format `value` for JSON serialization (e.g. unwrap tensors).
-
-    Fall back to strings.
-    """
-    if isinstance(value, torch.Tensor):
-        try:
-            value = value.item()
-        except ValueError:  # "only one element tensors can be converted to Python scalars"
-            pass
-    return value if isinstance(value, float) else str(value)
-
-
 class Loggers:
     """Initializes and manages various logging utilities for tracking YOLOv5 training and validation metrics."""
 
@@ -105,8 +91,6 @@ class Loggers:
         for k in LOGGERS:
             setattr(self, k, None)  # init empty logger dictionary
         self.csv = True  # always log to csv
-        self.ndjson_console = "ndjson_console" in self.include  # log ndjson to console
-        self.ndjson_file = "ndjson_file" in self.include  # log ndjson to file
 
         # Messages
         if not comet_ml:
@@ -247,7 +231,7 @@ class Loggers:
             self.comet_logger.on_val_end(nt, tp, fp, p, r, f1, ap, ap50, ap_class, confusion_matrix)
 
     def on_fit_epoch_end(self, vals, epoch, best_fitness, fi):
-        """Callback that logs metrics and saves them to CSV or NDJSON at the end of each fit (train+val) epoch."""
+        """Callback that logs metrics and saves them to CSV at the end of each fit (train+val) epoch."""
         x = dict(zip(self.keys, vals))
         if self.csv:
             file = self.save_dir / "results.csv"
@@ -255,14 +239,6 @@ class Loggers:
             s = "" if file.exists() else (("%20s," * n % ("epoch", *self.keys)).rstrip(",") + "\n")  # add header
             with open(file, "a") as f:
                 f.write(s + ("%20.5g," * n % (epoch, *vals)).rstrip(",") + "\n")
-        if self.ndjson_console or self.ndjson_file:
-            json_data = json.dumps(dict(epoch=epoch, **x), default=_json_default)
-        if self.ndjson_console:
-            print(json_data)
-        if self.ndjson_file:
-            file = self.save_dir / "results.ndjson"
-            with open(file, "a") as f:
-                print(json_data, file=f)
 
         if self.tb:
             for k, v in x.items():


### PR DESCRIPTION
Deletes `--ndjson-console` and `--ndjson-file` and everything that existed only to serve them.

### What it was

Added in **#10970** (Aarni Koskela, Jan 2024). It emitted the same per-epoch metrics that already go to `results.csv`, as one JSON object per line, either to stdout (`--ndjson-console`) or to `runs/train/exp/results.ndjson` (`--ndjson-file`).

It is undocumented — `grep -rn ndjson` over every `*.md`, `*.ipynb`, `*.yml` and `*.yaml` returns nothing, so no README, tutorial or workflow mentions it — and it was never ported to yolov3.

### What goes

| location | removed |
|---|---|
| `train.py` | the two `--ndjson-*` arguments, and the `include_loggers` list built solely to carry them into `Loggers` |
| `utils/loggers/__init__.py` | `self.ndjson_console` / `self.ndjson_file`, the emit block in `on_fit_epoch_end`, `_json_default`, and `import json` |

`Loggers` already defaults to `include=LOGGERS`, so the construction collapses from a 7-line call to one line. `torch` stays in `utils/loggers/__init__.py` — still used by the TensorBoard graph path.

`results.csv` is untouched and remains the per-epoch metrics record. `results.ndjson` is simply no longer produced.

### Why this unblocks the logger work

`--ndjson-console` wrote raw JSON to stdout with a bare `print()`, which made stdout a machine-readable stream. That is why `utils/general.py:77` pinned progress bars to stderr:

```python
TQDM = partial(_TQDM, file=sys.stderr)  # ... keeping stdout free for --ndjson-console
```

and why swapping in ultralytics' `LOGGER` — which installs a `StreamHandler(sys.stdout)` — would have interleaved human log lines into that JSON. With the feature gone, that constraint disappears. The comment is updated here so it no longer names something that does not exist; the actual stream change lands in the follow-up.

### Validation

- `python train.py ... --ndjson-console` → `error: unrecognized arguments: --ndjson-console` (same for `--ndjson-file`)
- `python train.py --imgsz 64 --batch 32 --weights yolov5n.pt --cfg yolov5n.yaml --epochs 1 --device cpu` → completes, writes `results.csv` and `results.png`, no `results.ndjson`
- `python -m pytest tests/ -m "not network"` → 20 passed
- `ruff check .` / `ruff format --check .` clean

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 Removes NDJSON training logs and simplifies YOLOv5 logger initialization, leaving CSV as the standard local metrics format.

### 📊 Key Changes
- Removed the `--ndjson-console` and `--ndjson-file` command-line options from `train.py`.
- Simplified `Loggers` setup by eliminating optional NDJSON logger configuration.
- Removed NDJSON serialization and output to `results.ndjson` or the console.
- Deleted the unused JSON conversion helper and related imports.
- Updated progress-bar comments to refer broadly to piped output rather than NDJSON specifically.
- Kept CSV logging through `results.csv` unchanged.

### 🎯 Purpose & Impact
- 🧩 Reduces logging code complexity and removes unsupported or unnecessary NDJSON paths.
- 📄 Makes CSV the consistent local output for epoch-level training metrics.
- ⚠️ Users relying on `--ndjson-console` or `--ndjson-file` will need to update scripts and workflows.
- ✅ Existing TensorBoard, Comet, and CSV logging integrations remain available.