### PR TITLE
Standardize .github configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/.github/workflows"
     schedule:
-      interval: daily
+      interval: weekly
       time: "04:00"
     open-pull-requests-limit: 5
     labels:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,12 +11,14 @@ on:
   discussion:
     types: [created]
   pull_request:
+    branches: [master]
     types: [opened, closed, synchronize, review_requested]
 
 permissions:
   contents: write # Modify code in PRs
   pull-requests: write # Add comments and labels to PRs
   issues: write # Add comments and labels to issues
+  discussions: write # Add labels to discussions
 
 jobs:
   actions:


### PR DESCRIPTION
Aligns .github/ with the current Ultralytics repository standard.

- format.yml: scope pull_request runs to the master default branch and grant discussions: write so the discussion trigger can label discussions
- dependabot.yml: weekly github-actions cadence instead of daily

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Standardized GitHub configuration by reducing GitHub Actions dependency checks to weekly and updating the formatting workflow for `master` pull requests and discussion labeling.

### 📊 Key Changes

- Changed Dependabot’s `github-actions` update schedule from daily to weekly at 04:00.
- Restricted the `format.yml` pull request trigger to the `master` branch.
- Added `discussions: write` permission to allow the workflow to label discussions.

### 🎯 Purpose & Impact

- GitHub Actions dependency update pull requests will be checked and opened less frequently.
- The formatting workflow will run for the specified pull request events targeting `master` and can modify discussion labels.
- No changes were made to the application or model behavior.