### PR TITLE
Use ultralytics' LOGGER everywhere

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -126,7 +126,7 @@ def run(
         except Exception as e:
             if hard_fail:
                 assert type(e) is AssertionError, f"Benchmark --hard-fail for {name}: {e}"
-            LOGGER.warning(f"WARNING ⚠️ Benchmark failure for {name}: {e}")
+            LOGGER.warning(f"Benchmark failure for {name}: {e}")
             y.append([name, None, None, None])  # mAP, t_inference
         if pt_only and i == 0:
             break  # break after PyTorch

--- a/classify/train.py
+++ b/classify/train.py
@@ -148,7 +148,7 @@ def train(opt, device):
             m = hub.list("ultralytics/yolov5")  # + hub.list('pytorch/vision')  # models
             raise ModuleNotFoundError(f"--model {opt.model} not found. Available models are: \n" + "\n".join(m))
         if isinstance(model, DetectionModel):
-            LOGGER.warning("WARNING ⚠️ pass YOLOv5 classifier model with '-cls' suffix, i.e. '--model yolov5s-cls.pt'")
+            LOGGER.warning("pass YOLOv5 classifier model with '-cls' suffix, i.e. '--model yolov5s-cls.pt'")
             model = ClassificationModel(model=model, nc=nc, cutoff=opt.cutoff or 10)  # convert to classification model
         reshape_classifier_output(model, nc)  # update class count
     for m in model.modules():

--- a/export.py
+++ b/export.py
@@ -151,7 +151,7 @@ def export_formats():
     Examples:
         ```python
         formats = export_formats()
-        print(f"Supported export formats:\n{formats}")
+        LOGGER.info(f"Supported export formats:\n{formats}")
         ```
 
     Notes:
@@ -674,7 +674,7 @@ def export_engine(
 
     if dynamic:
         if im.shape[0] <= 1:
-            LOGGER.warning(f"{prefix} WARNING ⚠️ --dynamic model requires maximum --batch-size argument")
+            LOGGER.warning(f"{prefix} --dynamic model requires maximum --batch-size argument")
         profile = builder.create_optimization_profile()
         for inp in inputs:
             profile.set_shape(inp.name, (1, *im.shape[1:]), (max(1, im.shape[0] // 2), *im.shape[1:]), im.shape)
@@ -755,8 +755,8 @@ def export_saved_model(
     LOGGER.info(f"\n{prefix} starting export with tensorflow {tf.__version__}...")
     if tf.__version__ > "2.13.1":
         helper_url = "https://github.com/ultralytics/yolov5/issues/12489"
-        LOGGER.info(
-            f"WARNING ⚠️ using Tensorflow {tf.__version__} > 2.13.1 might cause issue when exporting the model to tflite {helper_url}"
+        LOGGER.warning(
+            f"using Tensorflow {tf.__version__} > 2.13.1 might cause issue when exporting the model to tflite {helper_url}"
         )  # handling issue https://github.com/ultralytics/yolov5/issues/12489
     f = str(file).replace(".pt", "_saved_model")
     batch_size, ch, *imgsz = list(im.shape)  # BCHW

--- a/hubconf.py
+++ b/hubconf.py
@@ -95,14 +95,15 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
                 model.load_state_dict(csd, strict=False)  # load
                 if len(ckpt["model"].names) == classes:
                     model.names = ckpt["model"].names  # set class names attribute
-        if not verbose:
-            LOGGER.setLevel(prev_level)  # restore, LOGGER is shared with ultralytics
         return model.to(device)
 
     except Exception as e:
         help_url = "https://docs.ultralytics.com/yolov5/tutorials/pytorch_hub_model_loading"
         s = f"{e}. Cache may be out of date, try `force_reload=True` or see {help_url} for help."
         raise RuntimeError(s) from e
+
+    finally:
+        LOGGER.setLevel(prev_level)  # restore on both paths, LOGGER is shared with ultralytics
 
 
 def custom(path="path/to/model.pt", autoshape=True, _verbose=True, device=None):

--- a/hubconf.py
+++ b/hubconf.py
@@ -49,15 +49,17 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
         For more information on model loading and customization, visit the
         [YOLOv5 PyTorch Hub Documentation](https://docs.ultralytics.com/yolov5/tutorials/pytorch_hub_model_loading).
     """
+    import logging
     from pathlib import Path
 
     from models.common import AutoShape, DetectMultiBackend
     from models.experimental import attempt_load
     from models.yolo import ClassificationModel, DetectionModel, SegmentationModel
     from utils.downloads import attempt_download
-    from utils.general import LOGGER, ROOT, check_requirements, intersect_dicts, logging
+    from utils.general import LOGGER, ROOT, check_requirements, intersect_dicts
     from utils.torch_utils import select_device
 
+    prev_level = LOGGER.level
     if not verbose:
         LOGGER.setLevel(logging.WARNING)
     check_requirements(ROOT / "requirements.txt", exclude=("opencv-python", "tensorboard", "ultralytics-thop"))
@@ -71,12 +73,12 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
                 if autoshape:
                     if model.pt and isinstance(model.model, ClassificationModel):
                         LOGGER.warning(
-                            "WARNING ⚠️ YOLOv5 ClassificationModel is not yet AutoShape compatible. "
+                            "YOLOv5 ClassificationModel is not yet AutoShape compatible. "
                             "You must pass torch tensors in BCHW to this model, i.e. shape(1,3,224,224)."
                         )
                     elif model.pt and isinstance(model.model, SegmentationModel):
                         LOGGER.warning(
-                            "WARNING ⚠️ YOLOv5 SegmentationModel is not yet AutoShape compatible. "
+                            "YOLOv5 SegmentationModel is not yet AutoShape compatible. "
                             "You will not be able to run inference with this model."
                         )
                     else:
@@ -94,7 +96,7 @@ def _create(name, pretrained=True, channels=3, classes=80, autoshape=True, verbo
                 if len(ckpt["model"].names) == classes:
                     model.names = ckpt["model"].names  # set class names attribute
         if not verbose:
-            LOGGER.setLevel(logging.INFO)  # reset to default
+            LOGGER.setLevel(prev_level)  # restore, LOGGER is shared with ultralytics
         return model.to(device)
 
     except Exception as e:

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -493,7 +493,7 @@ if __name__ == "__main__":
             try:
                 _ = Model(cfg)
             except Exception as e:
-                print(f"Error in {cfg}: {e}")
+                LOGGER.error(f"in {cfg}: {e}")
 
     else:  # report fused model summary
         model.fuse()

--- a/segment/train.py
+++ b/segment/train.py
@@ -233,7 +233,7 @@ def train(hyp, opt, device):
     # DP mode
     if cuda and RANK == -1 and torch.cuda.device_count() > 1:
         LOGGER.warning(
-            "WARNING ⚠️ DP not recommended, use torch.distributed.run for best DDP Multi-GPU results.\n"
+            "DP not recommended, use torch.distributed.run for best DDP Multi-GPU results.\n"
             "See Multi-GPU Tutorial at https://docs.ultralytics.com/yolov5/tutorials/multi_gpu_training to get started."
         )
         model = torch.nn.DataParallel(model)

--- a/segment/val.py
+++ b/segment/val.py
@@ -335,7 +335,7 @@ def run(
     pf = "%22s" + "%11i" * 2 + "%11.3g" * 8  # print format
     LOGGER.info(pf % ("all", seen, nt.sum(), *metrics.mean_results()))
     if nt.sum() == 0:
-        LOGGER.warning(f"WARNING ⚠️ no labels found in {task} set, can not compute metrics without labels")
+        LOGGER.warning(f"no labels found in {task} set, can not compute metrics without labels")
 
     # Print results per class
     if (verbose or (nc < 50 and not training)) and nc > 1 and len(stats):
@@ -431,9 +431,9 @@ def main(opt):
 
     if opt.task in ("train", "val", "test"):  # run normally
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466
-            LOGGER.warning(f"WARNING ⚠️ confidence threshold {opt.conf_thres} > 0.001 produces invalid results")
+            LOGGER.warning(f"confidence threshold {opt.conf_thres} > 0.001 produces invalid results")
         if opt.save_hybrid:
-            LOGGER.warning("WARNING ⚠️ --save-hybrid returns high mAP from hybrid labels, not from predictions alone")
+            LOGGER.warning("--save-hybrid returns high mAP from hybrid labels, not from predictions alone")
         run(**vars(opt))
 
     else:

--- a/train.py
+++ b/train.py
@@ -79,7 +79,7 @@ from utils.general import (
     strip_optimizer,
     yaml_save,
 )
-from utils.loggers import LOGGERS, Loggers
+from utils.loggers import Loggers
 from utils.loggers.comet.comet_utils import check_comet_resume
 from utils.loss import ComputeLoss
 from utils.metrics import fitness
@@ -173,20 +173,7 @@ def train(hyp, opt, device, callbacks):
     # Loggers
     data_dict = None
     if RANK in {-1, 0}:
-        include_loggers = list(LOGGERS)
-        if getattr(opt, "ndjson_console", False):
-            include_loggers.append("ndjson_console")
-        if getattr(opt, "ndjson_file", False):
-            include_loggers.append("ndjson_file")
-
-        loggers = Loggers(
-            save_dir=save_dir,
-            weights=weights,
-            opt=opt,
-            hyp=hyp,
-            logger=LOGGER,
-            include=tuple(include_loggers),
-        )
+        loggers = Loggers(save_dir=save_dir, weights=weights, opt=opt, hyp=hyp, logger=LOGGER)
 
         # Register actions
         for k in methods(loggers):
@@ -610,8 +597,6 @@ def parse_opt(known=False):
     parser.add_argument("--artifact_alias", type=str, default="latest", help="Version of dataset artifact to use")
 
     # NDJSON logging
-    parser.add_argument("--ndjson-console", action="store_true", help="Log ndjson to console")
-    parser.add_argument("--ndjson-file", action="store_true", help="Log ndjson to file")
 
     return parser.parse_known_args()[0] if known else parser.parse_args()
 

--- a/train.py
+++ b/train.py
@@ -260,7 +260,7 @@ def train(hyp, opt, device, callbacks):
     # DP mode
     if cuda and RANK == -1 and torch.cuda.device_count() > 1:
         LOGGER.warning(
-            "WARNING ⚠️ DP not recommended, use torch.distributed.run for best DDP Multi-GPU results.\n"
+            "DP not recommended, use torch.distributed.run for best DDP Multi-GPU results.\n"
             "See Multi-GPU Tutorial at https://docs.ultralytics.com/yolov5/tutorials/multi_gpu_training to get started."
         )
         model = torch.nn.DataParallel(model)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -3,12 +3,12 @@
 
 import contextlib
 
-from ultralytics.utils import TryExcept, emojis, threaded  # noqa: F401
+from ultralytics.utils import LOGGER, TryExcept, emojis, threaded  # noqa: F401
 
 
 def notebook_init(verbose=True):
     """Initializes notebook environment by checking requirements, cleaning up, and displaying system info."""
-    print("Checking setup...")
+    LOGGER.info("Checking setup...")
 
     import os
     import shutil
@@ -42,5 +42,5 @@ def notebook_init(verbose=True):
         s = ""
 
     select_device(newline=False)
-    print(emojis(f"Setup complete ✅ {s}"))
+    LOGGER.info(emojis(f"Setup complete ✅ {s}"))
     return display

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -42,5 +42,5 @@ def notebook_init(verbose=True):
         s = ""
 
     select_device(newline=False)
-    LOGGER.info(emojis(f"Setup complete ✅ {s}"))
+    LOGGER.info(f"Setup complete ✅ {s}")
     return display

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -289,7 +289,7 @@ def classify_albumentations(
         return A.Compose(T)
 
     except ImportError:  # package not installed, skip
-        LOGGER.warning(f"{prefix}⚠️ not found, install with `pip install albumentations` (recommended)")
+        LOGGER.warning(f"{prefix}not found, install with `pip install albumentations` (recommended)")
     except Exception as e:
         LOGGER.info(f"{prefix}{e}")
 

--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -23,7 +23,7 @@ def check_anchor_order(m):
         m.anchors[:] = m.anchors.flip(0)
 
 
-@TryExcept(PREFIX.rstrip())
+@TryExcept(colorstr("AutoAnchor"))
 def check_anchors(dataset, model, thr=4.0, imgsz=640):
     """Evaluates anchor fit to dataset and adjusts if necessary, supporting customizable threshold and image size."""
     m = model.module.model[-1] if hasattr(model, "module") else model.model[-1]  # Detect()

--- a/utils/autoanchor.py
+++ b/utils/autoanchor.py
@@ -23,7 +23,7 @@ def check_anchor_order(m):
         m.anchors[:] = m.anchors.flip(0)
 
 
-@TryExcept(f"{PREFIX}ERROR")
+@TryExcept(PREFIX.rstrip())
 def check_anchors(dataset, model, thr=4.0, imgsz=640):
     """Evaluates anchor fit to dataset and adjusts if necessary, supporting customizable threshold and image size."""
     m = model.module.model[-1] if hasattr(model, "module") else model.model[-1]  # Detect()
@@ -127,7 +127,7 @@ def kmean_anchors(dataset="./data/coco128.yaml", n=9, img_size=640, thr=4.0, gen
     # Filter
     i = (wh0 < 3.0).any(1).sum()
     if i:
-        LOGGER.info(f"{PREFIX}WARNING ⚠️ Extremely small objects found: {i} of {len(wh0)} labels are <3 pixels in size")
+        LOGGER.warning(f"{PREFIX}Extremely small objects found: {i} of {len(wh0)} labels are <3 pixels in size")
     wh = wh0[(wh0 >= 2.0).any(1)].astype(np.float32)  # filter > 2 pixels
     # wh = wh * (npr.rand(wh.shape[0], 1) * 0.9 + 0.1)  # multiply by random scale 0-1
 
@@ -139,7 +139,7 @@ def kmean_anchors(dataset="./data/coco128.yaml", n=9, img_size=640, thr=4.0, gen
         k = kmeans(wh / s, n, iter=30)[0] * s  # points
         assert n == len(k)  # kmeans may return fewer points than requested if wh is insufficient or too similar
     except Exception:
-        LOGGER.warning(f"{PREFIX}WARNING ⚠️ switching strategies from kmeans to random init")
+        LOGGER.warning(f"{PREFIX}switching strategies from kmeans to random init")
         k = np.sort(npr.rand(n * 2)).reshape(n, 2) * img_size  # random init
     wh, wh0 = (torch.tensor(x, dtype=torch.float32) for x in (wh, wh0))
     k = print_results(k, verbose=False)

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -32,7 +32,7 @@ def autobatch(model, imgsz=640, fraction=0.8, batch_size=16):
         LOGGER.info(f"{prefix}CUDA not detected, using default CPU batch-size {batch_size}")
         return batch_size
     if torch.backends.cudnn.benchmark:
-        LOGGER.info(f"{prefix} ⚠️ Requires torch.backends.cudnn.benchmark=False, using default batch-size {batch_size}")
+        LOGGER.warning(f"{prefix}Requires torch.backends.cudnn.benchmark=False, using default batch-size {batch_size}")
         return batch_size
 
     # Inspect CUDA memory
@@ -64,7 +64,7 @@ def autobatch(model, imgsz=640, fraction=0.8, batch_size=16):
             b = batch_sizes[max(i - 1, 0)]  # select prior safe point
     if b < 1 or b > 1024:  # b outside of safe range
         b = batch_size
-        LOGGER.warning(f"{prefix}WARNING ⚠️ CUDA anomaly detected, recommend restart environment and retry command.")
+        LOGGER.warning(f"{prefix}CUDA anomaly detected, recommend restart environment and retry command.")
 
     fraction = (np.polyval(p, b) + r + a) / t  # actual fraction predicted
     LOGGER.info(f"{prefix}Using batch-size {b} for {d} {t * fraction:.2f}G/{t:.2f}G ({fraction * 100:.0f}%) ✅")

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -124,7 +124,7 @@ def create_dataloader(
 ):
     """Creates and returns a configured DataLoader instance for loading and processing image datasets."""
     if rect and shuffle:
-        LOGGER.warning("WARNING ⚠️ --rect is incompatible with DataLoader shuffle, setting shuffle=False")
+        LOGGER.warning("--rect is incompatible with DataLoader shuffle, setting shuffle=False")
         shuffle = False
     with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
         dataset = LoadImagesAndLabels(
@@ -419,7 +419,7 @@ class LoadStreams:
         self.auto = auto and self.rect
         self.transforms = transforms  # optional
         if not self.rect:
-            LOGGER.warning("WARNING ⚠️ Stream shapes differ. For optimal performance supply similarly-shaped streams.")
+            LOGGER.warning("Stream shapes differ. For optimal performance supply similarly-shaped streams.")
 
     def update(self, i, cap, stream):
         """Reads frames from stream `i`, updating imgs array; handles stream reopening on signal loss."""
@@ -432,7 +432,7 @@ class LoadStreams:
                 if success:
                     self.imgs[i] = im
                 else:
-                    LOGGER.warning("WARNING ⚠️ Video stream unresponsive, please check your IP camera connection.")
+                    LOGGER.warning("Video stream unresponsive, please check your IP camera connection.")
                     self.imgs[i] = np.zeros_like(self.imgs[i])
                     cap.open(stream)  # re-open stream if signal was lost
             time.sleep(0.0)  # wait time
@@ -676,7 +676,7 @@ class LoadImagesAndLabels(Dataset):
         if msgs:
             LOGGER.info("\n".join(msgs))
         if nf == 0:
-            LOGGER.warning(f"{prefix}WARNING ⚠️ No labels found in {path}. {HELP_URL}")
+            LOGGER.warning(f"{prefix}No labels found in {path}. {HELP_URL}")
         x["hash"] = get_hash(self.label_files + self.im_files)
         x["results"] = nf, nm, ne, nc, len(self.im_files)
         x["msgs"] = msgs  # warnings
@@ -686,7 +686,7 @@ class LoadImagesAndLabels(Dataset):
             path.with_suffix(".cache.npy").rename(path)  # remove .npy suffix
             LOGGER.info(f"{prefix}New cache created: {path}")
         except Exception as e:
-            LOGGER.warning(f"{prefix}WARNING ⚠️ Cache directory {path.parent} is not writeable: {e}")  # not writeable
+            LOGGER.warning(f"{prefix}Cache directory {path.parent} is not writeable: {e}")  # not writeable
         return x
 
     def __len__(self):

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -67,14 +67,14 @@ def safe_download(file, url, url2=None, min_bytes=1e0, error_msg=""):
     except Exception as e:  # url2
         if file.exists():
             file.unlink()  # remove partial downloads
-        LOGGER.info(f"ERROR: {e}\nRe-attempting {url2 or url} to {file}...")
+        LOGGER.warning(f"{e}\nRe-attempting {url2 or url} to {file}...")
         # curl download, retry and resume on fail
         curl_download(url2 or url, file)
     finally:
         if not file.exists() or file.stat().st_size < min_bytes:  # check
             if file.exists():
                 file.unlink()  # remove partial downloads
-            LOGGER.info(f"ERROR: {assert_msg}\n{error_msg}")
+            LOGGER.error(f"{assert_msg}\n{error_msg}")
         LOGGER.info("")
 
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -431,7 +431,7 @@ def check_amp(model):
         return True
     except Exception:
         help_url = "https://github.com/ultralytics/yolov5/issues/7908"
-        LOGGER.warning(f"{prefix}checks failed ❌, disabling Automatic Mixed Precision. See {help_url}")
+        LOGGER.warning(f"{prefix}checks failed, disabling Automatic Mixed Precision. See {help_url}")
         return False
 
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -42,7 +42,7 @@ except (ImportError, AssertionError):
 from ultralytics.data.converter import coco80_to_coco91_class  # noqa: F401
 from ultralytics.utils import (  # noqa: F401
     LOGGER,
-    TQDM,  # noqa: F401
+    TQDM,
     colorstr,
     get_default_args,
 )

--- a/utils/general.py
+++ b/utils/general.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 import contextlib
 import glob
 import inspect
-import logging
-import logging.config
 import os
 import platform
 import random
@@ -17,7 +15,6 @@ import sys
 import time
 import urllib
 from copy import deepcopy
-from functools import partial
 from itertools import repeat
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
@@ -43,8 +40,12 @@ except (ImportError, AssertionError):
     import ultralytics
 
 from ultralytics.data.converter import coco80_to_coco91_class  # noqa: F401
-from ultralytics.utils import TQDM as _TQDM
-from ultralytics.utils import colorstr, get_default_args  # noqa: F401
+from ultralytics.utils import (  # noqa: F401
+    LOGGER,
+    TQDM,  # noqa: F401
+    colorstr,
+    get_default_args,
+)
 from ultralytics.utils.checks import check_requirements as check_requirements_ultralytics
 from ultralytics.utils.checks import is_ascii
 from ultralytics.utils.files import WorkingDirectory, file_date, file_size, get_latest_run  # noqa: F401
@@ -73,8 +74,6 @@ RANK = int(os.getenv("RANK", "-1"))
 NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLOv5 multiprocessing threads
 DATASETS_DIR = Path(os.getenv("YOLOv5_DATASETS_DIR", ROOT.parent / "datasets"))  # global datasets directory
 AUTOINSTALL = str(os.getenv("YOLOv5_AUTOINSTALL", "true")).lower() == "true"  # global auto-install mode
-VERBOSE = str(os.getenv("YOLOv5_VERBOSE", "true")).lower() == "true"  # global verbose mode
-TQDM = partial(_TQDM, file=sys.stderr)  # progress bars on stderr like LOGGER, keeping stdout free for piped output
 FONT = "Arial.ttf"  # https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf
 
 torch.set_printoptions(linewidth=320, precision=5, profile="long")
@@ -142,43 +141,6 @@ def is_writeable(dir, test=False):
         return True
     except OSError:
         return False
-
-
-LOGGING_NAME = "yolov5"
-
-
-def set_logging(name=LOGGING_NAME, verbose=True):
-    """Configures logging with specified verbosity; `name` sets the logger's name, `verbose` controls logging level."""
-    rank = int(os.getenv("RANK", "-1"))  # rank in world for Multi-GPU trainings
-    level = logging.INFO if verbose and rank in {-1, 0} else logging.ERROR
-    logging.config.dictConfig(
-        {
-            "version": 1,
-            "disable_existing_loggers": False,
-            "formatters": {name: {"format": "%(message)s"}},
-            "handlers": {
-                name: {
-                    "class": "logging.StreamHandler",
-                    "formatter": name,
-                    "level": level,
-                }
-            },
-            "loggers": {
-                name: {
-                    "level": level,
-                    "handlers": [name],
-                    "propagate": False,
-                }
-            },
-        }
-    )
-
-
-set_logging(LOGGING_NAME)  # run before defining LOGGER
-LOGGER = logging.getLogger(LOGGING_NAME)  # define globally (used in train.py, val.py, detect.py, etc.)
-if platform.system() == "Windows":
-    for fn in LOGGER.info, LOGGER.warning:
-        setattr(LOGGER, fn.__name__, lambda x, fn=fn: fn(emojis(x)))  # emoji safe logging
 
 
 def user_config_dir(dir="Ultralytics", env_var="YOLOV5_CONFIG_DIR"):
@@ -293,9 +255,9 @@ def check_version(current="0.0.0", minimum="0.0.0", name="version ", pinned=Fals
     """Checks if the current version meets the minimum required version, exits or warns based on parameters."""
     current, minimum = (packaging.version.parse(x) for x in (current, minimum))
     result = (current == minimum) if pinned else (current >= minimum)  # bool
-    s = f"WARNING ⚠️ {name}{minimum} is required by YOLOv5, but {name}{current} is currently installed"  # string
+    s = f"{name}{minimum} is required by YOLOv5, but {name}{current} is currently installed"  # string
     if hard:
-        assert result, emojis(s)  # assert min requirements met
+        assert result, emojis(f"WARNING ⚠️ {s}")  # assert min requirements met
     if verbose and not result:
         LOGGER.warning(s)
     return result
@@ -309,7 +271,7 @@ def check_img_size(imgsz, s=32, floor=0):
         imgsz = list(imgsz)  # convert to list if tuple
         new_size = [max(make_divisible(x, int(s)), floor) for x in imgsz]
     if new_size != imgsz:
-        LOGGER.warning(f"WARNING ⚠️ --img-size {imgsz} must be multiple of max stride {s}, updating to {new_size}")
+        LOGGER.warning(f"--img-size {imgsz} must be multiple of max stride {s}, updating to {new_size}")
     return new_size
 
 
@@ -325,7 +287,7 @@ def check_imshow(warn=False):
         return True
     except Exception as e:
         if warn:
-            LOGGER.warning(f"WARNING ⚠️ Environment does not support cv2.imshow() or PIL Image.show()\n{e}")
+            LOGGER.warning(f"Environment does not support cv2.imshow() or PIL Image.show()\n{e}")
         return False
 
 
@@ -530,9 +492,9 @@ def download(url, dir=".", unzip=True, delete=True, curl=False, threads=1, retry
                 if success:
                     break
                 elif i < retry:
-                    LOGGER.warning(f"⚠️ Download failure, retrying {i + 1}/{retry} {url}...")
+                    LOGGER.warning(f"Download failure, retrying {i + 1}/{retry} {url}...")
                 else:
-                    LOGGER.warning(f"❌ Failed to download {url}...")
+                    LOGGER.warning(f"Failed to download {url}...")
 
         if unzip and success and (f.suffix == ".gz" or is_zipfile(f) or is_tarfile(f)):
             LOGGER.info(f"Unzipping {f}...")
@@ -799,7 +761,7 @@ def non_max_suppression(
         if mps:
             output[xi] = output[xi].to(device)
         if (time.time() - t) > time_limit:
-            LOGGER.warning(f"WARNING ⚠️ NMS time limit {time_limit:.3f}s exceeded")
+            LOGGER.warning(f"NMS time limit {time_limit:.3f}s exceeded")
             break  # time limit exceeded
 
     return output

--- a/utils/general.py
+++ b/utils/general.py
@@ -74,7 +74,7 @@ NUM_THREADS = min(8, max(1, os.cpu_count() - 1))  # number of YOLOv5 multiproces
 DATASETS_DIR = Path(os.getenv("YOLOv5_DATASETS_DIR", ROOT.parent / "datasets"))  # global datasets directory
 AUTOINSTALL = str(os.getenv("YOLOv5_AUTOINSTALL", "true")).lower() == "true"  # global auto-install mode
 VERBOSE = str(os.getenv("YOLOv5_VERBOSE", "true")).lower() == "true"  # global verbose mode
-TQDM = partial(_TQDM, file=sys.stderr)  # progress bars on stderr like LOGGER, keeping stdout free for --ndjson-console
+TQDM = partial(_TQDM, file=sys.stderr)  # progress bars on stderr like LOGGER, keeping stdout free for piped output
 FONT = "Arial.ttf"  # https://github.com/ultralytics/assets/releases/download/v0.0.0/Arial.ttf
 
 torch.set_printoptions(linewidth=320, precision=5, profile="long")

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -1,7 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 """Logging utils."""
 
-import json
 import os
 import warnings
 from pathlib import Path
@@ -61,19 +60,6 @@ except (ImportError, AssertionError):
     comet_ml = None
 
 
-def _json_default(value):
-    """Format `value` for JSON serialization (e.g. unwrap tensors).
-
-    Fall back to strings.
-    """
-    if isinstance(value, torch.Tensor):
-        try:
-            value = value.item()
-        except ValueError:  # "only one element tensors can be converted to Python scalars"
-            pass
-    return value if isinstance(value, float) else str(value)
-
-
 class Loggers:
     """Initializes and manages various logging utilities for tracking YOLOv5 training and validation metrics."""
 
@@ -105,8 +91,6 @@ class Loggers:
         for k in LOGGERS:
             setattr(self, k, None)  # init empty logger dictionary
         self.csv = True  # always log to csv
-        self.ndjson_console = "ndjson_console" in self.include  # log ndjson to console
-        self.ndjson_file = "ndjson_file" in self.include  # log ndjson to file
 
         # Messages
         if not comet_ml:
@@ -247,7 +231,7 @@ class Loggers:
             self.comet_logger.on_val_end(nt, tp, fp, p, r, f1, ap, ap50, ap_class, confusion_matrix)
 
     def on_fit_epoch_end(self, vals, epoch, best_fitness, fi):
-        """Callback that logs metrics and saves them to CSV or NDJSON at the end of each fit (train+val) epoch."""
+        """Callback that logs metrics and saves them to CSV at the end of each fit (train+val) epoch."""
         x = dict(zip(self.keys, vals))
         if self.csv:
             file = self.save_dir / "results.csv"
@@ -255,14 +239,6 @@ class Loggers:
             s = "" if file.exists() else (("%20s," * n % ("epoch", *self.keys)).rstrip(",") + "\n")  # add header
             with open(file, "a") as f:
                 f.write(s + ("%20.5g," * n % (epoch, *vals)).rstrip(",") + "\n")
-        if self.ndjson_console or self.ndjson_file:
-            json_data = json.dumps(dict(epoch=epoch, **x), default=_json_default)
-        if self.ndjson_console:
-            print(json_data)
-        if self.ndjson_file:
-            file = self.save_dir / "results.ndjson"
-            with open(file, "a") as f:
-                print(json_data, file=f)
 
         if self.tb:
             for k, v in x.items():

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -119,7 +119,7 @@ class Loggers:
                 self.clearml = None
                 prefix = colorstr("ClearML: ")
                 LOGGER.warning(
-                    f"{prefix}WARNING ⚠️ ClearML is installed but not configured, skipping ClearML logging."
+                    f"{prefix}ClearML is installed but not configured, skipping ClearML logging."
                     f" See https://docs.ultralytics.com/yolov5/tutorials/clearml_logging_integration"
                 )
 
@@ -362,7 +362,7 @@ class GenericLogger:
                 self.clearml = None
                 prefix = colorstr("ClearML: ")
                 LOGGER.warning(
-                    f"{prefix}WARNING ⚠️ ClearML is installed but not configured, skipping ClearML logging."
+                    f"{prefix}ClearML is installed but not configured, skipping ClearML logging."
                     f" See https://docs.ultralytics.com/yolov5/tutorials/clearml_logging_integration"
                 )
         else:
@@ -440,7 +440,7 @@ def log_tensorboard_graph(tb, model, imgsz=(640, 640)):
             warnings.simplefilter("ignore")  # suppress jit trace warning
             tb.add_graph(torch.jit.trace(de_parallel(model), im, strict=False), [])
     except Exception as e:
-        LOGGER.warning(f"WARNING ⚠️ TensorBoard graph visualization failure {e}")
+        LOGGER.warning(f"TensorBoard graph visualization failure {e}")
 
 
 def web_project_name(project):

--- a/utils/loggers/clearml/hpo.py
+++ b/utils/loggers/clearml/hpo.py
@@ -6,7 +6,6 @@ from clearml import Task
 # from here on everything is logged automatically
 from clearml.automation import HyperParameterOptimizer, UniformParameterRange
 from clearml.automation.optuna import OptimizerOptuna
-from ultralytics.utils import LOGGER
 
 task = Task.init(
     project_name="Hyper-Parameter Optimization",
@@ -87,5 +86,3 @@ optimizer.start_locally()
 optimizer.wait()
 # make sure background optimization stopped
 optimizer.stop()
-
-LOGGER.info("We are done, good bye")

--- a/utils/loggers/clearml/hpo.py
+++ b/utils/loggers/clearml/hpo.py
@@ -6,6 +6,7 @@ from clearml import Task
 # from here on everything is logged automatically
 from clearml.automation import HyperParameterOptimizer, UniformParameterRange
 from clearml.automation.optuna import OptimizerOptuna
+from ultralytics.utils import LOGGER
 
 task = Task.init(
     project_name="Hyper-Parameter Optimization",
@@ -87,4 +88,4 @@ optimizer.wait()
 # make sure background optimization stopped
 optimizer.stop()
 
-print("We are done, good bye")
+LOGGER.info("We are done, good bye")

--- a/utils/loggers/wandb/wandb_utils.py
+++ b/utils/loggers/wandb/wandb_utils.py
@@ -17,7 +17,7 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))  # add ROOT to PATH
 RANK = int(os.getenv("RANK", "-1"))
 DEPRECATION_WARNING = (
-    f"{colorstr('wandb')}: WARNING ⚠️ wandb is deprecated and will be removed in a future release. "
+    f"{colorstr('wandb')}: wandb is deprecated and will be removed in a future release. "
     f"See supported integrations at https://github.com/ultralytics/yolov5#integrations."
 )
 

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
+from ultralytics.utils import LOGGER
 from ultralytics.utils.metrics import box_iou, mask_iou, plot_mc_curve, plot_pr_curve, smooth
 
 from utils import TryExcept
@@ -217,7 +218,7 @@ class ConfusionMatrix:
     def print(self):
         """Prints the confusion matrix row-wise, with each class and its predictions separated by spaces."""
         for i in range(self.nc + 1):
-            print(" ".join(map(str, self.matrix[i])))
+            LOGGER.info(" ".join(map(str, self.matrix[i])))
 
 
 def process_batch(detections, labels, iouv, pred_masks=None, gt_masks=None, overlap=False, masks=False):

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -166,7 +166,7 @@ def plot_val_study(file="", dir="", x=None):
     ax2.set_ylabel("COCO AP val")
     ax2.legend(loc="lower right")
     f = save_dir / "study.png"
-    print(f"Saving {f}...")
+    LOGGER.info(f"Saving {f}...")
     plt.savefig(f, dpi=300)
 
 
@@ -257,7 +257,7 @@ def plot_evolve(evolve_csv="path/to/evolve.csv"):
     j = np.argmax(f)  # max fitness index
     plt.figure(figsize=(10, 12), tight_layout=True)
     matplotlib.rc("font", size=8)
-    print(f"Best results from row {j} of {evolve_csv}:")
+    LOGGER.info(f"Best results from row {j} of {evolve_csv}:")
     for i, k in enumerate(keys[7:]):
         v = x[:, 7 + i]
         mu = v[j]  # best single result
@@ -267,11 +267,11 @@ def plot_evolve(evolve_csv="path/to/evolve.csv"):
         plt.title(f"{k} = {mu:.3g}", fontdict={"size": 9})
         if i % 5 != 0:
             plt.yticks([])
-        print(f"{k:>15}: {mu:.3g}")
+        LOGGER.info(f"{k:>15}: {mu:.3g}")
     f = evolve_csv.with_suffix(".png")  # filename
     plt.savefig(f, dpi=200)
     plt.close()
-    print(f"Saved {f}")
+    LOGGER.info(f"Saved {f}")
 
 
 def plot_results(file="path/to/results.csv", dir=""):

--- a/utils/segment/dataloaders.py
+++ b/utils/segment/dataloaders.py
@@ -41,7 +41,7 @@ def create_dataloader(
 ):
     """Creates a dataloader for training, validating, or testing YOLO models with various dataset options."""
     if rect and shuffle:
-        LOGGER.warning("WARNING ⚠️ --rect is incompatible with DataLoader shuffle, setting shuffle=False")
+        LOGGER.warning("--rect is incompatible with DataLoader shuffle, setting shuffle=False")
         shuffle = False
     with torch_distributed_zero_first(rank):  # init dataset *.cache only once if DDP
         dataset = LoadImagesAndLabelsAndMasks(

--- a/utils/segment/plots.py
+++ b/utils/segment/plots.py
@@ -12,7 +12,7 @@ import pandas as pd
 import torch
 
 from .. import threaded
-from ..general import xywh2xyxy
+from ..general import LOGGER, xywh2xyxy
 from ..plots import Annotator, colors
 
 
@@ -144,7 +144,7 @@ def plot_results_with_masks(file="path/to/results.csv", dir="", best=True):
                     ax[i].scatter(x[-1], y[-1], color="r", label="last", marker="*", linewidth=3)
                     ax[i].set_title(s[j] + f"\n{round(y[-1], 5)}")
         except Exception as e:
-            print(f"Warning: Plotting error for {f}: {e}")
+            LOGGER.warning(f"Plotting error for {f}: {e}")
     ax[1].legend()
     fig.savefig(save_dir / "results.png", dpi=200)
     plt.close()

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -190,7 +190,7 @@ def profile(input, ops, n=10, device=None):
                 LOGGER.info(f"{p:12}{flops:12.4g}{mem:>14.3f}{tf:14.4g}{tb:14.4g}{s_in!s:>24s}{s_out!s:>24s}")
                 results.append([p, flops, mem, tf, tb, s_in, s_out])
             except Exception as e:
-                LOGGER.error(e)
+                LOGGER.warning(e)
                 results.append(None)
             torch.cuda.empty_cache()
     return results

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -54,7 +54,7 @@ def smartCrossEntropyLoss(label_smoothing=0.0):
     if check_version(torch.__version__, "1.10.0"):
         return nn.CrossEntropyLoss(label_smoothing=label_smoothing)
     if label_smoothing > 0:
-        LOGGER.warning(f"WARNING ⚠️ label smoothing {label_smoothing} requires torch>=1.10.0")
+        LOGGER.warning(f"label smoothing {label_smoothing} requires torch>=1.10.0")
     return nn.CrossEntropyLoss()
 
 
@@ -154,7 +154,7 @@ def profile(input, ops, n=10, device=None):
     results = []
     if not isinstance(device, torch.device):
         device = select_device(device)
-    print(
+    LOGGER.info(
         f"{'Params':>12s}{'GFLOPs':>12s}{'GPU_mem (GB)':>14s}{'forward (ms)':>14s}{'backward (ms)':>14s}"
         f"{'input':>24s}{'output':>24s}"
     )
@@ -187,10 +187,10 @@ def profile(input, ops, n=10, device=None):
                 mem = torch.cuda.memory_reserved() / 1e9 if torch.cuda.is_available() else 0  # (GB)
                 s_in, s_out = (tuple(x.shape) if isinstance(x, torch.Tensor) else "list" for x in (x, y))  # shapes
                 p = sum(x.numel() for x in m.parameters()) if isinstance(m, nn.Module) else 0  # parameters
-                print(f"{p:12}{flops:12.4g}{mem:>14.3f}{tf:14.4g}{tb:14.4g}{s_in!s:>24s}{s_out!s:>24s}")
+                LOGGER.info(f"{p:12}{flops:12.4g}{mem:>14.3f}{tf:14.4g}{tb:14.4g}{s_in!s:>24s}{s_out!s:>24s}")
                 results.append([p, flops, mem, tf, tb, s_in, s_out])
             except Exception as e:
-                print(e)
+                LOGGER.error(e)
                 results.append(None)
             torch.cuda.empty_cache()
     return results

--- a/val.py
+++ b/val.py
@@ -336,7 +336,7 @@ def run(
     pf = "%22s" + "%11i" * 2 + "%11.3g" * 4  # print format
     LOGGER.info(pf % ("all", seen, nt.sum(), mp, mr, map50, map))
     if nt.sum() == 0:
-        LOGGER.warning(f"WARNING ⚠️ no labels found in {task} set, can not compute metrics without labels")
+        LOGGER.warning(f"no labels found in {task} set, can not compute metrics without labels")
 
     # Print results per class
     if (verbose or (nc < 50 and not training)) and nc > 1 and len(stats):
@@ -493,9 +493,9 @@ def main(opt):
 
     if opt.task in ("train", "val", "test"):  # run normally
         if opt.conf_thres > 0.001:  # https://github.com/ultralytics/yolov5/issues/1466
-            LOGGER.info(f"WARNING ⚠️ confidence threshold {opt.conf_thres} > 0.001 produces invalid results")
+            LOGGER.warning(f"confidence threshold {opt.conf_thres} > 0.001 produces invalid results")
         if opt.save_hybrid:
-            LOGGER.info("WARNING ⚠️ --save-hybrid will return high mAP from hybrid labels, not from predictions alone")
+            LOGGER.warning("--save-hybrid will return high mAP from hybrid labels, not from predictions alone")
         run(**vars(opt))
 
     else:


### PR DESCRIPTION
> Stacked on #13839 (ndjson removal), which is what frees stdout. Base retargets to `master` when that merges.

Replaces the private `"yolov5"` logger with ultralytics', moves progress bars back onto the same stream, and converts every remaining bare `print()`.

### The logger

`utils/general.py` configured its own logger via `logging.config.dictConfig` and exported it. `LOGGING_NAME`, `set_logging`, the module-scope call, the `LOGGER = logging.getLogger(...)` assignment and the Windows-only emoji monkeypatch are deleted in favour of one name on the existing `from ultralytics.utils import ...` line. `set_logging` had **zero external callers**, so there is no per-rank invocation to preserve. Same `%(message)s` format, same `INFO if verbose and rank in {-1, 0} else ERROR` rule, same `propagate=False`.

Two things this quietly fixes:

- The Windows patch only wrapped `LOGGER.info` and `LOGGER.warning`, so `LOGGER.error` was never emoji-safe. ultralytics' `PrefixFormatter` runs `emojis()` on **every** level.
- `dictConfig` ran at import time and calls `_clearExistingHandlers()`, which shut down every handler registered before `utils.general` was imported — **including ultralytics' own**, created moments earlier. That global side effect is gone.

### Progress bars rejoin the log stream

With `--ndjson-console` deleted in #13839, nothing owns stdout any more, so `TQDM = partial(_TQDM, file=sys.stderr)` is dropped. ultralytics' `TQDM` already defaults to `sys.stdout` — the same place `LOGGER` now writes — so the val table header and its metric rows are back on one ordered stream instead of split across two. Dead `VERBOSE` (`YOLOv5_VERBOSE`, no readers anywhere) goes with it; verbosity is ultralytics' `YOLO_VERBOSE` now.

### The marker sweep

ultralytics' formatter prepends the marker itself, so every embedded literal on a warning path became doubled. **31 stripped**, **7 promoted** from `LOGGER.info` to `LOGGER.warning`/`.error` first.

Four of the stripped sites had **no `WARNING` word at all** and one used a non-emoji `ERROR:`, so a fixed-prefix grep cannot find them — this is exactly what made the earlier attempt at this change wrong:

| site | literal | why a prefix grep missed it |
|---|---|---|
| `utils/general.py` | `"⚠️ Download failure, retrying …"` | bare emoji on `LOGGER.warning` |
| `utils/general.py` | `"❌ Failed to download …"` | bare emoji on `LOGGER.warning` |
| `utils/augmentations.py` | `f"{prefix}⚠️ not found, install with …"` | bare emoji, mid-string |
| `utils/autoanchor.py` | `@TryExcept(f"{PREFIX}ERROR")` | decorator argument, not a `LOGGER.*` call |
| `utils/downloads.py` | `f"ERROR: {e}"` | non-emoji marker, at `INFO` level |

The `autoanchor` one is a **pre-existing bug**, not something this PR creates: `TryExcept` has come from ultralytics since #13832 and already routes to `LOGGER.warning`, so today it prints `WARNING ⚠️ AutoAnchor: ERROR: <exc>`.

### What deliberately keeps its literal

Anything that does **not** reach `LOGGER.warning`/`.error`, because nothing will re-add the marker and stripping would silently delete it:

- `utils/dataloaders.py` `verify_image_label` messages — accumulated into `msgs` and emitted by a single `LOGGER.info("\n".join(msgs))`, and persisted into `*.cache`, so old caches replay them verbatim
- assert messages (`export.py` `--include`, `utils/general.py` data.yaml) and `raise` messages (`models/common.py`)
- the generated `torch.hub.load` snippet's `# WARNING …` comments, printed inside a `LOGGER.info` block
- `utils/loggers/comet/*` — a module-private `logging.getLogger(__name__)` with no `PrefixFormatter`
- ✅/❌ **status** glyphs paired across success/failure branches at `INFO` (`export success ✅` / `export failure ❌`), which are not severity markers

`check_version` needed a **split**, not a strip: one string fed both `assert result, emojis(s)` and `LOGGER.warning(s)`. The marker now lives on the assert path only, so both read correctly:

```
AssertionError: WARNING ⚠️ torch2.0.0 is required by YOLOv5, but torch1.0.0 is currently installed
WARNING ⚠️ torch2.0.0 is required by YOLOv5, but torch1.0.0 is currently installed   # via the formatter
```

### `hubconf.py`

It imported stdlib `logging` **through** `utils.general`. Deleting `set_logging` orphans that import, and the `ruff --fix` Ultralytics Actions pushes would have stripped it, breaking `torch.hub` loading at runtime. It now imports `logging` directly, and saves/restores `LOGGER.level` rather than forcing `INFO` — the logger is shared with ultralytics now, so an unconditional reset would clobber a caller's setting.

### `print()` → `LOGGER`

All 13 remaining bare calls, at the appropriate level: `profile()`'s table and `plot_evolve()`'s rows to `.info`; `models/yolo.py`'s config error and `profile()`'s exception to `.error`; `utils/segment/plots.py`'s plotting failure to `.warning`. `utils/__init__.py` and `utils/metrics.py` import `LOGGER` straight from ultralytics rather than `utils.general`, which would be circular.

**Zero bare `print()` calls remain** (AST-verified, not grep).

### Validation

| check | result |
|---|---|
| `val.py --weights yolov5n.pt --data coco128.yaml --img 640` | `all 128 929 0.607 0.5 0.549 0.35` — unchanged |
| `segment/val.py` | all 8 metrics unchanged |
| doubled marker in a real run | **0 occurrences** of `WARNING ⚠️ WARNING`, `WARNING ⚠️ ⚠️`, `WARNING ⚠️ ❌` on either stream |
| `check_version(hard=True)` / `(verbose=True)` | assert keeps its marker; warning prints one |
| `hubconf._create(verbose=False)` | `LOGGER.level` 20 → 20, restored |
| `val.py` streams | full log on stdout, **0 bytes** on stderr |
| `train.py`, `detect.py` | pass |
| `pytest -m "not network"` | 20 passed |
| `ruff check .` / `--select I` / `format --check` | clean |

**Behaviour change to call out: log output moves from stderr to stdout.** Also, at `f"{prefix}WARNING ⚠️ …"` sites the auto-prefix now lands outside the `colorstr` prefix, so `AutoAnchor: WARNING ⚠️ msg` reads `WARNING ⚠️ AutoAnchor: msg`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Standardizes YOLOv5 logging by adopting the shared Ultralytics logger, improving message levels, and ensuring cleaner, more consistent output. 🛠️

### 📊 Key Changes

- Replaced direct `print()` calls with `LOGGER.info()`, `LOGGER.warning()`, or `LOGGER.error()` across training, validation, plotting, profiling, and setup utilities.
- Removed redundant `WARNING ⚠️` prefixes and emojis from warning messages, relying on the logger’s severity level instead.
- Migrated YOLOv5’s logging implementation to the shared `ultralytics.utils.LOGGER`.
- Updated Hub model loading to import Python’s standard `logging` module and restore the logger level reliably with `finally`, including on errors.
- Improved log severity classification:
  - Export and download failures now use warning or error levels appropriately.
  - TensorFlow export compatibility notices use `LOGGER.warning()`.
  - Model parsing failures use `LOGGER.error()`.
- Updated `export_formats()` examples to log supported formats through `LOGGER.info()`.
- Adjusted AutoAnchor error handling and warning output for clearer diagnostics.
- Removed an unnecessary completion message from the ClearML HPO script.

### 🎯 Purpose & Impact

- ✅ Provides consistent, centralized logging across the YOLOv5 codebase.
- 🔍 Makes warnings and errors easier to filter, monitor, and interpret in terminals, notebooks, and integrated applications.
- 🧩 Prevents Hub model loading from leaving the shared logger at an unintended verbosity level.
- 📉 Reduces duplicated warning labels and noisy output while preserving the underlying information.
- 🚀 Improves compatibility with Ultralytics logging infrastructure and downstream tooling without changing model training or inference behavior.