### PR TITLE
Remove feature visualization

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -87,7 +87,6 @@ def run(
     classes=None,  # filter by class: --class 0, or --class 0 2 3
     agnostic_nms=False,  # class-agnostic NMS
     augment=False,  # augmented inference
-    visualize=False,  # visualize features
     update=False,  # update all models
     project=ROOT / "runs/detect",  # save results to project/name
     name="exp",  # save results to project/name
@@ -122,7 +121,6 @@ def run(
         classes (list[int]): List of class indices to filter detections by. Default is None.
         agnostic_nms (bool): If True, perform class-agnostic non-max suppression. Default is False.
         augment (bool): If True, use augmented inference. Default is False.
-        visualize (bool): If True, visualize feature maps. Default is False.
         update (bool): If True, update all models' weights. Default is False.
         project (str | Path): Directory to save results. Default is 'runs/detect'.
         name (str): Name of the current experiment; used to create a subdirectory within 'project'. Default is 'exp'.
@@ -215,17 +213,16 @@ def run(
 
         # Inference
         with dt[1]:
-            visualize = increment_path(save_dir / Path(path).stem, mkdir=True) if visualize else False
             if model.xml and im.shape[0] > 1:
                 pred = None
                 for image in ims:
                     if pred is None:
-                        pred = model(image, augment=augment, visualize=visualize).unsqueeze(0)
+                        pred = model(image, augment=augment).unsqueeze(0)
                     else:
-                        pred = torch.cat((pred, model(image, augment=augment, visualize=visualize).unsqueeze(0)), dim=0)
+                        pred = torch.cat((pred, model(image, augment=augment).unsqueeze(0)), dim=0)
                 pred = [pred, None]
             else:
-                pred = model(im, augment=augment, visualize=visualize)
+                pred = model(im, augment=augment)
         # NMS
         with dt[2]:
             pred = non_max_suppression(pred, conf_thres, iou_thres, classes, agnostic_nms, max_det=max_det)
@@ -350,7 +347,6 @@ def parse_opt():
             None.
         --agnostic-nms (bool, optional): Flag for class-agnostic NMS. Defaults to False.
         --augment (bool, optional): Flag for augmented inference. Defaults to False.
-        --visualize (bool, optional): Flag for visualizing features. Defaults to False.
         --update (bool, optional): Flag to update all models in the model directory. Defaults to False.
         --project (str, optional): Directory to save results. Defaults to ROOT / 'runs/detect'.
         --name (str, optional): Sub-directory name for saving results within --project. Defaults to 'exp'.
@@ -396,7 +392,6 @@ def parse_opt():
     parser.add_argument("--classes", nargs="+", type=int, help="filter by class: --classes 0, or --classes 0 2 3")
     parser.add_argument("--agnostic-nms", action="store_true", help="class-agnostic NMS")
     parser.add_argument("--augment", action="store_true", help="augmented inference")
-    parser.add_argument("--visualize", action="store_true", help="visualize features")
     parser.add_argument("--update", action="store_true", help="update all models")
     parser.add_argument("--project", default=ROOT / "runs/detect", help="save results to project/name")
     parser.add_argument("--name", default="exp", help="save results to project/name")

--- a/models/common.py
+++ b/models/common.py
@@ -682,8 +682,8 @@ class DetectMultiBackend(nn.Module):
 
         self.__dict__.update(locals())  # assign all variables to self
 
-    def forward(self, im, augment=False, visualize=False):
-        """Performs YOLOv5 inference on input images with options for augmentation and visualization."""
+    def forward(self, im, augment=False):
+        """Performs YOLOv5 inference on input images with optional augmentation."""
         _b, _ch, h, w = im.shape  # batch, channel, height, width
         if self.fp16 and im.dtype != torch.float16:
             im = im.half()  # to FP16
@@ -691,7 +691,7 @@ class DetectMultiBackend(nn.Module):
             im = im.permute(0, 2, 3, 1)  # torch BCHW to numpy BHWC shape(1,320,192,3)
 
         if self.pt:  # PyTorch
-            y = self.model(im, augment=augment, visualize=visualize) if augment or visualize else self.model(im)
+            y = self.model(im, augment=augment) if augment else self.model(im)
         elif self.jit:  # TorchScript
             y = self.model(im)
         elif self.dnn:  # ONNX OpenCV DNN

--- a/models/experimental.py
+++ b/models/experimental.py
@@ -48,9 +48,9 @@ class MixConv2d(nn.Module):
 class Ensemble(nn.ModuleList):
     """Ensemble of models."""
 
-    def forward(self, x, augment=False, profile=False, visualize=False):
+    def forward(self, x, augment=False, profile=False):
         """Performs forward pass aggregating outputs from an ensemble of models."""
-        y = [module(x, augment, profile, visualize)[0] for module in self]
+        y = [module(x, augment, profile)[0] for module in self]
         # y = torch.stack(y).max(0)[0]  # max ensemble
         # y = torch.stack(y).mean(0)  # mean ensemble
         y = torch.cat(y, 1)  # nms ensemble

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -25,8 +25,6 @@ if str(ROOT) not in sys.path:
 if platform.system() != "Windows":
     ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
-from ultralytics.utils.plotting import feature_visualization
-
 from models.common import (
     C3,
     C3SPP,
@@ -68,6 +66,31 @@ try:
     import thop  # for FLOPs computation
 except ImportError:
     thop = None
+
+
+def feature_visualization(x, module_type, stage, n=32, save_dir=Path("runs/detect/exp")):
+    """Visualize feature maps of a given model module during inference."""
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    if any(m in module_type for m in ("Detect", "Segment", "Classify")):
+        return
+    if isinstance(x, torch.Tensor):
+        _, channels, height, width = x.shape
+        if height > 1 and width > 1:
+            f = save_dir / f"stage{stage}_{module_type.rsplit('.', 1)[-1]}_features.png"
+            blocks = torch.chunk(x[0].cpu(), channels, dim=0)
+            n = min(n, channels)
+            _, ax = plt.subplots(math.ceil(n / 8), 8, tight_layout=True)
+            ax = ax.ravel()
+            plt.subplots_adjust(wspace=0.05, hspace=0.05)
+            for i in range(n):
+                ax[i].imshow(blocks[i].squeeze().numpy())
+                ax[i].axis("off")
+            LOGGER.info(f"Saving {f}... ({n}/{channels})")
+            plt.savefig(f, dpi=300, bbox_inches="tight")
+            plt.close()
+            np.save(str(f.with_suffix(".npy")), x[0].cpu().numpy())
 
 
 class Detect(nn.Module):

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -68,31 +68,6 @@ except ImportError:
     thop = None
 
 
-def feature_visualization(x, module_type, stage, n=32, save_dir=Path("runs/detect/exp")):
-    """Visualize feature maps of a given model module during inference."""
-    import matplotlib.pyplot as plt
-    import numpy as np
-
-    if any(m in module_type for m in ("Detect", "Segment", "Classify")):
-        return
-    if isinstance(x, torch.Tensor):
-        _, channels, height, width = x.shape
-        if height > 1 and width > 1:
-            f = save_dir / f"stage{stage}_{module_type.rsplit('.', 1)[-1]}_features.png"
-            blocks = torch.chunk(x[0].cpu(), channels, dim=0)
-            n = min(n, channels)
-            _, ax = plt.subplots(math.ceil(n / 8), 8, tight_layout=True)
-            ax = ax.ravel()
-            plt.subplots_adjust(wspace=0.05, hspace=0.05)
-            for i in range(n):
-                ax[i].imshow(blocks[i].squeeze().numpy())
-                ax[i].axis("off")
-            LOGGER.info(f"Saving {f}... ({n}/{channels})")
-            plt.savefig(f, dpi=300, bbox_inches="tight")
-            plt.close()
-            np.save(str(f.with_suffix(".npy")), x[0].cpu().numpy())
-
-
 class Detect(nn.Module):
     """YOLOv5 Detect head for processing input tensors and generating detection outputs in object detection models."""
 
@@ -178,14 +153,12 @@ class Segment(Detect):
 class BaseModel(nn.Module):
     """YOLOv5 base model."""
 
-    def forward(self, x, profile=False, visualize=False):
-        """Executes a single-scale inference or training pass on the YOLOv5 base model, with options for profiling and
-        visualization.
-        """
-        return self._forward_once(x, profile, visualize)  # single-scale inference, train
+    def forward(self, x, profile=False):
+        """Executes a single-scale inference or training pass on the YOLOv5 base model."""
+        return self._forward_once(x, profile)  # single-scale inference, train
 
-    def _forward_once(self, x, profile=False, visualize=False):
-        """Performs a forward pass on the YOLOv5 model, enabling profiling and feature visualization options."""
+    def _forward_once(self, x, profile=False):
+        """Performs a forward pass on the YOLOv5 model, enabling profiling when requested."""
         y, dt = [], []  # outputs
         for m in self.model:
             if m.f != -1:  # if not from previous layer
@@ -194,8 +167,6 @@ class BaseModel(nn.Module):
                 self._profile_one_layer(m, x, dt)
             x = m(x)  # run
             y.append(x if m.i in self.save else None)  # save output
-            if visualize:
-                feature_visualization(x, m.type, m.i, save_dir=visualize)
         return x
 
     def _profile_one_layer(self, m, x, dt):
@@ -289,11 +260,11 @@ class DetectionModel(BaseModel):
         self.info()
         LOGGER.info("")
 
-    def forward(self, x, augment=False, profile=False, visualize=False):
-        """Performs single-scale or augmented inference and may include profiling or visualization."""
+    def forward(self, x, augment=False, profile=False):
+        """Performs single-scale or augmented inference and may include profiling."""
         if augment:
             return self._forward_augment(x)  # augmented inference, None
-        return self._forward_once(x, profile, visualize)  # single-scale inference, train
+        return self._forward_once(x, profile)  # single-scale inference, train
 
     def _forward_augment(self, x):
         """Performs augmented inference across different scales and flips, returning combined detections."""

--- a/segment/predict.py
+++ b/segment/predict.py
@@ -85,7 +85,6 @@ def run(
     classes=None,  # filter by class: --class 0, or --class 0 2 3
     agnostic_nms=False,  # class-agnostic NMS
     augment=False,  # augmented inference
-    visualize=False,  # visualize features
     update=False,  # update all models
     project=ROOT / "runs/predict-seg",  # save results to project/name
     name="exp",  # save results to project/name
@@ -143,8 +142,7 @@ def run(
 
         # Inference
         with dt[1]:
-            visualize = increment_path(save_dir / Path(path).stem, mkdir=True) if visualize else False
-            pred, proto = model(im, augment=augment, visualize=visualize)[:2]
+            pred, proto = model(im, augment=augment)[:2]
 
         # NMS
         with dt[2]:
@@ -271,7 +269,6 @@ def parse_opt():
     parser.add_argument("--classes", nargs="+", type=int, help="filter by class: --classes 0, or --classes 0 2 3")
     parser.add_argument("--agnostic-nms", action="store_true", help="class-agnostic NMS")
     parser.add_argument("--augment", action="store_true", help="augmented inference")
-    parser.add_argument("--visualize", action="store_true", help="visualize features")
     parser.add_argument("--update", action="store_true", help="update all models")
     parser.add_argument("--project", default=ROOT / "runs/predict-seg", help="save results to project/name")
     parser.add_argument("--name", default="exp", help="save results to project/name")


### PR DESCRIPTION
Ultralytics 8.4.113 removed `feature_visualization` while replacing raw feature-map dumps with predictor-level class activation maps. YOLOv5 cannot use that replacement through the released package without duplicating the new predictor integration, so remove the unsupported feature instead.

This deletes the `--visualize` flags from detection and segmentation prediction, removes visualization forwarding from model and backend APIs, and removes the stale package import that broke every CI job. Normal and augmented inference remain unchanged.

Effective diff: **17 additions, 31 deletions** across existing owners.

### Validation

- `ruff format --check detect.py segment/predict.py models/common.py models/experimental.py models/yolo.py`
- `ruff check detect.py segment/predict.py models/common.py models/experimental.py models/yolo.py`
- `python -m pytest tests/ -m "not network"` (20 passed, 1 deselected)
- Detection normal and augmented CPU inference
- Segmentation normal and augmented CPU inference
- Detection and segmentation CLI help no longer expose `--visualize`
- Direct normal and augmented `DetectionModel` forwards
- One-epoch CPU smoke train

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 Removes the feature-visualization option from YOLOv5 detection, segmentation, and model inference APIs.

### 📊 Key Changes
- Deleted the `visualize` argument from:
  - Detection and segmentation prediction scripts.
  - Common model wrappers and ensemble inference.
  - YOLOv5 base and task-specific model forward methods.
- Removed the `--visualize` command-line option and related documentation.
- Removed feature-map visualization calls and the associated `feature_visualization` import.
- Simplified inference calls to support augmentation and profiling only.

### 🎯 Purpose & Impact
- ✅ Streamlines the inference API and reduces unused or redundant code paths.
- 🚀 May slightly reduce maintenance overhead and avoid creating feature-visualization output directories during prediction.
- ⚠️ Existing scripts that pass `visualize=True` or use `--visualize` will need to be updated, as feature-map visualization is no longer supported through these YOLOv5 interfaces.
- 🎯 Standard detection, segmentation, augmentation, and profiling workflows remain unchanged.