### PR TITLE
Trim codespell config and drop unused isort table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,10 +115,6 @@ extra = [
 [tool.pytest.ini_options]
 norecursedirs = [".git", "dist", "build"]
 
-[tool.isort]
-line_length = 120
-multi_line_output = 0
-
 [tool.ruff]
 line-length = 120
 
@@ -144,5 +140,5 @@ pre-summary-newline = true
 close-quotes-on-newline = true
 
 [tool.codespell]
-ignore-words-list = "crate,nd,strack,dota,ane,segway,fo,gool,winn,commend"
-skip = '*.csv,*venv*,docs/??/,docs/mkdocs_??.yml'
+ignore-words-list = "grey,nd,writeable"
+skip = '*venv*'


### PR DESCRIPTION
`pyproject.toml` cleanup — both items were copied verbatim from `ultralytics/ultralytics` and never adapted to this repo:

- `[tool.codespell]`: the `skip` globs pointed at `docs/??/` and `docs/mkdocs_??.yml` (this repo has no `docs/`) and `*.csv` (no CSVs are tracked). The `ignore-words-list` was the YOLO-package list; running codespell with the Actions dictionaries (`clear,informal,en-GB_to_en-US`) against a clean checkout flags only `grey`, `nd`, and `writeable` here, and two of those were missing — a bare local `codespell` run reported false positives that CI hid because the Action passes its own `--ignore-words-list`. Trimmed to what this repo actually needs; `codespell` from the repo root is now clean with no extra flags.
- `[tool.isort]`: nothing runs isort. Import sorting comes from Ruff (`format.yml` runs Ruff + docformatter), which is already configured below it.

No dependency, classifier, version, or `requires-python` changes.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Streamlines project linting and spell-check configuration by removing obsolete isort settings and updating codespell rules. 🧹

### 📊 Key Changes
- Removed the dedicated `[tool.isort]` configuration from `pyproject.toml`.
- Simplified the codespell ignore list to `grey`, `nd`, and `writeable`.
- Reduced codespell exclusions to only skip virtual-environment paths.

### 🎯 Purpose & Impact
- Keeps development tooling configuration more consistent with the current Ruff-based formatting setup.
- Enables broader spell-check coverage across documentation and project files.
- May surface previously ignored spelling issues, helping improve code and documentation quality. ✅